### PR TITLE
fts: global BM25 statistics by default

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -69,7 +69,7 @@ jobs:
           # its own VM. Ceilings are sized per leg for two A/B arms plus
           # VM provision and compile.
           - { bench: supertable_fts_warm, docs: "1000000", suffix: st-fts-warm, corpus: realistic, timeout_minutes: "75" }
-          - { bench: supertable_fts_cold, docs: "1000000", suffix: st-fts-cold, corpus: realistic, timeout_minutes: "100" }
+          - { bench: supertable_fts_cold, docs: "1000000", suffix: st-fts-cold, corpus: realistic, timeout_minutes: "75" }
           - { bench: supertable_vector, docs: "1000000", suffix: st-vec }
           # Non-cosine (L2) leg: exercises the Sq16Adaptive default codec
           # (the cosine leg above stays on the fixed-grid Sq16).

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -328,7 +328,7 @@ async fn reader_loop(
                     QUERY_TERM,
                     TOP_K,
                     BoolMode::Or,
-                    Bm25Stats::PerSuperfile,
+                    Bm25Stats::default(),
                     None,
                 )
                 .expect("bm25_search"),

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -782,18 +782,11 @@ pub mod fts {
 
     impl FtsRead for SupertableReader {
         fn bm25_rows(&self, column: &str, query: &str, k: usize, mode: InfinoBoolMode) -> usize {
-            self.bm25_search(
-                column,
-                query,
-                k,
-                mode,
-                infino::Bm25Stats::PerSuperfile,
-                None,
-            )
-            .expect("supertable bm25_search")
-            .iter()
-            .map(|b| b.num_rows())
-            .sum()
+            self.bm25_search(column, query, k, mode, infino::Bm25Stats::default(), None)
+                .expect("supertable bm25_search")
+                .iter()
+                .map(|b| b.num_rows())
+                .sum()
         }
 
         fn bm25_rows_fetched(
@@ -808,7 +801,7 @@ pub mod fts {
                 query,
                 k,
                 mode,
-                infino::Bm25Stats::PerSuperfile,
+                infino::Bm25Stats::default(),
                 Some(&["_id", column, "score"]),
             )
             .expect("supertable bm25_search fetched")
@@ -825,14 +818,7 @@ pub mod fts {
             mode: InfinoBoolMode,
         ) -> ((u64, u64), (u64, u64)) {
             let search = self
-                .bm25_search(
-                    column,
-                    query,
-                    k,
-                    mode,
-                    infino::Bm25Stats::PerSuperfile,
-                    None,
-                )
+                .bm25_search(column, query, k, mode, infino::Bm25Stats::default(), None)
                 .expect("supertable bm25_search payload");
             let fetched = self
                 .bm25_search(
@@ -840,7 +826,7 @@ pub mod fts {
                     query,
                     k,
                     mode,
-                    infino::Bm25Stats::PerSuperfile,
+                    infino::Bm25Stats::default(),
                     Some(&["_id", column, "score"]),
                 )
                 .expect("supertable bm25_search fetched payload");

--- a/benches/utils/fts_diag.rs
+++ b/benches/utils/fts_diag.rs
@@ -94,7 +94,7 @@ pub fn run() {
     // Warm both paths for every shape (cache-hot before timing).
     for s in SHAPES {
         let _ = reader
-            .bm25_search(COLUMN, s.query, K, s.mode, Bm25Stats::PerSuperfile, None)
+            .bm25_search(COLUMN, s.query, K, s.mode, Bm25Stats::default(), None)
             .expect("warm-up bm25_search");
     }
 
@@ -145,7 +145,7 @@ pub fn run() {
         for _ in 0..cfg.iters {
             let t = Instant::now();
             let out = reader
-                .bm25_search(COLUMN, s.query, K, s.mode, Bm25Stats::PerSuperfile, None)
+                .bm25_search(COLUMN, s.query, K, s.mode, Bm25Stats::default(), None)
                 .expect("full bm25_search");
             full.push(t.elapsed());
             std::hint::black_box(out);

--- a/benches/utils/fts_quality.rs
+++ b/benches/utils/fts_quality.rs
@@ -20,7 +20,7 @@
 //!   (`stored_len`): exact below 16 tokens, truncated downward by up to
 //!   one bucket above. On a corpus with realistic length variation this
 //!   reorders near-ties.
-//! * **Sharded statistics.** Under the default [`Bm25Stats::PerSuperfile`]
+//! * **Sharded statistics.** Under [`Bm25Stats::PerSuperfile`]
 //!   each superfile scores with its own document count and term
 //!   frequencies; [`Bm25Stats::Global`] uses table-wide idf but still each
 //!   superfile's own average document length.
@@ -720,7 +720,7 @@ struct GradedRow {
     k: usize,
     n_matches: usize,
     recall_textbook: f64,
-    recall_default_stats: f64,
+    recall_per_superfile_stats: f64,
     recall_engine_model: f64,
     max_delta: f64,
 }
@@ -771,7 +771,7 @@ pub fn run(
         for (ki, &k) in QUALITY_KS.iter().enumerate() {
             let expected = k.min(top.n_matches);
             let global = engine_hits(reader, column, q, k, Bm25Stats::Global);
-            let default = engine_hits(reader, column, q, k, Bm25Stats::PerSuperfile);
+            let per_superfile = engine_hits(reader, column, q, k, Bm25Stats::PerSuperfile);
             let textbook_of = |row| oracle.score_row(row, rq).map(|(t, _)| t);
             let engine_model_of = |row| oracle.score_row(row, rq).map(|(_, e)| e);
             let recall_textbook = tie_aware_recall(
@@ -781,8 +781,8 @@ pub fn run(
                 TIE_TOLERANCE,
                 textbook_of,
             );
-            let recall_default_stats = tie_aware_recall(
-                &default,
+            let recall_per_superfile_stats = tie_aware_recall(
+                &per_superfile,
                 expected,
                 top.textbook_kth[ki],
                 TIE_TOLERANCE,
@@ -807,7 +807,7 @@ pub fn run(
                 k,
                 n_matches: top.n_matches,
                 recall_textbook,
-                recall_default_stats,
+                recall_per_superfile_stats,
                 recall_engine_model,
                 max_delta,
             });
@@ -857,7 +857,7 @@ fn emit(
                 "Query".into(),
                 "matches".into(),
                 "recall vs BM25".into(),
-                "recall (default stats)".into(),
+                "recall (per-superfile stats)".into(),
                 "recall vs engine BM25".into(),
                 "max score Δ".into(),
             ],
@@ -869,7 +869,7 @@ fn emit(
                         text(r.name),
                         text(fmt_count(r.n_matches)),
                         recall_cell(r.recall_textbook, false),
-                        recall_cell(r.recall_default_stats, false),
+                        recall_cell(r.recall_per_superfile_stats, false),
                         recall_cell(r.recall_engine_model, true),
                         metric(
                             r.max_delta,
@@ -893,8 +893,8 @@ fn emit(
              tie-aware (a hit is any returned doc scoring at least the oracle's k-th score). \
              `recall vs BM25` = `Bm25Stats::Global` against textbook BM25 with exact doc \
              lengths — the user-facing quality, which pays for the one-byte length \
-             quantization and per-superfile avgdl. `recall (default stats)` = the same under \
-             the default `PerSuperfile` idf. `recall vs engine BM25` = `Global` against BM25 \
+             quantization and per-superfile avgdl. `recall (per-superfile stats)` = the same under \
+             segment-local `PerSuperfile` idf (the pre-0.7 default). `recall vs engine BM25` = `Global` against BM25 \
              with the engine's stored (quantized) lengths, a hit allowed to fall short of the \
              k-th score by the avgdl residual ({tol:.1}% at this scale: the oracle normalizes \
              with the corpus-wide average length, the engine with each superfile's own) — \

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -526,7 +526,9 @@ fn listed_objects_under(table: &Supertable, prefix: &str) -> Option<Vec<(String,
 
 /// Cap on printed first-cold-query trace lines; the tail is summarized so a
 /// pre-drain fan (hundreds of GETs) can't flood the log.
-const COLD_TRACE_PRINT_MAX: usize = 12;
+// Raised (from 12) while the trace is forced on: the anomalous post-compact
+// open fans ~25 requests and the whole fan is the evidence.
+const COLD_TRACE_PRINT_MAX: usize = 40;
 /// Opt-in request-level cold trace; normal reports show only aggregate tables.
 const COLD_TRACE_ENV: &str = "INFINO_TRACE_VECTOR_COLD_FAN";
 
@@ -603,8 +605,14 @@ fn log_query_read_trace(prefix: &str, phase: &str, trace: &[storage_meter::Trace
     }
 }
 
+/// Temporarily forced on: the post-compact cold fan reads user data only
+/// on the CI VM, and the per-request trace is the diagnostic that names
+/// the exact objects. Revert to the env opt-in once that run is
+/// understood.
+const FORCE_COLD_TRACE: bool = true;
+
 fn cold_trace_enabled() -> bool {
-    env::var_os(COLD_TRACE_ENV).is_some()
+    FORCE_COLD_TRACE || env::var_os(COLD_TRACE_ENV).is_some()
 }
 
 /// Spread one cold consumer's metered + timed windows into the cost model's
@@ -3549,11 +3557,18 @@ pub mod vector {
         );
         let meter = storage_meter::wrap(Arc::clone(&built.storage));
         let trace_enabled = cold_trace_enabled();
+        let mut open_trace = None;
         let mut first_query_trace = None;
         let mut steady_trace = None;
         let measured = cold_store::measure_cold_store(
             &meter,
             || {
+                // Arm the trace across the open itself: an open that reads
+                // data-class bytes is exactly the anomaly the per-request
+                // listing needs to name.
+                if trace_enabled {
+                    meter.start_trace();
+                }
                 let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
                     meter.provider(),
                     Some(cache_budget_bytes),
@@ -3570,6 +3585,7 @@ pub mod vector {
             },
             |(consumer, _cache)| {
                 if trace_enabled {
+                    open_trace = Some(meter.take_trace());
                     meter.start_trace();
                 }
                 let _ = consumer
@@ -3626,6 +3642,9 @@ pub mod vector {
             },
         );
         log_cold_split(label, &measured.split);
+        if let Some(trace) = open_trace {
+            log_query_read_trace(label, "cold open", &trace);
+        }
         if let Some(trace) = first_query_trace {
             log_query_read_trace(label, "first cold query", &trace);
         }

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -1896,7 +1896,7 @@ pub mod fts {
                                 &query,
                                 TOP_K,
                                 exec_fts::to_infino_mode(q.mode),
-                                infino::Bm25Stats::PerSuperfile,
+                                infino::Bm25Stats::default(),
                                 None,
                             )
                             .expect("serving working-set bm25_search");
@@ -2109,7 +2109,7 @@ pub mod fts {
                             &query,
                             TOP_K,
                             mode,
-                            infino::Bm25Stats::PerSuperfile,
+                            infino::Bm25Stats::default(),
                             None,
                         )
                         .expect("routing-state warm bm25 search"),
@@ -2161,7 +2161,7 @@ pub mod fts {
                     &query,
                     TOP_K,
                     exec_fts::to_infino_mode(q.mode),
-                    infino::Bm25Stats::PerSuperfile,
+                    infino::Bm25Stats::default(),
                     None,
                 )
                 .expect("warm prewarm bm25_search");
@@ -2279,7 +2279,7 @@ pub mod fts {
                         &terms,
                         TOP_K,
                         mode,
-                        infino::Bm25Stats::PerSuperfile,
+                        infino::Bm25Stats::default(),
                         None,
                     )
                     .expect("metered cold bm25_search");
@@ -2296,7 +2296,7 @@ pub mod fts {
                         &terms,
                         TOP_K,
                         mode,
-                        infino::Bm25Stats::PerSuperfile,
+                        infino::Bm25Stats::default(),
                         None,
                     )
                     .expect("metered steady cold bm25_search");
@@ -2313,7 +2313,7 @@ pub mod fts {
                         &terms,
                         TOP_K,
                         mode,
-                        infino::Bm25Stats::PerSuperfile,
+                        infino::Bm25Stats::default(),
                         None,
                     )
                     .expect("metered repeat cold bm25_search");
@@ -2353,14 +2353,7 @@ pub mod fts {
             self.consumer
                 .reader()
                 .expect("reader")
-                .bm25_search(
-                    column,
-                    query,
-                    k,
-                    mode,
-                    infino::Bm25Stats::PerSuperfile,
-                    None,
-                )
+                .bm25_search(column, query, k, mode, infino::Bm25Stats::default(), None)
                 .expect("cold bm25_search")
                 .iter()
                 .map(|b| b.num_rows())
@@ -2382,7 +2375,7 @@ pub mod fts {
                     query,
                     k,
                     mode,
-                    infino::Bm25Stats::PerSuperfile,
+                    infino::Bm25Stats::default(),
                     Some(&["_id", column, "score"]),
                 )
                 .expect("cold bm25_search fetched")

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -1722,7 +1722,7 @@ pub mod fts {
         // superfile layout is untouched). The read phases then measure
         // the maintained shape a production table sits in. On an engine
         // without the sidecar this is a no-op maintenance pass.
-        if ingest_metrics.is_some() && phases.reads() {
+        if corpus.is_some() && phases.reads() {
             let (cache_dir, admin) = open_consumer(Modality::Fts, &built);
             let stats_only = OptimizeOptions::compact(CompactionSettings {
                 min_fill_percent: 100,

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -50,7 +50,7 @@ use std::{
 };
 
 use infino::{
-    OptimizeOptions,
+    CompactionSettings, OptimizeOptions,
     supertable::{
         Supertable,
         manifest::{ClusterCentroids, SuperfileEntry},
@@ -1714,6 +1714,30 @@ pub mod fts {
         };
         if let Some(metrics) = &ingest_metrics {
             emit_ingest(&mut report, n_docs, metrics);
+        }
+
+        // Maintenance parity for the global-stats default: publish the
+        // term-stats sidecar over the fresh fragmented layout via a
+        // stats-only optimize (both merge triggers disabled, so the
+        // superfile layout is untouched). The read phases then measure
+        // the maintained shape a production table sits in. On an engine
+        // without the sidecar this is a no-op maintenance pass.
+        if ingest_metrics.is_some() && phases.reads() {
+            let (cache_dir, admin) = open_consumer(Modality::Fts, &built);
+            let stats_only = OptimizeOptions::compact(CompactionSettings {
+                min_fill_percent: 100,
+                min_superfiles_for_merge: u64::MAX,
+                ..CompactionSettings::default()
+            });
+            let (result, wall, _cpu) = cpu::timed(|| admin.optimize(&stats_only));
+            result.expect("stats-only optimize");
+            eprintln!(
+                "[supertable_fts] term-stats maintenance (stats-only optimize): {:.1}s, {} superfiles",
+                wall.as_secs_f64(),
+                admin.reader().expect("reader").n_superfiles()
+            );
+            drop(admin);
+            drop(cache_dir);
         }
 
         // Full lifecycle (pre-drain → drain → post-drain → delta → post-delta

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -526,9 +526,7 @@ fn listed_objects_under(table: &Supertable, prefix: &str) -> Option<Vec<(String,
 
 /// Cap on printed first-cold-query trace lines; the tail is summarized so a
 /// pre-drain fan (hundreds of GETs) can't flood the log.
-// Raised (from 12) while the trace is forced on: the anomalous post-compact
-// open fans ~25 requests and the whole fan is the evidence.
-const COLD_TRACE_PRINT_MAX: usize = 40;
+const COLD_TRACE_PRINT_MAX: usize = 12;
 /// Opt-in request-level cold trace; normal reports show only aggregate tables.
 const COLD_TRACE_ENV: &str = "INFINO_TRACE_VECTOR_COLD_FAN";
 
@@ -605,14 +603,8 @@ fn log_query_read_trace(prefix: &str, phase: &str, trace: &[storage_meter::Trace
     }
 }
 
-/// Temporarily forced on: the post-compact cold fan reads user data only
-/// on the CI VM, and the per-request trace is the diagnostic that names
-/// the exact objects. Revert to the env opt-in once that run is
-/// understood.
-const FORCE_COLD_TRACE: bool = true;
-
 fn cold_trace_enabled() -> bool {
-    FORCE_COLD_TRACE || env::var_os(COLD_TRACE_ENV).is_some()
+    env::var_os(COLD_TRACE_ENV).is_some()
 }
 
 /// Spread one cold consumer's metered + timed windows into the cost model's
@@ -3557,18 +3549,11 @@ pub mod vector {
         );
         let meter = storage_meter::wrap(Arc::clone(&built.storage));
         let trace_enabled = cold_trace_enabled();
-        let mut open_trace = None;
         let mut first_query_trace = None;
         let mut steady_trace = None;
         let measured = cold_store::measure_cold_store(
             &meter,
             || {
-                // Arm the trace across the open itself: an open that reads
-                // data-class bytes is exactly the anomaly the per-request
-                // listing needs to name.
-                if trace_enabled {
-                    meter.start_trace();
-                }
                 let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
                     meter.provider(),
                     Some(cache_budget_bytes),
@@ -3585,7 +3570,6 @@ pub mod vector {
             },
             |(consumer, _cache)| {
                 if trace_enabled {
-                    open_trace = Some(meter.take_trace());
                     meter.start_trace();
                 }
                 let _ = consumer
@@ -3642,9 +3626,6 @@ pub mod vector {
             },
         );
         log_cold_split(label, &measured.split);
-        if let Some(trace) = open_trace {
-            log_query_read_trace(label, "cold open", &trace);
-        }
         if let Some(trace) = first_query_trace {
             log_query_read_trace(label, "first cold query", &trace);
         }

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -526,9 +526,7 @@ fn listed_objects_under(table: &Supertable, prefix: &str) -> Option<Vec<(String,
 
 /// Cap on printed first-cold-query trace lines; the tail is summarized so a
 /// pre-drain fan (hundreds of GETs) can't flood the log.
-// Raised (from 12) while the trace is forced on: the anomalous post-compact
-// open fans ~25 requests and the whole fan is the evidence.
-const COLD_TRACE_PRINT_MAX: usize = 40;
+const COLD_TRACE_PRINT_MAX: usize = 12;
 /// Opt-in request-level cold trace; normal reports show only aggregate tables.
 const COLD_TRACE_ENV: &str = "INFINO_TRACE_VECTOR_COLD_FAN";
 
@@ -605,14 +603,8 @@ fn log_query_read_trace(prefix: &str, phase: &str, trace: &[storage_meter::Trace
     }
 }
 
-/// Temporarily forced on: the post-compact cold fan reads user data only
-/// on the CI VM, and the per-request trace is the diagnostic that names
-/// the exact objects. Revert to the env opt-in once that run is
-/// understood.
-const FORCE_COLD_TRACE: bool = true;
-
 fn cold_trace_enabled() -> bool {
-    FORCE_COLD_TRACE || env::var_os(COLD_TRACE_ENV).is_some()
+    env::var_os(COLD_TRACE_ENV).is_some()
 }
 
 /// Spread one cold consumer's metered + timed windows into the cost model's
@@ -3564,18 +3556,11 @@ pub mod vector {
         );
         let meter = storage_meter::wrap(Arc::clone(&built.storage));
         let trace_enabled = cold_trace_enabled();
-        let mut open_trace = None;
         let mut first_query_trace = None;
         let mut steady_trace = None;
         let measured = cold_store::measure_cold_store(
             &meter,
             || {
-                // Arm the trace across the open itself: an open that reads
-                // data-class bytes is exactly the anomaly the per-request
-                // listing needs to name.
-                if trace_enabled {
-                    meter.start_trace();
-                }
                 let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
                     meter.provider(),
                     Some(cache_budget_bytes),
@@ -3592,7 +3577,6 @@ pub mod vector {
             },
             |(consumer, _cache)| {
                 if trace_enabled {
-                    open_trace = Some(meter.take_trace());
                     meter.start_trace();
                 }
                 let _ = consumer
@@ -3649,9 +3633,6 @@ pub mod vector {
             },
         );
         log_cold_split(label, &measured.split);
-        if let Some(trace) = open_trace {
-            log_query_read_trace(label, "cold open", &trace);
-        }
         if let Some(trace) = first_query_trace {
             log_query_read_trace(label, "first cold query", &trace);
         }

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -526,7 +526,9 @@ fn listed_objects_under(table: &Supertable, prefix: &str) -> Option<Vec<(String,
 
 /// Cap on printed first-cold-query trace lines; the tail is summarized so a
 /// pre-drain fan (hundreds of GETs) can't flood the log.
-const COLD_TRACE_PRINT_MAX: usize = 12;
+// Raised (from 12) while the trace is forced on: the anomalous post-compact
+// open fans ~25 requests and the whole fan is the evidence.
+const COLD_TRACE_PRINT_MAX: usize = 40;
 /// Opt-in request-level cold trace; normal reports show only aggregate tables.
 const COLD_TRACE_ENV: &str = "INFINO_TRACE_VECTOR_COLD_FAN";
 
@@ -603,8 +605,14 @@ fn log_query_read_trace(prefix: &str, phase: &str, trace: &[storage_meter::Trace
     }
 }
 
+/// Temporarily forced on: the post-compact cold fan reads user data only
+/// on the CI VM, and the per-request trace is the diagnostic that names
+/// the exact objects. Revert to the env opt-in once that run is
+/// understood.
+const FORCE_COLD_TRACE: bool = true;
+
 fn cold_trace_enabled() -> bool {
-    env::var_os(COLD_TRACE_ENV).is_some()
+    FORCE_COLD_TRACE || env::var_os(COLD_TRACE_ENV).is_some()
 }
 
 /// Spread one cold consumer's metered + timed windows into the cost model's
@@ -3556,11 +3564,18 @@ pub mod vector {
         );
         let meter = storage_meter::wrap(Arc::clone(&built.storage));
         let trace_enabled = cold_trace_enabled();
+        let mut open_trace = None;
         let mut first_query_trace = None;
         let mut steady_trace = None;
         let measured = cold_store::measure_cold_store(
             &meter,
             || {
+                // Arm the trace across the open itself: an open that reads
+                // data-class bytes is exactly the anomaly the per-request
+                // listing needs to name.
+                if trace_enabled {
+                    meter.start_trace();
+                }
                 let (cache_dir, cache) = tiers::fresh_supertable_search_cache(
                     meter.provider(),
                     Some(cache_budget_bytes),
@@ -3577,6 +3592,7 @@ pub mod vector {
             },
             |(consumer, _cache)| {
                 if trace_enabled {
+                    open_trace = Some(meter.take_trace());
                     meter.start_trace();
                 }
                 let _ = consumer
@@ -3633,6 +3649,9 @@ pub mod vector {
             },
         );
         log_cold_split(label, &measured.split);
+        if let Some(trace) = open_trace {
+            log_query_read_trace(label, "cold open", &trace);
+        }
         if let Some(trace) = first_query_trace {
             log_query_read_trace(label, "first cold query", &trace);
         }

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -913,6 +913,16 @@ const WARM_ITERS: usize = 20;
 // and every deterministic cold assertion (GET counts, byte ceilings, cost
 // tables) is per-iteration and unaffected by the count.
 const COLD_ITERS: usize = 3;
+/// FTS-only cold sampling: one fresh-cache pass per shape. The FTS cold
+/// battery is the most byte-bound cell in the suite (realistic text
+/// barely compresses, and every iteration re-pays the whole fan from
+/// the object store) and its latencies are informational — the merge
+/// gate reads warm p90, and the deterministic cold assertions (GET
+/// counts, byte ceilings, cost tables) hold per iteration. One pass
+/// keeps every column populated at a third of the wall time; the
+/// vector and sql cells keep [`COLD_ITERS`] for outlier-discarding
+/// medians.
+const FTS_COLD_ITERS: usize = 1;
 const TOP_K: usize = 10;
 
 /// Selected phases for a per-modality supertable runner.
@@ -2266,7 +2276,7 @@ pub mod fts {
             FTS_BATTERY,
             supertable::TEXT_COLUMN,
             TOP_K,
-            COLD_ITERS,
+            FTS_COLD_ITERS,
             true,
             "supertable_fts",
         )

--- a/benches/utils/tombstone_overhead.rs
+++ b/benches/utils/tombstone_overhead.rs
@@ -250,7 +250,7 @@ fn measure_fts(st: &Supertable) -> Duration {
             QUERY_TERM,
             TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::default(),
             None,
         )
         .expect("fts");
@@ -266,7 +266,7 @@ fn measure_fts(st: &Supertable) -> Duration {
                 black_box(QUERY_TERM),
                 black_box(TOP_K),
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::default(),
                 None,
             )
             .expect("fts");

--- a/docs/architecture/on-disk-layout.md
+++ b/docs/architecture/on-disk-layout.md
@@ -38,6 +38,14 @@ mydb/                                     database root (the connect() path)
 │   │       │          bloom + min/max summaries
 │   │       └ used   : skip-pruning; reject superfiles before reading their bytes
 │   │
+│   ├── term-stats/                       present only after a maintenance pass
+│   │   └── stats-<blake3>.bin            binary · magic "INFTSTA1", immutable,
+│   │                                     content-addressed
+│   │       ├ stores : document frequency per (column, term), summed over the
+│   │       │          superfile ids the file records as covered
+│   │       └ used   : corpus-wide BM25 statistics; one lookup replaces probing
+│   │                  every superfile's own term dictionary
+│   │
 │   ├── data/
 │   │   └── <superfile>.sf.parquet        the superfiles (files prefixed seg-)
 │   │       ├ stores : valid Parquet columns + embedded BM25 + vector index,
@@ -92,14 +100,20 @@ Who points to whom, and how many. The catalog lists many tables; each table pins
                │    │  (avro.zst)      │─ entry ━━━━━▶ seg-B.sf.parquet ╌╌╌╌╌▶ B.tombstones
                │    └──────────────────┘
                │
-               └──▶ ┌──────────────────┐
-                    │ manifest part 2  │─ entry ━━━━━▶ seg-C.sf.parquet ╌╌╌╌╌▶ C.tombstones
-                    │  (avro.zst)      │─ entry ━━━━━▶ seg-D.sf.parquet ╌╌╌╌╌▶ (none yet, as nothing deleted/updated)
-                    └──────────────────┘
+               ├──▶ ┌──────────────────┐
+               │    │ manifest part 2  │─ entry ━━━━━▶ seg-C.sf.parquet ╌╌╌╌╌▶ C.tombstones
+               │    │  (avro.zst)      │─ entry ━━━━━▶ seg-D.sf.parquet ╌╌╌╌╌▶ (none yet, as nothing deleted/updated)
+               │    └──────────────────┘
+               │
+               │    term_stats.uri
+               └──▶ ┌──────────────────────┐
+                    │ stats-<blake3>.bin   │  absent on a table no maintenance
+                    └──────────────────────┘  pass has run yet
 
    Legend
      seg-X            = data/seg-<id>.sf.parquet   (the superfile: Parquet + BM25 + vector)
      X.tombstones     = superfiles/<id>.tombstones (shares the superfile's id)
+     stats-<blake3>   = term-stats/stats-<blake3>.bin
 
      ━━━━━▶   stored pointer: the labelled field names the next file
      ╌╌╌╌╌▶   NOT a stored pointer: derived from the superfile id; the
@@ -113,6 +127,7 @@ Every hop below the two pointer files is content-addressed with a blake3 hash, s
 - `data/` holds the superfiles; `superfiles/` holds only their tombstones. The directory name is misleading.
 - The live set is whatever the current manifest names. An update writes a new superfile and tombstones the old one, so `data/` accumulates more `.sf.parquet` files than the table's live row count until GC removes the dead ones.
 - `wal/mutations/` is normally empty. A `<walid>.json` (and, for UPDATE, its `.arrow` sidecar) exists only while a mutation is in flight or was interrupted; the next recovery sweep drains it.
+- `term-stats/` is derived, not source data: every figure in it can be recomputed by reading the covered superfiles' own dictionaries, and a reader that cannot load the file falls back to doing exactly that. A maintenance pass (`optimize`) writes it; a commit that only appends keeps the reference, since the new superfiles are simply uncovered and a query tops their df up from their own dictionaries; a commit that removes superfiles drops the reference, because a departed superfile's contribution is baked into sums that cannot be attributed back out. So a table can legitimately have no `term-stats/` file, one file, or one live file alongside superseded ones GC has not yet swept.
 
 ## Source references
 
@@ -128,3 +143,4 @@ Anchored by symbol so they survive line moves:
 | `wal/mutations/` state-doc + `.arrow` sidecar | `WAL_DIR`, `WalStore` | [src/supertable/wal/persistence.rs](../../src/supertable/wal/persistence.rs) |
 | `superfiles/<id>.tombstones` sidecar paths | `SUPERFILES_DIR`, `tombstones_path` | [src/supertable/wal/persistence.rs](../../src/supertable/wal/persistence.rs) |
 | tombstone binary format (`INFTOMB\0` + RoaringBitmap) | `MAGIC`, layout doc | [src/supertable/wal/tombstones_codec.rs](../../src/supertable/wal/tombstones_codec.rs) |
+| `term-stats/stats-<hash>.bin` name, binary layout (`INFTSTA1` + covered ids + FST), and the carry/drop rule | `STORAGE_PREFIX`, `MAGIC`, `TermStatsSidecar` | [src/supertable/manifest/term_stats.rs](../../src/supertable/manifest/term_stats.rs) |

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -389,14 +389,14 @@ fn parse_mode(mode: Option<&str>) -> Result<BoolMode> {
     }
 }
 
-/// Parse a BM25 statistics-scope string (`"per_superfile"` default, or
-/// `"global"` for corpus-wide IDF across superfiles).
+/// Parse a BM25 statistics-scope string: `"global"` (corpus-wide IDF, the
+/// default when omitted) or `"per_superfile"` (segment-local IDF).
 fn parse_stats(stats: Option<&str>) -> Result<Bm25Stats> {
-    match stats
-        .unwrap_or("per_superfile")
-        .to_ascii_lowercase()
-        .as_str()
-    {
+    let Some(stats) = stats else {
+        // Omitted means the engine default.
+        return Ok(Bm25Stats::default());
+    };
+    match stats.to_ascii_lowercase().as_str() {
         "per_superfile" => Ok(Bm25Stats::PerSuperfile),
         "global" => Ok(Bm25Stats::Global),
         other => Err(Error::new(

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -932,11 +932,11 @@ fn parse_filter<'a>(
 }
 
 fn parse_stats(stats: Option<&str>) -> PyResult<Bm25Stats> {
-    match stats
-        .unwrap_or("per_superfile")
-        .to_ascii_lowercase()
-        .as_str()
-    {
+    let Some(stats) = stats else {
+        // Omitted means the engine default.
+        return Ok(Bm25Stats::default());
+    };
+    match stats.to_ascii_lowercase().as_str() {
         "per_superfile" => Ok(Bm25Stats::PerSuperfile),
         "global" => Ok(Bm25Stats::Global),
         other => Err(PyValueError::new_err(format!(

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -232,7 +232,7 @@ impl Supertable {
     /// Ranked BM25 full-text search over one FTS column.
     ///
     /// `opts` ([`Bm25SearchOptions`]) carries the boolean `mode` and the
-    /// corpus-statistics selector: [`Bm25Stats::PerSuperfile`](crate::Bm25Stats::PerSuperfile)
+    /// corpus-statistics selector: [`Bm25Stats::Global`](crate::Bm25Stats::Global)
     /// (the default, each segment scored against its own local statistics) or
     /// [`Bm25Stats::Global`](crate::Bm25Stats::Global) (one table-wide idf
     /// across all segments, so a fragmented table ranks like a single unified

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -29,6 +29,7 @@ use super::{
     filter::ExcludeFilter,
     metadata::{ColumnMeta, FtsColumnConfig, NormTable, OpenOptions},
     phrase::{AnyCursor, PhraseCursor},
+    search::FetchedTermMemo,
     sink::{TopKEntry, drain_top_k_desc},
     work::{term_cursor_bytes, term_cursor_ranges},
 };
@@ -79,6 +80,11 @@ pub(crate) struct ClauseLists<'a> {
     /// Per-term global idf for [`Bm25Stats::Global`]; `None` scores
     /// with per-superfile local idf (the default).
     pub global_idf: Option<&'a GlobalTermIdf>,
+    /// Open-wave fetches for the scored terms (global stats): the
+    /// cursor builds serve these terms from the memo instead of
+    /// re-reading the dictionary and postings ranges the df gather
+    /// already fetched. `None` on the single-pass path.
+    pub prefetched: Option<&'a FetchedTermMemo>,
 }
 
 impl ClauseLists<'_> {
@@ -1116,6 +1122,7 @@ impl FtsReader {
         terms: &[&str],
         phrases: &[Vec<String>],
         global_idf: Option<&GlobalTermIdf>,
+        prefetched: Option<&FetchedTermMemo>,
     ) -> Result<(Vec<Option<AnyCursor>>, u64), FtsError> {
         let col_meta = &self.columns[column_id as usize];
         if !phrases.is_empty() && !col_meta.positions {
@@ -1132,7 +1139,7 @@ impl FtsReader {
         // dictionary range for the whole batch.
         if !terms.is_empty() {
             let term_cursors = self
-                .build_term_cursors_opt(column_id, terms, global_idf, false, None)
+                .build_term_cursors_opt(column_id, terms, global_idf, false, None, prefetched)
                 .await?;
             dict_ranges += 1;
             for cursor in term_cursors {
@@ -1146,7 +1153,7 @@ impl FtsReader {
             // per-member rescale ratio cancels out of the phrase's tf/length
             // bound. Build members with the same `global_idf` as bare terms.
             let cursors = self
-                .build_term_cursors(column_id, &member_refs, global_idf, false, None)
+                .build_term_cursors(column_id, &member_refs, global_idf, false, None, prefetched)
                 .await?;
             dict_ranges += 1;
             if cursors.len() != member_refs.len() {

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -30,7 +30,7 @@ use super::{
     metadata::{ColumnMeta, FtsColumnConfig, NormTable, OpenOptions},
     phrase::{AnyCursor, PhraseCursor},
     search::FetchedTermMemo,
-    sink::{TopKEntry, drain_top_k_desc},
+    sink::{LiveFloor, TopKEntry, drain_top_k_desc},
     work::{term_cursor_bytes, term_cursor_ranges},
 };
 use crate::superfile::{
@@ -85,6 +85,13 @@ pub(crate) struct ClauseLists<'a> {
     /// re-reading the dictionary and postings ranges the df gather
     /// already fetched. `None` on the single-pass path.
     pub prefetched: Option<&'a FetchedTermMemo>,
+    /// The query fan-out's live cross-segment floor (see [`LiveFloor`]):
+    /// the atom walks re-read it per candidate — pruning phrase verify
+    /// work against every segment's published kth-best, not just the
+    /// snapshot taken at segment start — and publish their own local
+    /// kth into it as their heaps fill. `None` on single-superfile
+    /// entry points, where there is no fan-out to share with.
+    pub live_floor: Option<&'a LiveFloor>,
 }
 
 impl ClauseLists<'_> {

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -131,7 +131,7 @@ impl FtsReader {
         let column_id = self.resolve_column_id(column)?;
         // Unranked: idf is irrelevant to the match set, so build local.
         let (built, dict_ranges) = self
-            .build_atom_cursors(column_id, terms, phrases, None)
+            .build_atom_cursors(column_id, terms, phrases, None, None)
             .await?;
         let missing_and_atom = mode == BoolMode::And && built.iter().any(Option::is_none);
         let atoms: Vec<AnyCursor> = built.into_iter().flatten().collect();
@@ -165,7 +165,7 @@ impl FtsReader {
         let column_id = self.resolve_column_id(column)?;
         // Unranked: idf is irrelevant to the match set, so build local.
         let (built, dict_ranges) = self
-            .build_atom_cursors(column_id, terms, phrases, None)
+            .build_atom_cursors(column_id, terms, phrases, None, None)
             .await?;
         let missing_and_atom = mode == BoolMode::And && built.iter().any(Option::is_none);
         let atoms: Vec<AnyCursor> = built.into_iter().flatten().collect();
@@ -182,7 +182,7 @@ impl FtsReader {
         let mut filter = None;
         if !neg_terms.is_empty() || !neg_phrases.is_empty() {
             let (neg_built, neg_dict_ranges) = self
-                .build_atom_cursors(column_id, neg_terms, neg_phrases, None)
+                .build_atom_cursors(column_id, neg_terms, neg_phrases, None, None)
                 .await?;
             let neg_atoms: Vec<AnyCursor> = neg_built.into_iter().flatten().collect();
             // Count the negated clause's posting work the same way the
@@ -239,7 +239,7 @@ impl FtsReader {
             return Ok((Vec::new(), MatchWork::default()));
         }
         let cursors = self
-            .build_term_cursors(column_id, tokens, None, true, None)
+            .build_term_cursors(column_id, tokens, None, true, None, None)
             .await?;
         // Tallied before the mode branch: the cursors that DID build cost
         // their bytes even when a missing AND token empties the result.
@@ -279,7 +279,7 @@ impl FtsReader {
             return Ok((0, MatchWork::default()));
         }
         let cursors = self
-            .build_term_cursors(column_id, tokens, None, true, None)
+            .build_term_cursors(column_id, tokens, None, true, None, None)
             .await?;
         let mut work = MatchWork::for_cursors(&cursors);
         work.planned_ranges += 1;
@@ -668,7 +668,7 @@ mod tests {
         // Prove `mix` really has both encodings — else the test silently checks
         // nothing about the transition.
         let cursors = r
-            .build_term_cursors(0, &["mix"], None, true, None)
+            .build_term_cursors(0, &["mix"], None, true, None, None)
             .await
             .expect("build cursors");
         let mix = &cursors[0];

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -1130,7 +1130,7 @@ mod tests {
         let reader = FtsReader::open(bytes, json).expect("open FtsReader");
 
         let mut cursors = reader
-            .build_term_cursors(0, &["common"], None, false, None)
+            .build_term_cursors(0, &["common"], None, false, None, None)
             .await
             .expect("build term cursors");
         let cursor = cursors.first_mut().expect("`common` present in dictionary");

--- a/src/superfile/fts/reader/filter.rs
+++ b/src/superfile/fts/reader/filter.rs
@@ -117,7 +117,7 @@ mod tests {
     async fn exclude_filter_for(reader: &FtsReader, terms: &[&str]) -> ExcludeFilter {
         let column_id = reader.resolve_column_id("body").expect("column exists");
         let cursors = reader
-            .build_term_cursors(column_id, terms, None, false, None)
+            .build_term_cursors(column_id, terms, None, false, None, None)
             .await
             .expect("build cursors");
         ExcludeFilter::new(cursors)

--- a/src/superfile/fts/reader/mod.rs
+++ b/src/superfile/fts/reader/mod.rs
@@ -25,4 +25,5 @@ pub use core::*;
 pub(crate) use expand::{LONG_S_ASCII, TermPattern, has_fold_partner};
 pub use metadata::{ColumnMeta, OpenOptions};
 pub use options::{Bm25SearchOptions, Bm25Stats, BoolMode};
+pub(crate) use search::FetchedTermMemo;
 pub use work::MatchWork;

--- a/src/superfile/fts/reader/mod.rs
+++ b/src/superfile/fts/reader/mod.rs
@@ -26,4 +26,5 @@ pub(crate) use expand::{LONG_S_ASCII, TermPattern, has_fold_partner};
 pub use metadata::{ColumnMeta, OpenOptions};
 pub use options::{Bm25SearchOptions, Bm25Stats, BoolMode};
 pub(crate) use search::FetchedTermMemo;
+pub(crate) use sink::LiveFloor;
 pub use work::MatchWork;

--- a/src/superfile/fts/reader/options.rs
+++ b/src/superfile/fts/reader/options.rs
@@ -30,8 +30,7 @@ pub enum Bm25Stats {
     /// but a term's idf — and therefore a doc's score — depends on
     /// which superfile it lands in, so scores are only approximately
     /// comparable across superfiles and ranking drifts as the table
-    /// fragments. The default.
-    #[default]
+    /// fragments.
     PerSuperfile,
     /// Score every superfile against table-wide idf: the document count
     /// and per-term document-frequencies aggregated across all
@@ -39,7 +38,9 @@ pub enum Bm25Stats {
     /// idf for the whole table, so a fragmented table ranks like a
     /// single unified corpus, at the cost of a document-frequency
     /// gather before scoring. (Length normalization still uses each
-    /// superfile's own average document length.)
+    /// superfile's own average document length.) The default: ranking
+    /// should not depend on how commits happened to shard the corpus.
+    #[default]
     Global,
 }
 
@@ -47,20 +48,24 @@ impl From<&str> for Bm25Stats {
     fn from(s: &str) -> Self {
         match s.to_ascii_lowercase().as_str() {
             "global" => Bm25Stats::Global,
-            _ => Bm25Stats::PerSuperfile,
+            "per_superfile" => Bm25Stats::PerSuperfile,
+            // Anything else is treated as "unspecified" and takes the
+            // default, so this conversion and the enum default cannot
+            // drift apart.
+            _ => Bm25Stats::default(),
         }
     }
 }
 
 /// Options for a BM25 search: the boolean `mode` and the corpus-statistics
 /// `stats`. Set fields with the `with_*` builders; [`Default`] is
-/// [`BoolMode::Or`] with [`Bm25Stats::PerSuperfile`].
+/// [`BoolMode::Or`] with [`Bm25Stats::Global`].
 ///
 /// ```ignore
-/// // OR mode, per-superfile stats (the defaults):
+/// // OR mode, global stats (the defaults):
 /// Bm25SearchOptions::new()
-/// // AND mode, global stats:
-/// Bm25SearchOptions::new().with_mode(BoolMode::And).with_stats(Bm25Stats::Global)
+/// // AND mode, per-superfile (segment-local) stats:
+/// Bm25SearchOptions::new().with_mode(BoolMode::And).with_stats(Bm25Stats::PerSuperfile)
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub struct Bm25SearchOptions {
@@ -71,7 +76,7 @@ pub struct Bm25SearchOptions {
 }
 
 impl Bm25SearchOptions {
-    /// Default options: `Or` mode, per-superfile statistics.
+    /// Default options: `Or` mode, global statistics.
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/superfile/fts/reader/scorers.rs
+++ b/src/superfile/fts/reader/scorers.rs
@@ -2253,7 +2253,7 @@ impl FtsReader {
             return Ok(Vec::new());
         }
         let cursors = self
-            .build_term_cursors(column_id, terms, None, false, None)
+            .build_term_cursors(column_id, terms, None, false, None, None)
             .await?;
         if cursors.is_empty() {
             return Ok(Vec::new());
@@ -2411,7 +2411,7 @@ mod tests {
         let r = FtsReader::open(blob, json).expect("open");
 
         let mut cursors = r
-            .build_term_cursors(0, &["common"], None, false, None)
+            .build_term_cursors(0, &["common"], None, false, None, None)
             .await
             .expect("build common cursor");
         let cursor = &mut cursors[0];
@@ -2708,14 +2708,14 @@ mod tests {
         for (pos, neg) in cases {
             for k in [1usize, 5, 50] {
                 let mut wf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None, false, None)
+                    r.build_term_cursors(col, neg, None, false, None, None)
                         .await
                         .expect("neg cursors"),
                 );
                 let wms = r
                     .run_windowed_maxscore(
                         col,
-                        r.build_term_cursors(col, pos, None, false, None)
+                        r.build_term_cursors(col, pos, None, false, None, None)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -2726,14 +2726,14 @@ mod tests {
                     )
                     .expect("windowed-maxscore");
                 let mut bf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None, false, None)
+                    r.build_term_cursors(col, neg, None, false, None, None)
                         .await
                         .expect("neg cursors"),
                 );
                 let bmm = r
                     .run_max_score_bmm(
                         col,
-                        r.build_term_cursors(col, pos, None, false, None)
+                        r.build_term_cursors(col, pos, None, false, None, None)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -2921,7 +2921,7 @@ mod tests {
                 let wms = r
                     .run_windowed_maxscore(
                         col,
-                        r.build_term_cursors(col, terms, None, false, None)
+                        r.build_term_cursors(col, terms, None, false, None, None)
                             .await
                             .expect("cursors"),
                         k,
@@ -2934,7 +2934,7 @@ mod tests {
                 let bmm = r
                     .run_max_score_bmm_range(
                         col,
-                        r.build_term_cursors(col, terms, None, false, None)
+                        r.build_term_cursors(col, terms, None, false, None, None)
                             .await
                             .expect("cursors"),
                         k,
@@ -3023,11 +3023,11 @@ mod tests {
         for terms in shapes {
             for k in [1usize, 5, 50, 128] {
                 let cw = r
-                    .build_term_cursors(col, terms, None, false, None)
+                    .build_term_cursors(col, terms, None, false, None, None)
                     .await
                     .expect("cursors");
                 let cb = r
-                    .build_term_cursors(col, terms, None, false, None)
+                    .build_term_cursors(col, terms, None, false, None, None)
                     .await
                     .expect("cursors");
                 let wand = r.run_wand_bmw(col, cw, k).expect("wand");
@@ -3072,7 +3072,7 @@ mod tests {
 
         // common (df≈N) + rare (df≈N/200): ratio 200 ≥ 16 → anchor.
         let anchored = r
-            .build_term_cursors(col, &["common", "rare"], None, false, None)
+            .build_term_cursors(col, &["common", "rare"], None, false, None, None)
             .await
             .expect("cursors");
         assert!(
@@ -3081,7 +3081,7 @@ mod tests {
         );
         // common (df≈N) + frequent (df≈N/2): ratio 2 < 16 → no anchor.
         let uniform = r
-            .build_term_cursors(col, &["common", "frequent"], None, false, None)
+            .build_term_cursors(col, &["common", "frequent"], None, false, None, None)
             .await
             .expect("cursors");
         assert!(
@@ -3132,14 +3132,14 @@ mod tests {
         for (pos, neg) in cases {
             for k in [1usize, 5, 50] {
                 let mut wf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None, false, None)
+                    r.build_term_cursors(col, neg, None, false, None, None)
                         .await
                         .expect("neg cursors"),
                 );
                 let win = r
                     .run_windowed_union(
                         col,
-                        r.build_term_cursors(col, pos, None, false, None)
+                        r.build_term_cursors(col, pos, None, false, None, None)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -3150,14 +3150,14 @@ mod tests {
                     )
                     .expect("windowed");
                 let mut bf = ExcludeFilter::new(
-                    r.build_term_cursors(col, neg, None, false, None)
+                    r.build_term_cursors(col, neg, None, false, None, None)
                         .await
                         .expect("neg cursors"),
                 );
                 let bmm = r
                     .run_max_score_bmm(
                         col,
-                        r.build_term_cursors(col, pos, None, false, None)
+                        r.build_term_cursors(col, pos, None, false, None, None)
                             .await
                             .expect("pos cursors"),
                         k,
@@ -3187,7 +3187,7 @@ mod tests {
         let unfiltered = r
             .run_windowed_union(
                 col,
-                r.build_term_cursors(col, pos, None, false, None)
+                r.build_term_cursors(col, pos, None, false, None, None)
                     .await
                     .expect("pos"),
                 N_DOCS as usize,
@@ -3198,14 +3198,14 @@ mod tests {
             )
             .expect("unfiltered");
         let mut f = ExcludeFilter::new(
-            r.build_term_cursors(col, neg, None, false, None)
+            r.build_term_cursors(col, neg, None, false, None, None)
                 .await
                 .expect("neg"),
         );
         let filtered = r
             .run_windowed_union(
                 col,
-                r.build_term_cursors(col, pos, None, false, None)
+                r.build_term_cursors(col, pos, None, false, None, None)
                     .await
                     .expect("pos"),
                 N_DOCS as usize,

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -7,8 +7,9 @@
 //! BlockMaxWAND fast path, and the atom (phrase-aware) scored walk.
 //! Its own `impl FtsReader` block, split from the reader `core`.
 
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashMap};
 
+use bytes::Bytes;
 use rustc_hash::FxHashMap;
 
 use super::{
@@ -38,6 +39,57 @@ use crate::{
         },
     },
 };
+
+/// One scored term's open-wave fetch result: the dictionary resolution
+/// plus, for a PFOR term, its full postings range and header df.
+/// Cloning is cheap — `Bytes` is a refcounted slice.
+#[derive(Clone)]
+pub(crate) enum FetchedTermSlot {
+    /// df=1 inline dictionary slot (no postings-region bytes exist).
+    Inline { doc_id: u32, tf: u32 },
+    /// PFOR term: the fetched metadata+skip+blocks range and its df.
+    Pfor {
+        bytes: Bytes,
+        /// The dictionary slot carried no length hint, so the fetch paid
+        /// a header probe before the body — two planned ranges, which
+        /// the cursor built from these bytes must keep reporting.
+        header_probed: bool,
+        df: u64,
+    },
+}
+
+/// One superfile's open-wave fetches for a global-stats query's scored
+/// terms, keyed by term. A key that is present with a `None` value is a
+/// *resolved miss* (the term is absent from this superfile) — the walk
+/// wave must not re-probe the dictionary for it. Built by
+/// [`FtsReader::fetch_scored_terms`]; consumed by the cursor builds via
+/// the `prefetched` parameter.
+pub(crate) struct FetchedTermMemo {
+    map: HashMap<Box<str>, Option<FetchedTermSlot>>,
+}
+
+impl FetchedTermMemo {
+    /// `Some(entry)` when the open wave resolved this term (entry `None`
+    /// = absent from this superfile); `None` when the term was not part
+    /// of the fetch (e.g. a negated term — unscored, never gathered).
+    pub(crate) fn lookup(&self, term: &str) -> Option<Option<FetchedTermSlot>> {
+        self.map.get(term).cloned()
+    }
+
+    fn contains(&self, term: &str) -> bool {
+        self.map.contains_key(term)
+    }
+
+    /// This superfile's df contribution per term (0 for a miss or an
+    /// un-fetched term, 1 for an inline slot).
+    pub(crate) fn df(&self, term: &str) -> u64 {
+        match self.map.get(term) {
+            Some(Some(FetchedTermSlot::Inline { .. })) => 1,
+            Some(Some(FetchedTermSlot::Pfor { df, .. })) => *df,
+            _ => 0,
+        }
+    }
+}
 
 /// Threshold-first seed tuning for the single-term ranked walk. The walk
 /// fills its top-k heap in doc-id order, so its skip threshold rises only
@@ -415,7 +467,13 @@ impl FtsReader {
         if lists.has_phrases() {
             // Phrase-bearing query: the heterogeneous atom walks.
             let (must_atoms, must_dict) = self
-                .build_atom_cursors(column_id, lists.musts, lists.must_phrases, lists.global_idf)
+                .build_atom_cursors(
+                    column_id,
+                    lists.musts,
+                    lists.must_phrases,
+                    lists.global_idf,
+                    lists.prefetched,
+                )
                 .await?;
             if must_atoms.iter().any(Option::is_none) {
                 // A must atom can never match in this superfile. The
@@ -435,13 +493,20 @@ impl FtsReader {
                     lists.shoulds,
                     lists.should_phrases,
                     lists.global_idf,
+                    lists.prefetched,
                 )
                 .await?;
             let should_atoms: Vec<AnyCursor> = should_built.into_iter().flatten().collect();
             // Negatives are a hard exclusion filter, not scored, so their
             // idf is irrelevant — always build them local.
             let (negative_built, negative_dict) = self
-                .build_atom_cursors(column_id, lists.negatives, lists.negative_phrases, None)
+                .build_atom_cursors(
+                    column_id,
+                    lists.negatives,
+                    lists.negative_phrases,
+                    None,
+                    None,
+                )
                 .await?;
             let negative_atoms: Vec<AnyCursor> = negative_built.into_iter().flatten().collect();
             let postings_bytes = atom_cursor_bytes(&must_atoms)
@@ -477,7 +542,7 @@ impl FtsReader {
             // Negatives are a hard exclusion filter, not scored, so their
             // idf is irrelevant — always build them with local stats.
             _ => Some(ExcludeFilter::new(
-                self.build_term_cursors(column_id, lists.negatives, None, false, None)
+                self.build_term_cursors(column_id, lists.negatives, None, false, None, None)
                     .await?,
             )),
         };
@@ -515,9 +580,19 @@ impl FtsReader {
             let filter_postings_bytes = filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
             let filter_ranges = filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
             let (result, term_work, kernel_cpu_ns) = self
-                .search_single_term_bmw(column_id, term, k, filter.as_mut(), floor_eff, gidf)
+                .search_single_term_bmw(
+                    column_id,
+                    term,
+                    k,
+                    filter.as_mut(),
+                    floor_eff,
+                    gidf,
+                    lists.prefetched,
+                )
                 .await?;
-            // +1: the BMW walk's own dictionary fetch.
+            // +1: the walk's dictionary read — performed here on the
+            // single-pass path, by the open wave on the memo path; either
+            // way the query read it once and the walk wave reports it.
             dict_ranges += 1;
             return Ok(PreparedClauses::Done {
                 hits: result,
@@ -535,6 +610,7 @@ impl FtsReader {
                     lists.global_idf,
                     false,
                     Some(&should_qtf),
+                    lists.prefetched,
                 )
                 .await?;
             dict_ranges += 1;
@@ -561,7 +637,14 @@ impl FtsReader {
         // Build must cursors; if any must is missing, the
         // intersection is empty.
         let must_cursors = self
-            .build_term_cursors(column_id, &musts, lists.global_idf, false, Some(&must_qtf))
+            .build_term_cursors(
+                column_id,
+                &musts,
+                lists.global_idf,
+                false,
+                Some(&must_qtf),
+                lists.prefetched,
+            )
             .await?;
         dict_ranges += 1;
         if must_cursors.len() != musts.len() {
@@ -596,6 +679,7 @@ impl FtsReader {
                 lists.global_idf,
                 false,
                 Some(&should_qtf),
+                lists.prefetched,
             )
             .await?;
         dict_ranges += 1;
@@ -714,7 +798,9 @@ impl FtsReader {
         floor: f32,
         global_idf: Option<&GlobalTermIdf>,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
-        let set = self.build_or_cursor_set(column, terms, global_idf).await?;
+        let set = self
+            .build_or_cursor_set(column, terms, global_idf, None)
+            .await?;
         self.search_or_range_prebuilt(&set, k, doc_id_start, doc_id_end, floor)
     }
 
@@ -734,12 +820,13 @@ impl FtsReader {
         column: &str,
         terms: &[&str],
         global_idf: Option<&GlobalTermIdf>,
+        prefetched: Option<&FetchedTermMemo>,
     ) -> Result<OrCursorSet, FtsError> {
         let column_id = self.resolve_column_id(column)?;
         let cursors = if terms.is_empty() {
             Vec::new()
         } else {
-            self.build_term_cursors(column_id, terms, global_idf, false, None)
+            self.build_term_cursors(column_id, terms, global_idf, false, None, prefetched)
                 .await?
         };
         Ok(OrCursorSet { column_id, cursors })
@@ -835,16 +922,63 @@ impl FtsReader {
         mut filter: Option<&mut ExcludeFilter>,
         floor_eff: f32,
         global_idf: Option<f32>,
+        prefetched: Option<&FetchedTermMemo>,
     ) -> Result<(Vec<(u32, f32)>, MatchWork, u64), FtsError> {
-        let fst_bytes = self.dict_bytes_async().await?;
-        let dict = Self::open_dict(&fst_bytes)?;
         let col_meta = &self.columns[column_id as usize];
-        let key = make_key(&col_meta.name, term);
-        let Some(packed) = dict.lookup(&key) else {
-            return Ok((Vec::new(), MatchWork::default(), 0));
+        // Resolve the term: from the open-wave memo when the df gather
+        // prefetched it (global stats — the bytes below are the ones that
+        // wave fetched), else via the dictionary.
+        enum SingleSource {
+            Absent,
+            Inline { doc_id: u32, tf: u32 },
+            Bytes { bytes: Bytes, header_probed: bool },
+        }
+        let source = if let Some(entry) = prefetched.and_then(|m| m.lookup(term)) {
+            match entry {
+                None => SingleSource::Absent,
+                Some(FetchedTermSlot::Inline { doc_id, tf }) => SingleSource::Inline { doc_id, tf },
+                Some(FetchedTermSlot::Pfor {
+                    bytes,
+                    header_probed,
+                    ..
+                }) => SingleSource::Bytes {
+                    bytes,
+                    header_probed,
+                },
+            }
+        } else {
+            let fst_bytes = self.dict_bytes_async().await?;
+            let dict = Self::open_dict(&fst_bytes)?;
+            let key = make_key(&col_meta.name, term);
+            match dict.lookup(&key) {
+                None => SingleSource::Absent,
+                Some(packed) => match FstValue::unpack(packed) {
+                    FstValue::Inline { doc_id, tf } => SingleSource::Inline { doc_id, tf },
+                    FstValue::Pfor {
+                        metadata_offset,
+                        postings_length_hint,
+                    } => {
+                        // Fetch only this term's byte range (metadata header
+                        // + skip table + blocks). The returned buffer starts
+                        // at the metadata header, so all indexing below is
+                        // relative to offset 0.
+                        let mut fetched = self
+                            .fetch_term_postings(&[(
+                                metadata_offset as usize,
+                                postings_length_hint.map(|len| len as usize),
+                            )])
+                            .await?;
+                        SingleSource::Bytes {
+                            bytes: fetched.pop().expect("one fetched range for one PFOR term"),
+                            header_probed: postings_length_hint.is_none(),
+                        }
+                    }
+                },
+            }
         };
-        let (metadata_offset, postings_length) = match FstValue::unpack(packed) {
-            FstValue::Inline { doc_id, tf } => {
+        let (term_bytes, header_probed) = match source {
+            SingleSource::Absent => return Ok((Vec::new(), MatchWork::default(), 0)),
+            SingleSource::Inline { doc_id, tf } => {
                 // df=1 inline path: no postings-region read, no
                 // skip-table, no PFOR decode. The single doc's score
                 // is the entire result for any k ≥ 1 (unless it sits
@@ -874,23 +1008,10 @@ impl FtsReader {
                 }
                 return Ok((vec![(doc_id, score)], MatchWork::default(), 0));
             }
-            FstValue::Pfor {
-                metadata_offset,
-                postings_length_hint,
-            } => (
-                metadata_offset as usize,
-                postings_length_hint.map(|len| len as usize),
-            ),
-        };
-        // Fetch only this term's byte range (metadata header + skip
-        // table + blocks). The returned buffer starts at the metadata
-        // header, so the region-relative `metadata_offset` rebases to
-        // 0 for all indexing below.
-        let term_bytes = {
-            let mut fetched = self
-                .fetch_term_postings(&[(metadata_offset, postings_length)])
-                .await?;
-            fetched.pop().expect("one fetched range for one PFOR term")
+            SingleSource::Bytes {
+                bytes,
+                header_probed,
+            } => (bytes, header_probed),
         };
         let postings = term_bytes.as_ref();
         let metadata_offset = 0usize;
@@ -1131,7 +1252,7 @@ impl FtsReader {
                 postings_bytes: term_bytes.len() as u64,
                 // A hint-less slot costs a header probe before the body
                 // fetch — two planned ranges instead of one.
-                planned_ranges: 1 + u64::from(postings_length.is_none()),
+                planned_ranges: 1 + u64::from(header_probed),
                 // The walk's ns travel in the tuple's third element.
                 kernel_cpu_ns: 0,
             },
@@ -1155,13 +1276,100 @@ impl FtsReader {
         global_idf: Option<&GlobalTermIdf>,
         count_only: bool,
         qtf: Option<&[u32]>,
+        prefetched: Option<&FetchedTermMemo>,
     ) -> Result<Vec<TermCursor>, FtsError> {
         Ok(self
-            .build_term_cursors_opt(column_id, terms, global_idf, count_only, qtf)
+            .build_term_cursors_opt(column_id, terms, global_idf, count_only, qtf, prefetched)
             .await?
             .into_iter()
             .flatten()
             .collect())
+    }
+
+    /// Open-wave fetch for `Bm25Stats::Global`: resolve `terms` in this
+    /// superfile's dictionary and fetch each PFOR term's full postings
+    /// range — exactly the reads the cursor build performs — recording
+    /// df per term so the caller can aggregate corpus-wide idf BEFORE
+    /// any walk starts. The returned memo travels back into the walk
+    /// wave, whose cursor builds then issue no byte-source reads for
+    /// these terms (see the `prefetched` parameter on
+    /// [`Self::build_term_cursors_opt`]).
+    ///
+    /// Work accounting stays with the walk wave: the cursors built from
+    /// the memo report the same posting bytes and planned ranges they
+    /// would have reported fetching for themselves, so per-query work
+    /// stats under global stats equal the per-superfile plan — the
+    /// whole point of fusing the gather into this wave.
+    pub(crate) async fn fetch_scored_terms(
+        &self,
+        column: &str,
+        terms: &[&str],
+    ) -> Result<FetchedTermMemo, FtsError> {
+        let column_id = self.resolve_column_id(column)?;
+        let col_meta = &self.columns[column_id as usize];
+        let fst_bytes = self.dict_bytes_async().await?;
+        let dict = Self::open_dict(&fst_bytes)?;
+
+        // Resolve every term, collecting the PFOR ranges for one
+        // coalesced fetch (mirrors `build_term_cursors_opt`).
+        enum Pre {
+            Inline { doc_id: u32, tf: u32 },
+            Pfor { header_probed: bool },
+        }
+        let mut resolved: Vec<(Box<str>, Option<Pre>)> = Vec::with_capacity(terms.len());
+        let mut pfor_offsets: Vec<(usize, Option<usize>)> = Vec::new();
+        for term in terms {
+            let key = make_key(&col_meta.name, term);
+            let pre = dict
+                .lookup(&key)
+                .map(|packed| match FstValue::unpack(packed) {
+                    FstValue::Inline { doc_id, tf } => Pre::Inline { doc_id, tf },
+                    FstValue::Pfor {
+                        metadata_offset,
+                        postings_length_hint,
+                    } => {
+                        pfor_offsets.push((
+                            metadata_offset as usize,
+                            postings_length_hint.map(|len| len as usize),
+                        ));
+                        Pre::Pfor {
+                            header_probed: postings_length_hint.is_none(),
+                        }
+                    }
+                });
+            resolved.push((Box::from(*term), pre));
+        }
+        let pfor_bytes = self.fetch_term_postings(&pfor_offsets).await?;
+        let mut pfor_iter = pfor_bytes.into_iter();
+
+        let mut map: HashMap<Box<str>, Option<FetchedTermSlot>> =
+            HashMap::with_capacity(resolved.len());
+        for (term, pre) in resolved {
+            let slot = match pre {
+                None => None,
+                Some(Pre::Inline { doc_id, tf }) => Some(FetchedTermSlot::Inline { doc_id, tf }),
+                Some(Pre::Pfor { header_probed }) => {
+                    let bytes = pfor_iter.next().expect("one fetched range per PFOR term");
+                    // df sits in the term's metadata header at the head of
+                    // the fetched range — the same parse the cursor build
+                    // repeats (CPU-only, no extra read).
+                    let term_meta = TermMeta::parse(
+                        bytes.as_ref(),
+                        0,
+                        col_meta.positions,
+                        false,
+                        self.has_coarse_block_max,
+                    )?;
+                    Some(FetchedTermSlot::Pfor {
+                        bytes,
+                        header_probed,
+                        df: term_meta.df,
+                    })
+                }
+            };
+            map.insert(term, slot);
+        }
+        Ok(FetchedTermMemo { map })
     }
 
     /// Build a `TermCursor` for every term, **preserving input order and
@@ -1182,20 +1390,25 @@ impl FtsReader {
         global_idf: Option<&GlobalTermIdf>,
         count_only: bool,
         qtf: Option<&[u32]>,
+        prefetched: Option<&FetchedTermMemo>,
     ) -> Result<Vec<Option<TermCursor>>, FtsError> {
-        let fst_bytes = self.dict_bytes_async().await?;
-        let dict = Self::open_dict(&fst_bytes)?;
         let col_meta = &self.columns[column_id as usize];
 
         // Resolve each term to an inline (df=1) value, a PFOR metadata
         // offset, or a miss — preserving query order and arity (a miss is a
-        // `None` slot, so the caller can tell which term was absent). Collect
-        // the PFOR offsets so all their byte ranges can be fetched in one
-        // parallel fan-out below — never the whole postings region. Each
-        // resolved entry carries its term's global idf (when in
+        // `None` slot, so the caller can tell which term was absent). A term
+        // the open-wave memo already resolved (global stats) is served from
+        // it — its bytes were fetched when its df was gathered — so the
+        // dictionary is opened, and the PFOR fan below issued, only for the
+        // terms the memo does not cover (all of them on the single-pass
+        // path). Each resolved entry carries its term's global idf (when in
         // `Bm25Stats::Global`) so the cursor is built with the global value;
         // `None` per term falls back to this superfile's local idf.
         enum Resolved {
+            Memo {
+                slot: FetchedTermSlot,
+                gidf: Option<f32>,
+            },
             Inline {
                 doc_id: u32,
                 tf: u32,
@@ -1206,15 +1419,31 @@ impl FtsReader {
                 header_probed: bool,
             },
         }
+        let all_prefetched = prefetched.is_some_and(|m| terms.iter().all(|t| m.contains(t)));
+        let dict_bytes = match all_prefetched {
+            true => None,
+            false => Some(self.dict_bytes_async().await?),
+        };
+        let dict = match dict_bytes.as_ref() {
+            Some(b) => Some(Self::open_dict(b)?),
+            None => None,
+        };
         let mut resolved: Vec<Option<Resolved>> = Vec::with_capacity(terms.len());
         let mut pfor_offsets: Vec<(usize, Option<usize>)> = Vec::new();
         for term in terms {
+            let gidf = global_idf.and_then(|m| m.get(*term).copied());
+            if let Some(entry) = prefetched.and_then(|m| m.lookup(term)) {
+                resolved.push(entry.map(|slot| Resolved::Memo { slot, gidf }));
+                continue;
+            }
+            let dict = dict
+                .as_ref()
+                .expect("dictionary opened for un-memoed terms");
             let key = make_key(&col_meta.name, term);
             let Some(packed) = dict.lookup(&key) else {
                 resolved.push(None);
                 continue;
             };
-            let gidf = global_idf.and_then(|m| m.get(*term).copied());
             match FstValue::unpack(packed) {
                 FstValue::Inline { doc_id, tf } => {
                     resolved.push(Some(Resolved::Inline { doc_id, tf, gidf }));
@@ -1247,6 +1476,50 @@ impl FtsReader {
             let weight = qtf.map_or(1, |w| w[i]);
             match r {
                 None => cursors.push(None),
+                // Memo-served slots build from the open wave's bytes and
+                // report the same posting bytes / planned ranges they
+                // would have reported fetching for themselves, so work
+                // stats stay equal to the per-superfile plan (the walk
+                // wave is the only flusher).
+                Some(Resolved::Memo {
+                    slot: FetchedTermSlot::Inline { doc_id, tf },
+                    gidf,
+                }) => {
+                    let tf = match col_meta.positions {
+                        true => 1,
+                        false => tf,
+                    };
+                    let dl_norm_k1 = col_meta.dl_norm_k1.get(doc_id);
+                    cursors.push(Some(TermCursor::new_inline(
+                        doc_id,
+                        tf,
+                        self.n_docs as u64,
+                        dl_norm_k1,
+                        gidf,
+                        weight,
+                    )));
+                }
+                Some(Resolved::Memo {
+                    slot:
+                        FetchedTermSlot::Pfor {
+                            bytes,
+                            header_probed,
+                            ..
+                        },
+                    gidf,
+                }) => {
+                    let cursor = TermCursor::new(
+                        bytes,
+                        self.n_docs as u64,
+                        col_meta.positions,
+                        gidf,
+                        weight,
+                        header_probed,
+                        count_only,
+                        self.has_coarse_block_max,
+                    )?;
+                    cursors.push(Some(cursor));
+                }
                 Some(Resolved::Inline { doc_id, tf, gidf }) => {
                     // On a positional column the inline slot carries
                     // the term's single position, tf implied 1 — the
@@ -1729,7 +2002,7 @@ mod tests {
 
         let terms: &[&str] = &["alpha", "beta", "gamma", "delta"];
         let set = r
-            .build_or_cursor_set("body", terms, None)
+            .build_or_cursor_set("body", terms, None, None)
             .await
             .expect("set");
         let windows = [

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -18,7 +18,7 @@ use super::{
     filter::{AtomExcludeFilter, ExcludeFilter},
     options::BoolMode,
     phrase::AnyCursor,
-    sink::{TopKEntry, and_heap_push, drain_top_k_desc},
+    sink::{LiveFloor, TopKEntry, and_heap_push, drain_top_k_desc},
     work::{
         MatchWork, atom_cursor_bytes, atom_planned_ranges, term_cursor_bytes, term_cursor_ranges,
     },
@@ -127,6 +127,15 @@ impl FtsReader {
     /// with none, the shoulds' union matches. Docs excluded by
     /// `filter` never reach the heap; docs scoring strictly below
     /// `floor_eff` are dropped at admission.
+    ///
+    /// Phrase verification (the position decode) dominates this walk,
+    /// and its bar-skip is only as good as the bar — so the walk keeps
+    /// the bar live: `live_floor`, when present, is re-read every
+    /// candidate (other segments of the fan-out raise it as their
+    /// heaps fill) and this walk publishes its own kth-best back as it
+    /// improves. A one-shot `floor_eff` snapshot instead left each
+    /// segment verifying against its slowly-filling local heap alone,
+    /// which showed up as phrase shapes degrading to count-like work.
     fn run_atoms_search(
         &self,
         column_id: u32,
@@ -135,10 +144,29 @@ impl FtsReader {
         k: usize,
         mut filter: Option<AtomExcludeFilter>,
         floor_eff: f32,
+        live_floor: Option<&LiveFloor>,
     ) -> Result<Vec<(u32, f32)>, FtsError> {
         let dl_norm_k1 = &self.columns[column_id as usize].dl_norm_k1;
         let initial_cap = top_k_initial_capacity(k, u64::from(self.n_docs), None);
         let mut heap: BinaryHeap<TopKEntry> = BinaryHeap::with_capacity(initial_cap);
+        // The strict-below admission cutoff, refreshed from the live
+        // floor: everything published there is a real kth-best, so the
+        // same `next_down` the caller applied to its snapshot keeps
+        // exact ties admissible.
+        let floor_now = || match live_floor {
+            Some(live) => live.load().next_down().max(floor_eff),
+            None => floor_eff,
+        };
+        // Publish this walk's kth-best once its heap is full — the
+        // fan-out's other segments prune against it immediately.
+        let publish = |heap: &BinaryHeap<TopKEntry>| {
+            if let Some(live) = live_floor
+                && heap.len() >= k
+                && let Some(worst) = heap.peek()
+            {
+                live.raise(worst.0);
+            }
+        };
 
         // Per-atom pruning slack: an atom only needs to contribute
         // more than the walk's bar minus what every *other* atom could
@@ -166,6 +194,7 @@ impl FtsReader {
                     Some(f) => f.admits(doc)?,
                     None => true,
                 };
+                let floor_live = floor_now();
                 if admitted {
                     let norm = dl_norm_k1.get(doc);
                     let score: f32 = shoulds
@@ -173,16 +202,17 @@ impl FtsReader {
                         .filter(|a| !a.is_exhausted() && a.current_doc_id() == doc)
                         .map(|a| a.score_current(norm))
                         .sum();
-                    if score > floor_eff {
+                    if score > floor_live {
                         and_heap_push(&mut heap, k, None, score, doc);
+                        publish(&heap);
                     }
                 }
                 let Some(next) = doc.checked_add(1) else {
                     break;
                 };
                 let bar = match heap.len() >= k {
-                    true => heap.peek().expect("heap len == k").0.max(floor_eff),
-                    false => floor_eff,
+                    true => heap.peek().expect("heap len == k").0.max(floor_live),
+                    false => floor_live,
                 };
                 for (a, &others) in shoulds.iter_mut().zip(&others_ub) {
                     if !a.is_exhausted() && a.current_doc_id() == doc {
@@ -207,9 +237,10 @@ impl FtsReader {
         };
         let mut target = 0u32;
         'docs: loop {
+            let floor_live = floor_now();
             let bar = match heap.len() >= k {
-                true => heap.peek().expect("heap len == k").0.max(floor_eff),
-                false => floor_eff,
+                true => heap.peek().expect("heap len == k").0.max(floor_live),
+                false => floor_live,
             };
             // Phase 1 — approximate alignment (phrase = member co-occurrence,
             // no positions).
@@ -268,8 +299,9 @@ impl FtsReader {
                             score += sh.score_current(norm);
                         }
                     }
-                    if score > floor_eff {
+                    if score > floor_live {
                         and_heap_push(&mut heap, k, None, score, aligned);
+                        publish(&heap);
                     }
                 }
             }
@@ -527,8 +559,15 @@ impl FtsReader {
             // its on-CPU time here (sync section, no awaits inside).
             // Gated: an unmetered process must not pay the procfs reads.
             let kernel_start = metering_active().then(thread_cpu_ns).flatten();
-            let result =
-                self.run_atoms_search(column_id, must_atoms, should_atoms, k, filter, floor_eff)?;
+            let result = self.run_atoms_search(
+                column_id,
+                must_atoms,
+                should_atoms,
+                k,
+                filter,
+                floor_eff,
+                lists.live_floor,
+            )?;
             return Ok(PreparedClauses::Done {
                 hits: result,
                 postings_bytes,

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -499,22 +499,23 @@ impl FtsReader {
         // Single-atom fast path: BlockMaxWAND-driven block skipping.
         // One term scores identically whichever clause list it sits
         // in (a lone must and a lone should both rank that term's
-        // postings), so both shapes take it. Skipped under global stats
-        // — the bespoke single-term BMW does not take an idf override,
-        // so route a lone term through the general cursor path (which
-        // does) instead; correctness over the single-term micro-opt.
-        if lists.global_idf.is_none() && lists.musts.len() + lists.shoulds.len() == 1 {
+        // postings), so both shapes take it. A global-idf override rides
+        // along: the walk scores with it and rescales its stored bounds
+        // by the exact linear ratio, so the skip decisions stay as tight
+        // as the per-superfile path's.
+        if lists.musts.len() + lists.shoulds.len() == 1 {
             let term = lists
                 .musts
                 .iter()
                 .chain(lists.shoulds)
                 .next()
                 .expect("one atom");
+            let gidf = lists.global_idf.and_then(|m| m.get(*term).copied());
             let mut filter = neg_filter;
             let filter_postings_bytes = filter.as_ref().map_or(0, ExcludeFilter::postings_bytes);
             let filter_ranges = filter.as_ref().map_or(0, ExcludeFilter::planned_ranges);
             let (result, term_work, kernel_cpu_ns) = self
-                .search_single_term_bmw(column_id, term, k, filter.as_mut(), floor_eff)
+                .search_single_term_bmw(column_id, term, k, filter.as_mut(), floor_eff, gidf)
                 .await?;
             // +1: the BMW walk's own dictionary fetch.
             dict_ranges += 1;
@@ -833,6 +834,7 @@ impl FtsReader {
         k: usize,
         mut filter: Option<&mut ExcludeFilter>,
         floor_eff: f32,
+        global_idf: Option<f32>,
     ) -> Result<(Vec<(u32, f32)>, MatchWork, u64), FtsError> {
         let fst_bytes = self.dict_bytes_async().await?;
         let dict = Self::open_dict(&fst_bytes)?;
@@ -855,7 +857,7 @@ impl FtsReader {
                     true => 1,
                     false => tf,
                 };
-                let idf_t = bm25::idf(self.n_docs as u64, 1);
+                let idf_t = global_idf.unwrap_or_else(|| bm25::idf(self.n_docs as u64, 1));
                 let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);
                 // Drop the lone match if a negated term excludes it.
                 // The inline slot read no postings-region bytes; the
@@ -906,8 +908,19 @@ impl FtsReader {
             self.has_coarse_block_max,
         )?;
 
-        let idf_t = bm25::idf(self.n_docs as u64, term_meta.df);
+        let local_idf = bm25::idf(self.n_docs as u64, term_meta.df);
+        let idf_t = global_idf.unwrap_or(local_idf);
         let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);
+        // Stored block-max and coarse entries bake in the LOCAL idf. Scores
+        // below use the (possibly overridden) effective idf, and the score
+        // is linear in idf, so rescaling every stored bound by the ratio
+        // keeps bounds exactly as tight as the per-superfile path — the
+        // same exact rescale `TermCursor::new` applies (see cursor.rs).
+        let bound_rescale = if local_idf > 0.0 && idf_t != local_idf {
+            idf_t / local_idf
+        } else {
+            1.0
+        };
         let dl_norm_k1 = &col_meta.dl_norm_k1;
 
         // Top-k min-heap; see `TopKEntry` for the reversed ordering
@@ -955,7 +968,7 @@ impl FtsReader {
             // Gather enough top spans to contain the top `m_want` blocks
             // (over-cover: worst case each is in its own span).
             let mut spans: Vec<(f32, usize)> = (0..num_coarse)
-                .map(|g| (term_meta.coarse_entry(postings, g), g))
+                .map(|g| (term_meta.coarse_entry(postings, g) * bound_rescale, g))
                 .collect();
             let s = m_want.max(seed::TOP_SPANS).min(spans.len());
             spans.select_nth_unstable_by(s.saturating_sub(1), |a, b| b.0.total_cmp(&a.0));
@@ -967,7 +980,7 @@ impl FtsReader {
                 let end = (start + coarse_span).min(term_meta.num_blocks);
                 for bi in start..end {
                     let (_, _, bm) = term_meta.skip_entry(postings, bi);
-                    cand.push((bm, bi));
+                    cand.push((bm * bound_rescale, bi));
                 }
             }
             let m = m_want.min(cand.len());
@@ -1023,7 +1036,7 @@ impl FtsReader {
         let mut i = 0usize;
         while i < term_meta.num_blocks {
             if coarse_enabled && i.is_multiple_of(coarse_span) {
-                let coarse_max = term_meta.coarse_entry(postings, i / coarse_span);
+                let coarse_max = term_meta.coarse_entry(postings, i / coarse_span) * bound_rescale;
                 let span_end = (i + coarse_span).min(term_meta.num_blocks);
                 // Seed skip, span-wide (strict): no block in the span can
                 // reach the seeded lower bound on the k-th, so none can be
@@ -1052,7 +1065,8 @@ impl FtsReader {
 
             // last_doc_id (first tuple slot) is unused here — it serves
             // AND-merge seeks, which single-term never does.
-            let (_, block_offset_in_term, block_max_bm25) = term_meta.skip_entry(postings, i);
+            let (_, block_offset_in_term, raw_block_max) = term_meta.skip_entry(postings, i);
+            let block_max_bm25 = raw_block_max * bound_rescale;
 
             // Seed skip (strict): block can't reach the seeded lower bound
             // on the k-th, so it holds no top-k doc.

--- a/src/superfile/fts/reader/sink.rs
+++ b/src/superfile/fts/reader/sink.rs
@@ -6,10 +6,59 @@
 //! AND flat-merge over score-into-heap vs collect/count, and the shared
 //! `and_heap_push`. `pub(super)` within `reader/`.
 
-use std::{cmp::Ordering, collections::BinaryHeap};
+use std::{
+    cmp::Ordering,
+    collections::BinaryHeap,
+    sync::atomic::{AtomicU32, Ordering as AtomicOrdering},
+};
 
 use super::{cursor::TermCursor, filter::ExcludeFilter, metadata::NormTable};
 use crate::superfile::fts::bm25;
+
+/// A monotonically rising score floor shared by every segment of one
+/// query's fan-out, readable and raisable lock-free mid-walk.
+///
+/// The kth-best score of any one segment is a lower bound on the
+/// kth-best of the whole query (the merged candidate set is a
+/// superset), so each walk may publish its local kth as it improves
+/// and every other walk may prune against the highest published value
+/// — the same cross-segment floor the fan-out already applies at
+/// segment start, made live. Pruning stays exact: walks skip only
+/// work strictly below the floor, so score ties still surface and the
+/// merged top-k is unchanged; only the amount of skipped work depends
+/// on timing.
+pub(crate) struct LiveFloor(AtomicU32);
+
+impl LiveFloor {
+    pub(crate) fn new() -> Self {
+        Self(AtomicU32::new(f32::NEG_INFINITY.to_bits()))
+    }
+
+    /// The highest floor published so far (`NEG_INFINITY` until some
+    /// segment has k scores).
+    #[inline]
+    pub(crate) fn load(&self) -> f32 {
+        f32::from_bits(self.0.load(AtomicOrdering::Acquire))
+    }
+
+    /// Raise the floor to `candidate` if it exceeds the current value;
+    /// lower values are ignored, so the floor is monotone under any
+    /// interleaving of publishers.
+    pub(crate) fn raise(&self, candidate: f32) {
+        let mut current = self.0.load(AtomicOrdering::Relaxed);
+        while candidate.total_cmp(&f32::from_bits(current)) == Ordering::Greater {
+            match self.0.compare_exchange_weak(
+                current,
+                candidate.to_bits(),
+                AtomicOrdering::Release,
+                AtomicOrdering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(seen) => current = seen,
+            }
+        }
+    }
+}
 
 /// Top-k min-heap entry `(score, doc_id)`, shared by every search
 /// path (single-term BMW, WAND+BMW, MaxScore+BMM, exhaustive union,

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1132,6 +1132,7 @@ impl SuperfileReader {
                 negative_phrases: &negative_phrases,
                 global_idf: None,
                 prefetched: None,
+                live_floor: None,
             },
             k,
             f32::NEG_INFINITY,

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1131,6 +1131,7 @@ impl SuperfileReader {
                 should_phrases: &should_phrases,
                 negative_phrases: &negative_phrases,
                 global_idf: None,
+                prefetched: None,
             },
             k,
             f32::NEG_INFINITY,
@@ -1302,6 +1303,20 @@ impl SuperfileReader {
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
         Ok(fts.term_dfs(column, tokens).await?)
+    }
+
+    /// Open-wave fetch of `terms`' dictionary slots + postings ranges
+    /// with per-term df, for the fused global-stats gather. Delegates to
+    /// [`FtsReader::fetch_scored_terms`].
+    pub(crate) async fn fetch_scored_terms(
+        &self,
+        column: &str,
+        terms: &[&str],
+    ) -> Result<fts_reader::FetchedTermMemo, ReadError> {
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        Ok(fts.fetch_scored_terms(column, terms).await?)
     }
 
     /// Two-pass exact match of a **raw string** `value` against
@@ -1533,11 +1548,14 @@ impl SuperfileReader {
         column: &str,
         terms: &[&str],
         global_idf: Option<&fts_reader::GlobalTermIdf>,
+        prefetched: Option<&fts_reader::FetchedTermMemo>,
     ) -> Result<OrCursorSet, ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
-        Ok(fts.build_or_cursor_set(column, terms, global_idf).await?)
+        Ok(fts
+            .build_or_cursor_set(column, terms, global_idf, prefetched)
+            .await?)
     }
 
     /// Expand `prefix` via the FST and build its OR cursor set, for
@@ -1563,7 +1581,9 @@ impl SuperfileReader {
             .iter()
             .filter_map(|b| str::from_utf8(b).ok())
             .collect();
-        Ok(fts.build_or_cursor_set(column, &term_strings, None).await?)
+        Ok(fts
+            .build_or_cursor_set(column, &term_strings, None, None)
+            .await?)
     }
 
     /// Ranged multi-term OR against prebuilt cursors — see

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -2901,28 +2901,14 @@ mod tests {
         measured_iters: usize,
     ) -> u128 {
         for _ in 0..warmup_iters {
-            st.bm25_search(
-                "title",
-                query,
-                10,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
-                None,
-            )
-            .expect("bm25_search warmup");
+            st.bm25_search("title", query, 10, BoolMode::Or, Bm25Stats::Global, None)
+                .expect("bm25_search warmup");
         }
         let mut samples = Vec::with_capacity(measured_iters);
         for _ in 0..measured_iters {
             let start = Instant::now();
-            st.bm25_search(
-                "title",
-                query,
-                10,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
-                None,
-            )
-            .expect("bm25_search measured");
+            st.bm25_search("title", query, 10, BoolMode::Or, Bm25Stats::Global, None)
+                .expect("bm25_search measured");
             samples.push(start.elapsed().as_micros());
         }
         samples.sort_unstable();

--- a/src/supertable/gc/mod.rs
+++ b/src/supertable/gc/mod.rs
@@ -19,6 +19,7 @@ use crate::{
         manifest::{
             SUPERFILE_DATA_DIR, SuperfileUri,
             commit::{MANIFEST_DIR, MANIFEST_PARTS_DIR, POINTER_PATH, manifest_uri},
+            term_stats::STORAGE_PREFIX as TERM_STATS_STORAGE_PREFIX,
         },
         slow_vector_state::{self, STORAGE_PREFIX as SLOW_VECTOR_STATE_STORAGE_PREFIX},
         wal::persistence::{SUPERFILES_DIR, WalStore},
@@ -88,6 +89,11 @@ fn build_live_set(manifest: &ManifestSnapshot) -> (HashSet<String>, bool) {
     }
     if let Some(graphs) = manifest.resident_vector_index_blob() {
         live.insert(graphs.uri.clone());
+    }
+    // The global term-stats sidecar, same list-ref discipline: the current
+    // artifact is live; superseded generations age out past the safety gap.
+    if let Some(stats) = manifest.term_stats_blob() {
+        live.insert(stats.uri.clone());
     }
 
     // Each resident superfile's tombstone sidecar. `superfiles/` is swept whatever the flag says,
@@ -217,6 +223,7 @@ pub(super) async fn gc_storage_sweep_for_inner(
         MANIFEST_DIR,
         MANIFEST_PARTS_DIR,
         SLOW_VECTOR_STATE_STORAGE_PREFIX,
+        TERM_STATS_STORAGE_PREFIX,
         // Tombstone sidecars under `superfiles/` (live set includes the
         // paths for current superfiles; orphans age out past the safety gap).
         SUPERFILES_DIR,
@@ -439,6 +446,7 @@ mod tests {
                 slow_vector_state_content_hash: None,
                 slow_vector_state_centroids: None,
                 slow_vector_state_graphs: None,
+                term_stats: None,
                 parts: vec![ManifestPartEntry {
                     part_id,
                     uri: format!("manifest-parts/part-{part_id}.avro.zst"),
@@ -513,6 +521,7 @@ mod tests {
                     content_hash: section_hash,
                 }),
                 slow_vector_state_graphs: None,
+                term_stats: None,
                 parts: Vec::new(),
             }),
         );

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -18,7 +18,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt,
     future::Future,
-    sync::{Arc, Mutex, OnceLock, Weak, atomic::AtomicBool},
+    sync::{Arc, Mutex, OnceLock, RwLock as StdRwLock, Weak, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -35,6 +35,7 @@ use super::{
     manifest::{
         ManifestSnapshot,
         list::{CellRoutingParams, PartitionStrategy},
+        term_stats::{self, TermStatsSidecar},
     },
     options::SupertableOptions,
 };
@@ -153,6 +154,11 @@ pub(super) struct SupertableInner {
     /// queries under `Bm25Stats::Global` skip the dictionary gather
     /// fan — see [`GlobalIdfCache`].
     pub(super) global_idf_cache: GlobalIdfCache,
+    /// Lazily loaded + verified global term-stats sidecar, keyed by its
+    /// content-addressed URI so appends (which carry the same ref) reuse
+    /// the parsed artifact and a maintenance republish swaps it. `None`
+    /// until first use or when the manifest carries no ref.
+    pub(super) term_stats_cache: StdRwLock<Option<(String, Arc<TermStatsSidecar>)>>,
     /// Per-process reader-side cache of per-superfile tombstone
     /// bitmaps. `Some` when storage is attached (the cache
     /// fetches sidecars from `superfiles/<id>.tombstones`);
@@ -872,6 +878,14 @@ impl Supertable {
     /// per call.
     pub(crate) fn block_on_query<F: Future>(&self, fut: F) -> F::Output {
         bridge_on_runtime(fut, &self.query_runtime())
+    }
+
+    /// Build and publish the global term-stats sidecar over the current
+    /// membership (see `manifest::term_stats`). Not part of the public
+    /// API — [`Supertable::optimize`] calls this after compaction so the
+    /// artifact describes the post-merge superfile set.
+    pub(crate) fn refresh_term_stats_sync(&self) -> Result<(), BuildError> {
+        self.block_on_query(super::writer::stamp_term_stats(&self.inner))
     }
 
     /// Route undrained user superfiles into the hidden per-cell index. Not part
@@ -1670,6 +1684,7 @@ async fn build_handle(
         sql_logical_plan_cache: Mutex::new(None),
         decoded_scalar_cache: DecodedScalarCache::default(),
         global_idf_cache: GlobalIdfCache::default(),
+        term_stats_cache: StdRwLock::new(None),
         tombstone_cache,
         handle_id,
         vector_index_table,
@@ -2014,6 +2029,45 @@ impl SupertableReader {
     /// minted from this supertable — see [`GlobalIdfCache`].
     pub(crate) fn global_idf_cache(&self) -> &GlobalIdfCache {
         &self.inner.global_idf_cache
+    }
+
+    /// The manifest-referenced global term-stats sidecar, loaded (and
+    /// hash-verified) once per artifact and cached on the handle by its
+    /// content-addressed URI. Returns `None` when the manifest carries
+    /// no reference, when no storage is attached, or when the load
+    /// fails — global-stats queries then fall back to the query-time
+    /// gather wave, trading latency for availability.
+    pub(crate) async fn term_stats_sidecar(&self) -> Option<Arc<TermStatsSidecar>> {
+        let reference = self.manifest.term_stats_blob()?.clone();
+        {
+            let cached = self
+                .inner
+                .term_stats_cache
+                .read()
+                .expect("term stats cache lock");
+            if let Some((uri, sidecar)) = cached.as_ref()
+                && *uri == reference.uri
+            {
+                return Some(Arc::clone(sidecar));
+            }
+        }
+        let storage = self.manifest.options.storage.as_ref()?;
+        match term_stats::load(storage.as_ref(), &reference).await {
+            Ok(sidecar) => {
+                let sidecar = Arc::new(sidecar);
+                *self
+                    .inner
+                    .term_stats_cache
+                    .write()
+                    .expect("term stats cache lock") =
+                    Some((reference.uri.clone(), Arc::clone(&sidecar)));
+                Some(sidecar)
+            }
+            Err(e) => {
+                warn!(error = %e, uri = %reference.uri, "term-stats sidecar load failed; falling back to the query-time df gather");
+                None
+            }
+        }
     }
 
     /// The shared `Arc<SupertableInner>` backing this reader. Used to

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -4220,14 +4220,7 @@ mod tests {
         // pre-compact warm/cold queries against a disk-cache consumer).
         use crate::superfile::fts::reader::{Bm25Stats, BoolMode};
         let hits = consumer
-            .bm25_search(
-                "title",
-                "doc",
-                5,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
-                None,
-            )
+            .bm25_search("title", "doc", 5, BoolMode::Or, Bm25Stats::Global, None)
             .expect("bm25 pre-optimize");
         assert!(!hits.is_empty(), "pre-optimize FTS should return hits");
 
@@ -4236,14 +4229,7 @@ mod tests {
             .expect("sql-shaped optimize after lazy reads");
 
         let hits_after = consumer
-            .bm25_search(
-                "title",
-                "doc",
-                5,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
-                None,
-            )
+            .bm25_search("title", "doc", 5, BoolMode::Or, Bm25Stats::Global, None)
             .expect("bm25 post-optimize");
         assert!(
             !hits_after.is_empty(),
@@ -8094,14 +8080,7 @@ mod tests {
     fn bm25_title_hits(table: &Supertable, query: &str) -> usize {
         use crate::superfile::fts::reader::{Bm25Stats, BoolMode};
         table
-            .bm25_search(
-                "title",
-                query,
-                10,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
-                None,
-            )
+            .bm25_search("title", query, 10, BoolMode::Or, Bm25Stats::Global, None)
             .expect("bm25 search")
             .iter()
             .map(|b| b.num_rows())

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -54,6 +54,7 @@ use crate::{
         manifest::commit::{PointerProbe, probe_pointer, read_pointer},
         options::Consistency,
         query::{
+            fts::GlobalIdfCache,
             scalar_cache::DecodedScalarCache,
             sql::{SqlSchemas, build_sql_schemas},
         },
@@ -147,6 +148,11 @@ pub(super) struct SupertableInner {
     /// Bounded decoded-row cache shared by all readers of this immutable
     /// supertable handle.
     pub(super) decoded_scalar_cache: DecodedScalarCache,
+    /// Per-generation cache of global BM25 idf per (column, term),
+    /// shared by every reader minted from this handle so repeat
+    /// queries under `Bm25Stats::Global` skip the dictionary gather
+    /// fan — see [`GlobalIdfCache`].
+    pub(super) global_idf_cache: GlobalIdfCache,
     /// Per-process reader-side cache of per-superfile tombstone
     /// bitmaps. `Some` when storage is attached (the cache
     /// fetches sidecars from `superfiles/<id>.tombstones`);
@@ -1663,6 +1669,7 @@ async fn build_handle(
         sql_session_cache: Mutex::new(None),
         sql_logical_plan_cache: Mutex::new(None),
         decoded_scalar_cache: DecodedScalarCache::default(),
+        global_idf_cache: GlobalIdfCache::default(),
         tombstone_cache,
         handle_id,
         vector_index_table,
@@ -2001,6 +2008,12 @@ impl SupertableReader {
 
     pub(crate) fn decoded_scalar_cache(&self) -> &DecodedScalarCache {
         &self.inner.decoded_scalar_cache
+    }
+
+    /// Per-generation global BM25 idf cache shared across every reader
+    /// minted from this supertable — see [`GlobalIdfCache`].
+    pub(crate) fn global_idf_cache(&self) -> &GlobalIdfCache {
+        &self.inner.global_idf_cache
     }
 
     /// The shared `Arc<SupertableInner>` backing this reader. Used to

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -28,6 +28,7 @@ use chrono::Utc;
 use datafusion::{execution::context::SessionContext, logical_expr::LogicalPlan};
 use tokio::runtime::Runtime;
 use tracing::{Instrument, debug, warn};
+use uuid::Uuid;
 
 use super::{
     error::{BuildError, CommitError, OpenError},
@@ -78,6 +79,30 @@ use crate::{
 #[derive(Clone)]
 pub struct Supertable {
     inner: Arc<SupertableInner>,
+}
+
+/// The parsed global term-stats artifact plus the verdict of checking
+/// its coverage, so neither cost is repaid per query.
+///
+/// Two things are memoized here because each is invariant over a
+/// different key. The parsed FST is keyed by the artifact's
+/// content-addressed `uri`: an append carries the same reference
+/// forward, so successive generations reuse it and only a maintenance
+/// republish refetches. The coverage verdict is keyed by manifest
+/// generation, because a manifest pins both its superfile list and its
+/// artifact reference — so `usable` is a pure function of
+/// `checked_generation`, and one check per generation serves every
+/// query on that snapshot.
+pub(super) struct CachedTermStats {
+    /// The artifact's content-addressed storage uri.
+    pub(super) uri: String,
+    /// Manifest generation `usable` was evaluated against.
+    pub(super) checked_generation: u64,
+    /// Whether every superfile the artifact covers was still listed by
+    /// that generation's manifest. `false` means callers must read df
+    /// from the superfile dictionaries instead.
+    pub(super) usable: bool,
+    pub(super) sidecar: Arc<TermStatsSidecar>,
 }
 
 /// Internal shared state. Every `Supertable` clone holds one Arc
@@ -154,11 +179,10 @@ pub(super) struct SupertableInner {
     /// queries under `Bm25Stats::Global` skip the dictionary gather
     /// fan — see [`GlobalIdfCache`].
     pub(super) global_idf_cache: GlobalIdfCache,
-    /// Lazily loaded + verified global term-stats sidecar, keyed by its
-    /// content-addressed URI so appends (which carry the same ref) reuse
-    /// the parsed artifact and a maintenance republish swaps it. `None`
-    /// until first use or when the manifest carries no ref.
-    pub(super) term_stats_cache: StdRwLock<Option<(String, Arc<TermStatsSidecar>)>>,
+    /// Lazily loaded + verified global term-stats sidecar. `None` until
+    /// first use or when the manifest carries no ref — see
+    /// [`CachedTermStats`] for what the entry holds and why.
+    pub(super) term_stats_cache: StdRwLock<Option<CachedTermStats>>,
     /// Per-process reader-side cache of per-superfile tombstone
     /// bitmaps. `Some` when storage is attached (the cache
     /// fetches sidecars from `superfiles/<id>.tombstones`);
@@ -1555,7 +1579,7 @@ pub(crate) fn legacy_vector_index_storage_prefix() -> &'static str {
 }
 
 fn generate_vector_index_storage_prefix() -> String {
-    format!("_infino_{}_vector_index", uuid::Uuid::new_v4())
+    format!("_infino_{}_vector_index", Uuid::new_v4())
 }
 
 fn resolve_vector_index_storage_prefix(
@@ -2039,35 +2063,88 @@ impl SupertableReader {
     /// gather wave, trading latency for availability.
     pub(crate) async fn term_stats_sidecar(&self) -> Option<Arc<TermStatsSidecar>> {
         let reference = self.manifest.term_stats_blob()?.clone();
+        let generation = self.manifest.get_manifest_id();
+        // Already parsed AND already checked against this generation's
+        // superfiles: the whole call is one cache read.
         {
             let cached = self
                 .inner
                 .term_stats_cache
                 .read()
                 .expect("term stats cache lock");
-            if let Some((uri, sidecar)) = cached.as_ref()
-                && *uri == reference.uri
+            if let Some(entry) = cached.as_ref()
+                && entry.uri == reference.uri
+                && entry.checked_generation == generation
             {
-                return Some(Arc::clone(sidecar));
+                return entry.usable.then(|| Arc::clone(&entry.sidecar));
             }
         }
-        let storage = self.manifest.options.storage.as_ref()?;
-        match term_stats::load(storage.as_ref(), &reference).await {
-            Ok(sidecar) => {
-                let sidecar = Arc::new(sidecar);
-                *self
-                    .inner
-                    .term_stats_cache
-                    .write()
-                    .expect("term stats cache lock") =
-                    Some((reference.uri.clone(), Arc::clone(&sidecar)));
-                Some(sidecar)
+        // Same artifact, new generation (an append carries the
+        // reference forward): keep the parsed FST and re-check its
+        // coverage rather than refetching.
+        let parsed = {
+            let cached = self
+                .inner
+                .term_stats_cache
+                .read()
+                .expect("term stats cache lock");
+            cached
+                .as_ref()
+                .filter(|entry| entry.uri == reference.uri)
+                .map(|entry| Arc::clone(&entry.sidecar))
+        };
+        let sidecar = match parsed {
+            Some(sidecar) => sidecar,
+            None => {
+                let storage = self.manifest.options.storage.as_ref()?;
+                match term_stats::load(storage.as_ref(), &reference).await {
+                    Ok(sidecar) => Arc::new(sidecar),
+                    Err(e) => {
+                        warn!(error = %e, uri = %reference.uri, "term-stats sidecar load failed; falling back to the query-time df gather");
+                        return None;
+                    }
+                }
             }
-            Err(e) => {
-                warn!(error = %e, uri = %reference.uri, "term-stats sidecar load failed; falling back to the query-time df gather");
-                None
-            }
+        };
+        // Coverage check, once per (artifact, generation). The artifact's
+        // sums are aggregates over the superfiles it names, so a
+        // superfile that has since left the manifest cannot be
+        // subtracted back out — serving df from it would over-count and
+        // depress idf for the affected terms. The manifest carry rule
+        // drops the reference on any commit that removes superfiles,
+        // which is what makes a stale artifact unreachable; this is the
+        // belt to those braces, and it runs in every build because the
+        // failure mode is silently wrong ranking rather than an error.
+        // Rejecting an artifact costs latency, never correctness: with
+        // no artifact, callers read df from every superfile's own
+        // dictionary.
+        let current: HashSet<Uuid> = self
+            .manifest
+            .superfiles
+            .iter()
+            .map(|entry| entry.superfile_id)
+            .collect();
+        let usable = sidecar.covered().iter().all(|id| current.contains(id));
+        if !usable {
+            warn!(
+                uri = %reference.uri,
+                generation,
+                "term-stats sidecar covers a superfile this manifest no longer lists; \
+                 ignoring it and reading document frequency from the superfile \
+                 dictionaries instead"
+            );
         }
+        *self
+            .inner
+            .term_stats_cache
+            .write()
+            .expect("term stats cache lock") = Some(CachedTermStats {
+            uri: reference.uri.clone(),
+            checked_generation: generation,
+            usable,
+            sidecar: Arc::clone(&sidecar),
+        });
+        usable.then_some(sidecar)
     }
 
     /// The shared `Arc<SupertableInner>` backing this reader. Used to

--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -844,6 +844,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: Vec::new(),
         };
         let res = write_manifest(storage.as_ref(), &list)

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -170,6 +170,18 @@ pub struct Manifest {
     /// manifests and above the scale ceiling (consumers fall back to the
     /// lazy build or the scan path).
     pub slow_vector_state_graphs: Option<RoutingRef>,
+    /// Global term-statistics sidecar: a content-addressed artifact
+    /// holding gross `df` per (column, term) summed over a recorded set
+    /// of this table's superfiles, so a global-stats BM25 query reads
+    /// corpus-wide df in one lookup instead of fanning over every
+    /// superfile's dictionary. Written by maintenance (optimize);
+    /// **carried through appends** (new superfiles are simply uncovered
+    /// tail the query tops up from their own dictionaries) and
+    /// **dropped by any commit that removes superfiles** (a removed
+    /// superfile's contribution is baked into the sum and cannot be
+    /// attributed, so only a fresh maintenance pass may republish).
+    /// Absent on older manifests and until the first maintenance pass.
+    pub term_stats: Option<RoutingRef>,
     /// Entries — one per manifest part referenced by this
     /// list. Ordered by insertion order (commit order); the
     /// list-level pruner walks them in order.
@@ -1236,6 +1248,10 @@ struct ManifestDto {
     slow_vector_state_graphs_uri: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     slow_vector_state_graphs_content_hash: Option<String>, // "blake3:<64hex>"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    term_stats_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    term_stats_content_hash: Option<String>, // "blake3:<64hex>"
     partition_strategy: PartitionStrategyDto,
     #[serde(default)]
     global_vector_index: Option<GlobalVectorIndexDto>,
@@ -1806,6 +1822,8 @@ fn list_to_dto(l: &Manifest) -> Result<ManifestDto, ListEncodeError> {
             .slow_vector_state_graphs
             .as_ref()
             .map(|r| encode_hash(&r.content_hash)),
+        term_stats_uri: l.term_stats.as_ref().map(|r| r.uri.clone()),
+        term_stats_content_hash: l.term_stats.as_ref().map(|r| encode_hash(&r.content_hash)),
         parts,
         tombstone_seqs: l
             .tombstone_seqs
@@ -1915,6 +1933,14 @@ fn list_from_dto(d: ManifestDto) -> Result<Manifest, ListParseError> {
             d.slow_vector_state_graphs_uri,
             d.slow_vector_state_graphs_content_hash.as_deref(),
         ) {
+            (Some(uri), Some(hash)) => Some(RoutingRef {
+                uri,
+                content_hash: decode_hash(hash)?,
+            }),
+            _ => None,
+        },
+        // Same both-halves discipline as the refs above.
+        term_stats: match (d.term_stats_uri, d.term_stats_content_hash.as_deref()) {
             (Some(uri), Some(hash)) => Some(RoutingRef {
                 uri,
                 content_hash: decode_hash(hash)?,
@@ -2529,6 +2555,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![],
         }
     }
@@ -3098,6 +3125,41 @@ mod tests {
         assert!(
             matches!(err, ListParseError::BadContentHash(_)),
             "expected BadContentHash, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn term_stats_ref_round_trips_and_requires_both_halves() {
+        let mut list = empty_list();
+        list.term_stats = Some(RoutingRef {
+            uri: "term-stats/stats-abc.bin".into(),
+            content_hash: ContentHash([7u8; 32]),
+        });
+        let bytes = encode(&list).expect("encode");
+        let decoded = decode(&bytes).expect("decode");
+        assert_eq!(decoded.term_stats, list.term_stats);
+        // A manifest without the field decodes to None (older writers).
+        let empty_bytes = encode(&empty_list()).expect("encode empty");
+        let s = from_utf8(&empty_bytes).expect("utf8");
+        assert!(
+            !s.contains("term_stats"),
+            "absent ref must not appear on the wire (older manifests stay byte-identical)"
+        );
+        assert!(
+            decode(&empty_bytes)
+                .expect("decode empty")
+                .term_stats
+                .is_none()
+        );
+        // One half without the other is treated as no ref, like the
+        // centroid/graph refs.
+        let with_ref = from_utf8(&bytes).expect("utf8");
+        let uri_only = with_ref.replacen("term_stats_content_hash", "term_stats_ignored", 1);
+        assert!(
+            decode(uri_only.as_bytes())
+                .expect("decode uri-only")
+                .term_stats
+                .is_none()
         );
     }
 

--- a/src/supertable/manifest/list_prune.rs
+++ b/src/supertable/manifest/list_prune.rs
@@ -313,6 +313,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: entries,
         }
     }

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -34,6 +34,7 @@ pub mod options_hash;
 pub mod part;
 pub mod partition;
 pub mod term_range;
+pub mod term_stats;
 
 use std::{
     cmp::Ordering,
@@ -460,6 +461,7 @@ impl ManifestSnapshot {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts,
             tombstone_seqs,
             superseded_cells,
@@ -1225,6 +1227,37 @@ impl ManifestSnapshot {
     /// centroids in `(entry, column, cell)` order) — the stripped-summary
     /// admit rescore hydrates it once instead of fanning per-cell superfile
     /// reads. `None` on manifests written before the sibling existed.
+    /// The manifest's global term-stats sidecar reference, when one is
+    /// stamped and still valid for this membership (the carry rule drops
+    /// it on any superfile removal). See `manifest::term_stats`.
+    pub(crate) fn term_stats_blob(&self) -> Option<&RoutingRef> {
+        self.list.as_ref().and_then(|l| l.term_stats.as_ref())
+    }
+
+    /// Successor manifest (bumped id) with the term-stats sidecar
+    /// reference stamped — the maintenance publish, mirroring
+    /// [`Self::with_slow_vector_state`].
+    pub(crate) fn with_term_stats(&self, reference: RoutingRef) -> Self {
+        let next_id = self.get_next_manifest_id();
+        let new_list = self.list.as_ref().map(|list| {
+            let mut list = list.clone();
+            list.manifest_id = next_id;
+            list.term_stats = Some(reference.clone());
+            list
+        });
+        let mut superfile_list = self.superfile_list.clone();
+        superfile_list.manifest_id = next_id;
+        Self {
+            superfile_list,
+            list: new_list,
+            parts: self.parts.clone(),
+            loader: self.loader.clone(),
+            stamped_partition_strategy: self.stamped_partition_strategy.clone(),
+            stamped_global_vector_index: self.stamped_global_vector_index.clone(),
+            stamped_drained_ranges: self.stamped_drained_ranges.clone(),
+        }
+    }
+
     pub(crate) fn slow_vector_state_centroids_blob(&self) -> Option<&RoutingRef> {
         self.list.as_ref()?.slow_vector_state_centroids.as_ref()
     }
@@ -1964,6 +1997,18 @@ impl ManifestSnapshot {
             slow_vector_state_uri: None,
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
+            // The term-stats sidecar sums gross df over a recorded set of
+            // superfiles. An append leaves that set intact — the new
+            // superfiles are simply uncovered tail the query tops up from
+            // their own dictionaries — so the ref carries forward. A
+            // removal bakes departed superfiles' contributions into a sum
+            // that can no longer be attributed, so the ref drops and only
+            // a fresh maintenance pass republishes it.
+            term_stats: if entries_to_remove.is_empty() {
+                self.list.as_ref().and_then(|l| l.term_stats.clone())
+            } else {
+                None
+            },
             // The `hnsw` graph ref, by contrast, IS carried forward:
             // the graph is a function of which stable doc ids exist, not how
             // they are packed, so it survives a repack. The post-drain /
@@ -4596,6 +4641,7 @@ mod tests {
                 slow_vector_state_content_hash: None,
                 slow_vector_state_centroids: None,
                 slow_vector_state_graphs: None,
+                term_stats: None,
                 parts: entries,
             }
         }
@@ -4902,6 +4948,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![list::ManifestPartEntry {
                 part_id: entry,
                 uri: "manifests/part-x".into(),
@@ -5080,6 +5127,7 @@ mod tests {
                 slow_vector_state_content_hash: None,
                 slow_vector_state_centroids: None,
                 slow_vector_state_graphs: None,
+                term_stats: None,
                 parts: vec![],
             }),
             parts: DashMap::new(),
@@ -5216,6 +5264,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![part_entry(pa_id), part_entry(pb_id)],
         };
         let loader = ManifestPartLoader::new(storage, &list);
@@ -5291,6 +5340,7 @@ mod tests {
             slow_vector_state_content_hash: Some(ContentHash([7u8; 32])),
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: Vec::new(),
         };
         // Storage must be attached: `new` only keeps the list (and builds
@@ -5417,6 +5467,7 @@ mod tests {
             slow_vector_state_content_hash: slow_hash,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri,
@@ -5627,6 +5678,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: part.part_id,
                 uri: part_uri(&full_hash),
@@ -5887,6 +5939,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri,
@@ -6040,6 +6093,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![
                 entry_for(&pw_a_old),
                 entry_for(&pw_a_latest),
@@ -6251,6 +6305,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri,
@@ -6354,6 +6409,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri,
@@ -6484,6 +6540,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri.clone(),
@@ -6604,6 +6661,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![
                 ManifestPartEntry {
                     part_id: pw_old.part_id,
@@ -6740,6 +6798,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![
                 ManifestPartEntry {
                     part_id: pw_a.part_id,
@@ -6886,6 +6945,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![
                 ManifestPartEntry {
                     part_id: pw_a.part_id,
@@ -7046,6 +7106,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![
                 ManifestPartEntry {
                     part_id: pw_a_old.part_id,
@@ -7268,6 +7329,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri,
@@ -7368,6 +7430,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri,
@@ -7484,6 +7547,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![
                 ManifestPartEntry {
                     part_id: pw_a.part_id,
@@ -7623,6 +7687,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![
                 ManifestPartEntry {
                     part_id: pw_a_old.part_id,
@@ -7759,6 +7824,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri,
@@ -7849,6 +7915,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![ManifestPartEntry {
                 part_id: pw.part_id,
                 uri: pw.uri,
@@ -7958,6 +8025,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts: vec![
                 ManifestPartEntry {
                     part_id: pw_a_old.part_id,
@@ -8090,6 +8158,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts,
         }
     }

--- a/src/supertable/manifest/term_stats.rs
+++ b/src/supertable/manifest/term_stats.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Global term-statistics sidecar: gross `df` per (column, term) summed
+//! over a recorded set of superfiles, so a global-stats BM25 query reads
+//! corpus-wide document frequency in one artifact lookup instead of
+//! fanning a dictionary probe over every superfile at query time.
+//!
+//! The artifact is content-addressed (`term-stats/stats-<blake3>.bin`)
+//! and referenced from the manifest list ([`Manifest::term_stats`]);
+//! maintenance (optimize) builds it over the manifest's current
+//! superfiles, appends leave it valid (new superfiles are uncovered
+//! *tail* the query tops up from their own dictionaries), and any commit
+//! that removes superfiles drops the reference — a removed superfile's
+//! contribution is baked into the sums and cannot be attributed, so only
+//! a fresh maintenance pass may republish (see the carry rule in
+//! `ManifestSnapshot::update_inner`).
+//!
+//! Layout: a fixed header (magic, version, covered-superfile ids) then a
+//! standard FST map — the same `column <FST_SEPARATOR> term → u64`
+//! shape as a superfile dictionary, values holding summed gross df.
+//! Gross means tombstoned docs still count until compaction rewrites the
+//! underlying dictionaries — exactly the semantics of the query-time
+//! gather this sidecar replaces (consumers clamp df to `n_docs_total`).
+//!
+//! [`Manifest::term_stats`]: super::list::Manifest::term_stats
+
+use std::{collections::BTreeMap, str::from_utf8, sync::Arc};
+
+use bytes::Bytes;
+use fst::Map;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    storage::{StorageError, StorageProvider},
+    superfile::{
+        SuperfileReader,
+        fts::dict::{DictBuilder, make_key},
+    },
+    supertable::manifest::{RoutingRef, part::ContentHash},
+};
+
+/// Object-store directory prefix for term-stats artifacts, sibling to
+/// the superfile data and slow-vector-state prefixes.
+pub(crate) const STORAGE_PREFIX: &str = "term-stats/";
+
+/// Artifact magic: identifies the file and its major layout family.
+const MAGIC: &[u8; 8] = b"INFTSTA1";
+/// Layout version within the magic family; bump on any layout change.
+const FORMAT_VERSION: u32 = 1;
+/// Header size before the covered-id array: magic + version + count.
+const HEADER_FIXED_LEN: usize = 8 + 4 + 4;
+/// Terms per `term_dfs` batch while building — bounds the coalesced
+/// header-fetch wave and the per-batch scratch.
+const BUILD_DF_BATCH_TERMS: usize = 8_192;
+/// Multipart threshold for the artifact PUT (same figure the
+/// slow-vector-state blob uses; a term-stats FST is far smaller).
+const STATS_MULTIPART_THRESHOLD_BYTES: u64 = 100 * 1024 * 1024;
+
+#[derive(Debug, Error)]
+pub enum TermStatsError {
+    #[error("term-stats storage error: {0}")]
+    Storage(String),
+    #[error("term-stats artifact malformed: {0}")]
+    Malformed(String),
+    #[error("term-stats artifact hash mismatch")]
+    HashMismatch,
+    #[error("term-stats build error: {0}")]
+    Build(String),
+}
+
+/// One decoded term-stats artifact: which superfiles its sums cover,
+/// and the `(column, term) → gross df` map.
+pub(crate) struct TermStatsSidecar {
+    covered: Vec<Uuid>,
+    map: Map<Bytes>,
+}
+
+impl TermStatsSidecar {
+    /// Superfile ids whose dictionaries are summed into this artifact.
+    pub(crate) fn covered(&self) -> &[Uuid] {
+        &self.covered
+    }
+
+    /// Summed gross df for `term` in `column` across the covered set
+    /// (0 when the term appears in none of them).
+    pub(crate) fn df(&self, column: &str, term: &str) -> u64 {
+        self.map.get(make_key(column, term)).unwrap_or(0)
+    }
+
+    /// Decode an artifact, verifying layout only (the content hash is
+    /// checked against the manifest reference by [`load`]).
+    pub(crate) fn decode(bytes: Bytes) -> Result<Self, TermStatsError> {
+        let too_short = || TermStatsError::Malformed("truncated header".into());
+        if bytes.len() < HEADER_FIXED_LEN {
+            return Err(too_short());
+        }
+        if &bytes[..8] != MAGIC {
+            return Err(TermStatsError::Malformed("bad magic".into()));
+        }
+        let version = u32::from_le_bytes(bytes[8..12].try_into().expect("4 bytes"));
+        if version != FORMAT_VERSION {
+            return Err(TermStatsError::Malformed(format!(
+                "unsupported version {version} (expected {FORMAT_VERSION})"
+            )));
+        }
+        let n_covered = u32::from_le_bytes(bytes[12..16].try_into().expect("4 bytes")) as usize;
+        let ids_end = HEADER_FIXED_LEN + n_covered * 16;
+        if bytes.len() < ids_end {
+            return Err(too_short());
+        }
+        let covered: Vec<Uuid> = bytes[HEADER_FIXED_LEN..ids_end]
+            .chunks_exact(16)
+            .map(|c| Uuid::from_bytes(c.try_into().expect("16 bytes")))
+            .collect();
+        let map = Map::new(bytes.slice(ids_end..))
+            .map_err(|e| TermStatsError::Malformed(format!("fst: {e}")))?;
+        Ok(Self { covered, map })
+    }
+}
+
+/// Encode an artifact from sorted `(key, df)` entries (dictionary key
+/// order — [`DictBuilder`] enforces it) and the covered id set.
+fn encode(covered: &[Uuid], entries: &BTreeMap<Vec<u8>, u64>) -> Vec<u8> {
+    let mut dict = DictBuilder::new();
+    for (key, df) in entries {
+        dict.insert(key, *df);
+    }
+    let fst_bytes = dict.finish();
+    let mut out = Vec::with_capacity(HEADER_FIXED_LEN + covered.len() * 16 + fst_bytes.len());
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
+    out.extend_from_slice(&(covered.len() as u32).to_le_bytes());
+    for id in covered {
+        out.extend_from_slice(id.as_bytes());
+    }
+    out.extend_from_slice(&fst_bytes);
+    out
+}
+
+/// Build the artifact bytes over `readers`: for every FTS column of
+/// every superfile, walk its dictionary terms and sum gross df. The df
+/// reads are the batched header probes [`SuperfileReader::term_dfs`]
+/// performs (one dictionary parse + coalesced header fetches per batch)
+/// — no posting bodies are read, which is what makes this a *light*
+/// stats-only pass rather than a compaction.
+pub(crate) async fn build(
+    readers: &[(Uuid, Arc<SuperfileReader>)],
+) -> Result<Vec<u8>, TermStatsError> {
+    let mut merged: BTreeMap<Vec<u8>, u64> = BTreeMap::new();
+    let mut covered: Vec<Uuid> = Vec::with_capacity(readers.len());
+    for (id, reader) in readers {
+        covered.push(*id);
+        let Some(fts) = reader.fts() else { continue };
+        let columns: Vec<String> = fts.fts_columns_config().map(|c| c.name.clone()).collect();
+        for column in &columns {
+            let term_bytes = fts
+                .iter_column_terms(column)
+                .map_err(|e| TermStatsError::Build(format!("term walk: {e}")))?;
+            let terms: Vec<&str> = term_bytes
+                .iter()
+                .map(|t| from_utf8(t).map_err(|_| TermStatsError::Build("non-utf8 term".into())))
+                .collect::<Result<_, _>>()?;
+            for chunk in terms.chunks(BUILD_DF_BATCH_TERMS) {
+                let (dfs, _work) = reader
+                    .term_dfs(column, chunk)
+                    .await
+                    .map_err(|e| TermStatsError::Build(format!("df batch: {e}")))?;
+                for (term, df) in chunk.iter().zip(dfs) {
+                    *merged.entry(make_key(column, term)).or_insert(0) += df;
+                }
+            }
+        }
+    }
+    covered.sort_unstable();
+    Ok(encode(&covered, &merged))
+}
+
+/// Content-address and persist artifact bytes; returns the manifest
+/// reference. Idempotent: an object that already exists under its hash
+/// name is the same bytes.
+pub(crate) async fn write(
+    storage: &dyn StorageProvider,
+    bytes: Vec<u8>,
+) -> Result<RoutingRef, TermStatsError> {
+    let content_hash = ContentHash::of(&bytes);
+    let uri = format!("{STORAGE_PREFIX}stats-{}.bin", content_hash.to_hex());
+    match crate::supertable::writer::put_bytes_multipart_or_atomic(
+        storage,
+        &uri,
+        Bytes::from(bytes),
+        STATS_MULTIPART_THRESHOLD_BYTES,
+    )
+    .await
+    {
+        Ok(()) | Err(StorageError::PreconditionFailed { .. }) => {}
+        Err(e) => return Err(TermStatsError::Storage(e.to_string())),
+    }
+    Ok(RoutingRef { uri, content_hash })
+}
+
+/// Fetch + verify + decode the artifact a manifest references.
+pub(crate) async fn load(
+    storage: &dyn StorageProvider,
+    reference: &RoutingRef,
+) -> Result<TermStatsSidecar, TermStatsError> {
+    let (bytes, _meta) = storage
+        .get(&reference.uri)
+        .await
+        .map_err(|e| TermStatsError::Storage(e.to_string()))?;
+    if ContentHash::of(bytes.as_ref()) != reference.content_hash {
+        return Err(TermStatsError::HashMismatch);
+    }
+    TermStatsSidecar::decode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_covered_ids_and_dfs() {
+        let ids = vec![Uuid::from_u128(7), Uuid::from_u128(3)];
+        let mut entries = BTreeMap::new();
+        entries.insert(make_key("title", "alpha"), 41);
+        entries.insert(make_key("title", "beta"), 1);
+        entries.insert(make_key("body", "alpha"), 9);
+        let bytes = encode(&ids, &entries);
+        let side = TermStatsSidecar::decode(Bytes::from(bytes)).expect("decode");
+        assert_eq!(side.covered(), ids.as_slice());
+        assert_eq!(side.df("title", "alpha"), 41);
+        assert_eq!(side.df("title", "beta"), 1);
+        assert_eq!(side.df("body", "alpha"), 9);
+        assert_eq!(side.df("title", "missing"), 0);
+        assert_eq!(side.df("other", "alpha"), 0);
+    }
+
+    #[test]
+    fn decode_rejects_bad_magic_and_version() {
+        let good = encode(&[], &BTreeMap::new());
+        let mut bad_magic = good.clone();
+        bad_magic[0] ^= 0xFF;
+        assert!(matches!(
+            TermStatsSidecar::decode(Bytes::from(bad_magic)),
+            Err(TermStatsError::Malformed(_))
+        ));
+        let mut bad_version = good;
+        bad_version[8] ^= 0xFF;
+        assert!(matches!(
+            TermStatsSidecar::decode(Bytes::from(bad_version)),
+            Err(TermStatsError::Malformed(_))
+        ));
+        assert!(matches!(
+            TermStatsSidecar::decode(Bytes::from_static(b"short")),
+            Err(TermStatsError::Malformed(_))
+        ));
+    }
+}

--- a/src/supertable/optimize/mod.rs
+++ b/src/supertable/optimize/mod.rs
@@ -33,6 +33,12 @@ impl Supertable {
         self.drain_hidden_vector_cells_sync()
             .map_err(|e| OptimizeError::Build(e.to_string()))?;
         self.compact(&opts.compaction)?;
+        // Refresh the global term-stats sidecar over the post-merge
+        // membership (compaction's removals dropped any prior reference —
+        // see the manifest carry rule). Runs before gc so the sweep's live
+        // set names the fresh artifact.
+        self.refresh_term_stats_sync()
+            .map_err(|e| OptimizeError::Build(e.to_string()))?;
         match self.gc(opts.gc.safety_gap) {
             Ok(_) | Err(GcError::NoStorage) => {}
             Err(e) => return Err(OptimizeError::Gc(e)),

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -1073,7 +1073,7 @@ mod tests {
                 "rust",
                 10,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["_id"]),
             )
             .expect("bm25_search _id");
@@ -1090,14 +1090,7 @@ mod tests {
         let batches = st
             .reader()
             .expect("reader")
-            .bm25_search(
-                "title",
-                "rust",
-                10,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
-                None,
-            )
+            .bm25_search("title", "rust", 10, BoolMode::Or, Bm25Stats::Global, None)
             .expect("bm25_search default");
         let b = &batches[0];
         assert_eq!(b.num_columns(), 2);
@@ -1118,7 +1111,7 @@ mod tests {
                 "rust",
                 10,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["_id", "title", "score"]),
             )
             .expect("bm25_search title");
@@ -1142,7 +1135,7 @@ mod tests {
             "rust",
             10,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             Some(&["nope"]),
         );
         assert!(res.is_err(), "unknown projected column must error");
@@ -1159,7 +1152,7 @@ mod tests {
                 "nonexistentterm",
                 10,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["_id"]),
             )
             .expect("bm25_search empty");
@@ -1677,7 +1670,7 @@ mod tests {
                 "rust",
                 10,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["title", "score"]),
             )
             .expect("cold bm25 with scalar projection");
@@ -1717,7 +1710,7 @@ mod tests {
                 "rust",
                 10,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["_id", "title", "score"]),
             )
             .expect("cold bm25 with id and scalar projection");
@@ -1744,7 +1737,7 @@ mod tests {
                 "nonexistentterm",
                 10,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["title", "score"]),
             )
             .expect("cold bm25 with no matches");

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -377,7 +377,7 @@ impl ExecutionPlan for Bm25Exec {
             let hits = match &query {
                 Bm25Query::Terms { query, mode } => {
                     reader
-                        .bm25_search_async(&column, query, k, *mode, Bm25Stats::PerSuperfile)
+                        .bm25_search_async(&column, query, k, *mode, Bm25Stats::default())
                         .await
                 }
                 Bm25Query::Prefix { prefix } => {

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -152,7 +152,7 @@ impl SupertableReader {
         // Both retrievers run concurrently on the query runtime; each
         // inherits its own manifest skip and returns hits best-first.
         let (bm25_res, vector_res) = future::join(
-            self.bm25_search_async(text_col, q_text, k, mode, Bm25Stats::PerSuperfile),
+            self.bm25_search_async(text_col, q_text, k, mode, Bm25Stats::default()),
             self.vector_search_user_table_async(vec_col, &q_vec, k, options),
         )
         .await;

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -79,7 +79,7 @@
 use std::{
     borrow::Cow,
     cmp::{Ordering, Reverse},
-    collections::{BinaryHeap, HashMap},
+    collections::{BinaryHeap, HashMap, HashSet},
     slice,
     sync::{
         Arc, Mutex, RwLock,
@@ -127,8 +127,8 @@ use crate::{
         fts::{
             bm25,
             reader::{
-                Bm25Stats, ClauseLists, GlobalTermIdf, OR_WINDOW_MIN_TERMS, OrCursorSet,
-                PreparedClauses,
+                Bm25Stats, ClauseLists, FetchedTermMemo, GlobalTermIdf, OR_WINDOW_MIN_TERMS,
+                OrCursorSet, PreparedClauses,
             },
         },
     },
@@ -145,6 +145,12 @@ use crate::{
         tombstones::SidecarCache,
     },
 };
+
+/// Per-superfile open-wave fetches for one global-stats query, keyed by
+/// superfile id — `None` when every scored term came from the idf cache
+/// (or the query is per-superfile), in which case the walk wave fetches
+/// for itself exactly as before.
+type PrefetchMemos = Option<Arc<HashMap<Uuid, Arc<FetchedTermMemo>>>>;
 
 /// Cap on cached (column, term) global-idf entries. Past it the map is
 /// cleared and repopulates from subsequent queries — an epoch reset
@@ -503,16 +509,21 @@ impl SupertableReader {
             return Ok(Vec::new());
         }
 
-        // Under global stats, gather corpus-wide idf per scored term once
-        // (global N from the manifest + df summed across the superfiles
-        // that contain the term), then score every superfile against it
-        // instead of its own per-superfile idf. The scored set is every
+        // Under global stats, corpus-wide idf per scored term comes from an
+        // OPEN WAVE fused with the query's own reads: each kept superfile
+        // fetches its scored terms' dictionary slots and postings ranges —
+        // exactly the reads its walk needs, handed back to it via a memo —
+        // and reports df; superfiles that may contain a scored term but were
+        // pruned from scoring (the AND-shape residual) contribute df through
+        // a dict-only probe in the same wave. Repeat terms skip the wave
+        // entirely via the per-generation idf cache. The scored set is every
         // term that contributes to a score: the bare musts + shoulds, plus
         // each member of a scored (must/should) phrase — a phrase's score
         // is Σ member idf. Negated terms/phrases are pure exclusions, so
-        // their idf never matters and they stay out of the gather.
-        let global_idf: Option<Arc<GlobalTermIdf>> = match stats {
-            Bm25Stats::PerSuperfile => None,
+        // their idf never matters and they stay out of the wave.
+        let (global_idf, prefetch_memos): (Option<Arc<GlobalTermIdf>>, PrefetchMemos) = match stats
+        {
+            Bm25Stats::PerSuperfile => (None, None),
             Bm25Stats::Global => {
                 let mut scored: Vec<String> = Vec::new();
                 let mut add = |t: &String| {
@@ -529,11 +540,13 @@ impl SupertableReader {
                     }
                 }
                 match scored.is_empty() {
-                    true => None,
-                    false => Some(Arc::new(
-                        self.gather_global_term_idf(manifest.as_ref(), column, &scored)
-                            .await?,
-                    )),
+                    true => (None, None),
+                    false => {
+                        let (map, memos) = self
+                            .global_idf_open_wave(manifest.as_ref(), column, &scored, &kept)
+                            .await?;
+                        (Some(Arc::new(map)), memos)
+                    }
                 }
             }
         };
@@ -615,8 +628,14 @@ impl SupertableReader {
             let reader_pool = Arc::clone(&reader_pool);
             let tombstones = tombstones.clone();
             let global_idf = global_idf.clone();
+            let prefetch_memos = prefetch_memos.clone();
             let op_stats = op_stats.clone();
             async move {
+                // This superfile's open-wave fetches (global stats): the
+                // cursor builds below serve the scored terms from the memo
+                // instead of re-reading what the df wave already fetched.
+                let memo: Option<Arc<FetchedTermMemo>> =
+                    prefetch_memos.as_ref().and_then(|m| m.get(&suid)).cloned();
                 // Share the global kth-best floor with every superfile —
                 // single-term queries included — so each prunes its scored
                 // scan against the running top-k instead of returning a full
@@ -652,6 +671,7 @@ impl SupertableReader {
                                         &column_arc,
                                         &should_refs,
                                         global_idf.as_deref(),
+                                        memo.as_deref(),
                                     )
                                     .await
                                     .map_err(fts_read_error)?;
@@ -713,6 +733,7 @@ impl SupertableReader {
                                     should_phrases: &should_ph_arc,
                                     negative_phrases: &neg_ph_arc,
                                     global_idf: global_idf.as_deref(),
+                                    prefetched: memo.as_deref(),
                                 },
                                 k,
                                 floor,
@@ -782,92 +803,127 @@ impl SupertableReader {
         Ok(hits)
     }
 
-    /// Gather global BM25 idf per scored term for [`Bm25Stats::Global`]:
-    /// corpus-wide `N` from the manifest, plus each term's `df` summed
-    /// across the superfiles that contain it (bloom-pruned — a superfile
-    /// absent the term contributes `df = 0`, so the pruned set covers
-    /// every term's postings). The `df` read is `O(1)` per superfile
-    /// from the stored dictionary value.
-    async fn gather_global_term_idf(
+    /// Global BM25 idf per scored term for [`Bm25Stats::Global`], via the
+    /// fused open wave: corpus-wide `N` from the manifest, df per term
+    /// summed across (a) the scoring-kept superfiles — which fetch their
+    /// scored terms' postings ranges here, the very reads their walks
+    /// need, returned to them as per-superfile memos — and (b) the
+    /// presence residual (superfiles that may contain a scored term but
+    /// were pruned from scoring), which contribute df through a
+    /// dict-only probe in the same wave. Terms already cached for this
+    /// manifest generation skip the wave entirely.
+    ///
+    /// Work accounting: memo fetches are NOT flushed here — the walk
+    /// wave's cursors report them, keeping per-query stats equal to the
+    /// per-superfile plan. Residual probes flush here (they have no
+    /// walk), bounded by presence − kept superfiles, dict-only.
+    async fn global_idf_open_wave(
         &self,
         manifest: &ManifestSnapshot,
         column: &str,
         terms: &[String],
-    ) -> Result<GlobalTermIdf, QueryError> {
+        kept: &[Arc<SuperfileEntry>],
+    ) -> Result<(GlobalTermIdf, PrefetchMemos), QueryError> {
         let mut map = GlobalTermIdf::with_capacity(terms.len());
         let global_n = manifest.n_docs_total();
         if terms.is_empty() || global_n == 0 {
-            return Ok(map);
+            return Ok((map, None));
         }
         // Idf is a pure function of the snapshot, so serve repeat terms
-        // from the per-generation cache and fan only over the misses.
+        // from the per-generation cache and run the wave only for misses.
         let manifest_id = manifest.manifest_id;
         let cache = self.global_idf_cache();
         let cached = cache.get(manifest_id, column, terms);
+        for (t, c) in terms.iter().zip(cached.iter()) {
+            if let Some(idf) = c {
+                map.insert(t.clone(), *idf);
+            }
+        }
         let misses: Vec<String> = terms
             .iter()
             .zip(cached.iter())
             .filter(|(_, c)| c.is_none())
             .map(|(t, _)| t.clone())
             .collect();
-        for (t, c) in terms.iter().zip(cached) {
-            if let Some(idf) = c {
-                map.insert(t.clone(), idf);
-            }
-        }
         if misses.is_empty() {
-            return Ok(map);
+            return Ok((map, None));
         }
-        let terms = &misses;
+
+        // Presence prune over the missing terms: every superfile whose
+        // bloom may contain any of them owes a df contribution.
         let prune = PruneLeaf::TermPresence {
             column: column.to_owned(),
-            terms: terms.to_vec(),
+            terms: misses.clone(),
             mode: BoolMode::Or,
         };
-        let kept = select_superfiles(manifest, slice::from_ref(&prune)).await?;
+        let presence = select_superfiles(manifest, slice::from_ref(&prune)).await?;
+        let kept_ids: HashSet<Uuid> = kept.iter().map(|e| e.superfile_id).collect();
         let column_arc = Arc::new(column.to_owned());
-        let terms_arc: Arc<Vec<String>> = Arc::new(terms.to_vec());
-        let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
+        let terms_arc: Arc<Vec<String>> = Arc::new(misses.clone());
+        let units: Vec<(Arc<SuperfileEntry>, (Uuid, bool))> = presence
+            .into_iter()
+            .map(|e| {
+                let suid = e.superfile_id;
+                let full = kept_ids.contains(&suid);
+                (e, (suid, full))
+            })
+            .collect();
         let op_stats = self.op_stats.clone();
-        let per_sf: Vec<Vec<u64>> = dispatch::fanout_with(
+        let per_sf: Vec<(Uuid, Vec<u64>, Option<Arc<FetchedTermMemo>>)> = dispatch::fanout_with(
             self,
             units,
             false,
             true,
-            move |r, _entry, _sidecars, _now, _params: ()| {
+            move |r, _entry, _sidecars, _now, (suid, full): (Uuid, bool)| {
                 let column_arc = Arc::clone(&column_arc);
                 let terms_arc = Arc::clone(&terms_arc);
                 let op_stats = op_stats.clone();
                 async move {
-                    // One FST parse + one coalesced header fetch for all
-                    // scored terms in this superfile, rather than a parse
-                    // and fetch per term.
                     let refs: Vec<&str> = terms_arc.iter().map(String::as_str).collect();
-                    let (dfs, work) = r
-                        .term_dfs(&column_arc, &refs)
-                        .await
-                        .map_err(fts_read_error)?;
-                    // The global-stats pre-pass reads real header ranges;
-                    // it is part of the query's plan and counts like any
-                    // other posting work.
-                    if let Some(stats) = &op_stats {
-                        stats.add_fts_postings_bytes(work.postings_bytes);
-                        stats.add_planned_read_ranges(work.planned_ranges);
-                        stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
+                    if full {
+                        // Scoring superfile: fetch the scored terms outright
+                        // — dictionary + postings ranges, the walk's own
+                        // reads — and hand them back through the memo. The
+                        // walk wave flushes this work when it builds the
+                        // cursors, so nothing is flushed here.
+                        let memo = r
+                            .fetch_scored_terms(&column_arc, &refs)
+                            .await
+                            .map_err(fts_read_error)?;
+                        let dfs: Vec<u64> = refs.iter().map(|t| memo.df(t)).collect();
+                        Ok::<_, QueryError>((suid, dfs, Some(Arc::new(memo))))
+                    } else {
+                        // Residual superfile (contains a scored term, pruned
+                        // from scoring): df only, from the dictionary value
+                        // + header hint — no postings body.
+                        let (dfs, work) = r
+                            .term_dfs(&column_arc, &refs)
+                            .await
+                            .map_err(fts_read_error)?;
+                        if let Some(stats) = &op_stats {
+                            stats.add_fts_postings_bytes(work.postings_bytes);
+                            stats.add_planned_read_ranges(work.planned_ranges);
+                            stats.add_kernel_cpu_ns(work.kernel_cpu_ns);
+                        }
+                        Ok((suid, dfs, None))
                     }
-                    Ok::<Vec<u64>, QueryError>(dfs)
                 }
             },
         )
         .await?;
-        let mut global_df = vec![0u64; terms.len()];
-        for sf in per_sf {
-            for (i, d) in sf.into_iter().enumerate() {
+
+        let mut global_df = vec![0u64; misses.len()];
+        let mut memos: HashMap<Uuid, Arc<FetchedTermMemo>> = HashMap::new();
+        for (suid, dfs, memo) in per_sf {
+            for (i, d) in dfs.into_iter().enumerate() {
                 global_df[i] += d;
             }
+            if let Some(m) = memo {
+                memos.insert(suid, m);
+            }
         }
-        let mut fresh: Vec<(&str, f32)> = Vec::with_capacity(terms.len());
-        for (i, t) in terms.iter().enumerate() {
+        let mut fresh: Vec<(&str, f32)> = Vec::with_capacity(misses.len());
+        for (i, t) in misses.iter().enumerate() {
             // df can't exceed the collection size; clamp so idf's
             // df <= n_docs invariant holds under gross-vs-live counts.
             let df = global_df[i].min(global_n);
@@ -876,7 +932,7 @@ impl SupertableReader {
             fresh.push((t.as_str(), idf));
         }
         cache.insert(manifest_id, column, &fresh);
-        Ok(map)
+        Ok((map, Some(Arc::new(memos))))
     }
 
     /// Prefix-expanded BM25 search across the pinned manifest's

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -54,7 +54,7 @@
 //! drifts as the table fragments. [`Bm25Stats`] selects how a query
 //! handles this:
 //!
-//!  - [`Bm25Stats::PerSuperfile`] (default) scores each superfile
+//!  - [`Bm25Stats::PerSuperfile`] scores each superfile
 //!    against its own local statistics — no extra pass, fastest. For
 //!    `k ≥ 10` and reasonably balanced superfiles the top-k *set* still
 //!    converges to the global answer even if score *order* within the
@@ -1544,8 +1544,23 @@ impl SupertableReader {
         k: usize,
         mode: BoolMode,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
+        self.bm25_hits_stats(column, query, k, mode, Bm25Stats::default())
+    }
+
+    /// [`bm25_hits`](Self::bm25_hits) with an explicit statistics
+    /// scope. Callers that pin mode-specific behavior (the
+    /// per-superfile fan shape, or local-idf scoring parity) select it
+    /// here instead of relying on the crate default.
+    pub fn bm25_hits_stats(
+        &self,
+        column: &str,
+        query: &str,
+        k: usize,
+        mode: BoolMode,
+        stats: Bm25Stats,
+    ) -> Result<Vec<SuperfileHit>, QueryError> {
         let _foreground = ForegroundQueryGuard::enter();
-        self.block_on(self.bm25_search_async(column, query, k, mode, Bm25Stats::PerSuperfile))
+        self.block_on(self.bm25_search_async(column, query, k, mode, stats))
     }
 
     /// Prefix-expanded BM25 search — see [`SupertableReader::bm25_search`]
@@ -2603,7 +2618,7 @@ mod tests {
                 "rust",
                 5,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["title", "does_not_exist"]),
             )
             .expect_err("unknown projection column must error");
@@ -2910,14 +2925,7 @@ mod tests {
 
         // Bare call → `_id` + `score` only (no scalar decode).
         let bare = st
-            .bm25_search(
-                "title",
-                "fox",
-                10,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
-                None,
-            )
+            .bm25_search("title", "fox", 10, BoolMode::Or, Bm25Stats::Global, None)
             .expect("bm25 rows");
         assert_eq!(bare.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
         assert_eq!(bare[0].num_columns(), 2, "_id + score");
@@ -2929,7 +2937,7 @@ mod tests {
                 "fox",
                 10,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["_id", "title", "score"]),
             )
             .expect("bm25 projected rows");

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -849,14 +849,41 @@ impl SupertableReader {
             return Ok((map, None));
         }
 
+        // Maintenance-published corpus stats first: the sidecar sums gross
+        // df over its covered superfiles, so the wave below shrinks to the
+        // uncovered tail (recent commits) — and vanishes entirely on a
+        // table whose maintenance is current, restoring the single fully
+        // overlapped dispatch of the per-superfile plan. A load failure
+        // degrades to the full query-time wave.
+        let sidecar = self.term_stats_sidecar().await;
+        let covered: HashSet<Uuid> = sidecar
+            .as_ref()
+            .map(|s| s.covered().iter().copied().collect())
+            .unwrap_or_default();
+        debug_assert!(
+            {
+                let current: HashSet<Uuid> =
+                    manifest.superfiles.iter().map(|e| e.superfile_id).collect();
+                covered.iter().all(|id| current.contains(id))
+            },
+            "term-stats sidecar covers a removed superfile — the manifest \
+             carry rule must drop the ref on any removal"
+        );
+
         // Presence prune over the missing terms: every superfile whose
-        // bloom may contain any of them owes a df contribution.
+        // bloom may contain any of them owes a df contribution — minus the
+        // sidecar-covered set, whose contribution is already summed.
         let prune = PruneLeaf::TermPresence {
             column: column.to_owned(),
             terms: misses.clone(),
             mode: BoolMode::Or,
         };
-        let presence = select_superfiles(manifest, slice::from_ref(&prune)).await?;
+        let presence: Vec<Arc<SuperfileEntry>> =
+            select_superfiles(manifest, slice::from_ref(&prune))
+                .await?
+                .into_iter()
+                .filter(|e| !covered.contains(&e.superfile_id))
+                .collect();
         let kept_ids: HashSet<Uuid> = kept.iter().map(|e| e.superfile_id).collect();
         let column_arc = Arc::new(column.to_owned());
         let terms_arc: Arc<Vec<String>> = Arc::new(misses.clone());
@@ -924,9 +951,12 @@ impl SupertableReader {
         }
         let mut fresh: Vec<(&str, f32)> = Vec::with_capacity(misses.len());
         for (i, t) in misses.iter().enumerate() {
-            // df can't exceed the collection size; clamp so idf's
-            // df <= n_docs invariant holds under gross-vs-live counts.
-            let df = global_df[i].min(global_n);
+            // Sidecar-covered superfiles' contribution rides the artifact;
+            // the wave above summed only the uncovered tail. df can't
+            // exceed the collection size; clamp so idf's df <= n_docs
+            // invariant holds under gross-vs-live counts.
+            let sidecar_df = sidecar.as_ref().map_or(0, |s| s.df(column, t));
+            let df = (global_df[i] + sidecar_df).min(global_n);
             let idf = bm25::idf(global_n, df);
             map.insert(t.clone(), idf);
             fresh.push((t.as_str(), idf));

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -81,10 +81,7 @@ use std::{
     cmp::{Ordering, Reverse},
     collections::{BinaryHeap, HashMap, HashSet},
     slice,
-    sync::{
-        Arc, Mutex, RwLock,
-        atomic::{self, AtomicU32},
-    },
+    sync::{Arc, Mutex, RwLock},
     time::Instant,
 };
 
@@ -127,8 +124,8 @@ use crate::{
         fts::{
             bm25,
             reader::{
-                Bm25Stats, ClauseLists, FetchedTermMemo, GlobalTermIdf, OR_WINDOW_MIN_TERMS,
-                OrCursorSet, PreparedClauses,
+                Bm25Stats, ClauseLists, FetchedTermMemo, GlobalTermIdf, LiveFloor,
+                OR_WINDOW_MIN_TERMS, OrCursorSet, PreparedClauses,
             },
         },
     },
@@ -326,9 +323,11 @@ struct SharedTopK {
     k: usize,
     /// Min-heap (via `Reverse`) of the best `k` scores seen so far.
     heap: Mutex<BinaryHeap<Reverse<OrdScore>>>,
-    /// f32 bits of the current floor; `NEG_INFINITY` until `k` scores
-    /// have been seen. Monotonically non-decreasing.
-    floor_bits: AtomicU32,
+    /// The current floor — `NEG_INFINITY` until `k` scores have been
+    /// seen, monotone after. Shared with the atom walks as their live
+    /// mid-walk bar (see [`LiveFloor`]), so it rises both from finished
+    /// segments' merges and from running walks' local kth-bests.
+    floor: LiveFloor,
 }
 
 /// Total-order f32 wrapper for the [`SharedTopK`] heap (BM25 scores
@@ -352,13 +351,19 @@ impl SharedTopK {
         Arc::new(Self {
             k,
             heap: Mutex::new(BinaryHeap::new()),
-            floor_bits: AtomicU32::new(f32::NEG_INFINITY.to_bits()),
+            floor: LiveFloor::new(),
         })
     }
 
     /// The current global floor — `NEG_INFINITY` until k scores merged.
     fn floor(&self) -> f32 {
-        f32::from_bits(self.floor_bits.load(atomic::Ordering::Acquire))
+        self.floor.load()
+    }
+
+    /// The floor as the live handle the atom walks read and raise
+    /// mid-walk.
+    fn live_floor(&self) -> &LiveFloor {
+        &self.floor
     }
 
     /// Merge one finished segment's (tombstone-surviving) scores and
@@ -378,10 +383,10 @@ impl SharedTopK {
         if heap.len() == self.k
             && let Some(Reverse(OrdScore(min))) = heap.peek()
         {
-            // The heap min only rises, so a plain store stays monotone
-            // under the lock.
-            self.floor_bits
-                .store(min.to_bits(), atomic::Ordering::Release);
+            // `raise` rather than a plain store: running walks may have
+            // published a higher local kth than this merge's heap min,
+            // and the floor must never move down.
+            self.floor.raise(*min);
         }
     }
 }
@@ -648,6 +653,19 @@ impl SupertableReader {
                 // included — matches an uncoordinated run; only the amount
                 // of skipped work depends on segment completion order.
                 let floor = shared.floor();
+                // The atom walks may also read the floor LIVE mid-walk and
+                // publish their own local kth into it — but a kernel heap
+                // is pre-tombstone-filter, so only a superfile with no
+                // tombstoned rows may participate: its local kth is a
+                // floor the merge (which sees only surviving scores) can
+                // never contradict. The sidecars were warmed by the
+                // dispatcher, so this lookup is an in-memory hit; on a
+                // miss/error the unit just keeps the snapshot floor.
+                let live_floor = match tombstones.as_ref().map(|c| c.bitmap_for(suid, now)) {
+                    Some(Ok(bitmap)) if !bitmap.is_empty() => None,
+                    Some(Err(_)) => None,
+                    _ => Some(shared.live_floor()),
+                };
                 let hits = match range {
                     // Ranged units exist only for pure multi-should
                     // queries (`fanout_for` never slices when a must
@@ -734,6 +752,7 @@ impl SupertableReader {
                                     negative_phrases: &neg_ph_arc,
                                     global_idf: global_idf.as_deref(),
                                     prefetched: memo.as_deref(),
+                                    live_floor,
                                 },
                                 k,
                                 floor,

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -82,7 +82,7 @@ use std::{
     collections::{BinaryHeap, HashMap},
     slice,
     sync::{
-        Arc, Mutex,
+        Arc, Mutex, RwLock,
         atomic::{self, AtomicU32},
     },
     time::Instant,
@@ -145,6 +145,91 @@ use crate::{
         tombstones::SidecarCache,
     },
 };
+
+/// Cap on cached (column, term) global-idf entries. Past it the map is
+/// cleared and repopulates from subsequent queries — an epoch reset
+/// instead of LRU bookkeeping, sized far above any realistic distinct
+/// scored-term working set.
+const GLOBAL_IDF_CACHE_MAX_TERMS: usize = 65_536;
+
+/// Process-lifetime cache of global BM25 idf per `(column, term)`,
+/// valid for exactly one manifest generation.
+///
+/// Global idf is a pure function of the pinned snapshot (corpus-wide
+/// `N` plus the term's summed `df`), so without a cache every query
+/// under [`Bm25Stats::Global`] re-runs the dictionary gather fan over
+/// all unpruned superfiles — measured as a flat ~0.3–1.7 ms added to
+/// every warm query at 10M docs / 256 superfiles. Caching per
+/// generation makes only the first query for a term pay the fan.
+///
+/// One generation at a time: a commit publishes a higher
+/// `manifest_id`, and the first query against the newer snapshot
+/// resets the map. A reader still pinned to an older snapshot bypasses
+/// the cache (never repopulates backwards), so mixed-generation
+/// readers stay correct at the cost of gathering uncached.
+pub(crate) struct GlobalIdfCache {
+    state: RwLock<GlobalIdfCacheState>,
+}
+
+struct GlobalIdfCacheState {
+    manifest_id: u64,
+    idf: HashMap<(Box<str>, Box<str>), f32>,
+}
+
+impl Default for GlobalIdfCache {
+    fn default() -> Self {
+        Self {
+            state: RwLock::new(GlobalIdfCacheState {
+                manifest_id: 0,
+                idf: HashMap::new(),
+            }),
+        }
+    }
+}
+
+impl GlobalIdfCache {
+    /// Cached idf per term under `manifest_id`, `None` per miss. Every
+    /// slot is a miss when the cache tracks a different generation.
+    fn get(&self, manifest_id: u64, column: &str, terms: &[String]) -> Vec<Option<f32>> {
+        let state = self.state.read().expect("global idf cache lock");
+        if state.manifest_id != manifest_id {
+            return vec![None; terms.len()];
+        }
+        terms
+            .iter()
+            .map(|t| {
+                state
+                    .idf
+                    .get(&(Box::from(column), Box::from(t.as_str())))
+                    .copied()
+            })
+            .collect()
+    }
+
+    /// Record gathered idfs under `manifest_id`. A newer generation
+    /// resets the map to it; an older one is dropped (a pinned
+    /// old-snapshot reader must not clobber current-generation
+    /// entries).
+    fn insert(&self, manifest_id: u64, column: &str, entries: &[(&str, f32)]) {
+        let mut state = self.state.write().expect("global idf cache lock");
+        match manifest_id.cmp(&state.manifest_id) {
+            Ordering::Less => return,
+            Ordering::Greater => {
+                state.manifest_id = manifest_id;
+                state.idf.clear();
+            }
+            Ordering::Equal => {}
+        }
+        if state.idf.len() + entries.len() > GLOBAL_IDF_CACHE_MAX_TERMS {
+            state.idf.clear();
+        }
+        for (term, idf) in entries {
+            state
+                .idf
+                .insert((Box::from(column), Box::from(*term)), *idf);
+        }
+    }
+}
 
 /// An unranked query's match set: the terms and exact phrases every
 /// (`And`) or any (`Or`) of which a doc must contain. Produced by
@@ -714,6 +799,26 @@ impl SupertableReader {
         if terms.is_empty() || global_n == 0 {
             return Ok(map);
         }
+        // Idf is a pure function of the snapshot, so serve repeat terms
+        // from the per-generation cache and fan only over the misses.
+        let manifest_id = manifest.manifest_id;
+        let cache = self.global_idf_cache();
+        let cached = cache.get(manifest_id, column, terms);
+        let misses: Vec<String> = terms
+            .iter()
+            .zip(cached.iter())
+            .filter(|(_, c)| c.is_none())
+            .map(|(t, _)| t.clone())
+            .collect();
+        for (t, c) in terms.iter().zip(cached) {
+            if let Some(idf) = c {
+                map.insert(t.clone(), idf);
+            }
+        }
+        if misses.is_empty() {
+            return Ok(map);
+        }
+        let terms = &misses;
         let prune = PruneLeaf::TermPresence {
             column: column.to_owned(),
             terms: terms.to_vec(),
@@ -761,12 +866,16 @@ impl SupertableReader {
                 global_df[i] += d;
             }
         }
+        let mut fresh: Vec<(&str, f32)> = Vec::with_capacity(terms.len());
         for (i, t) in terms.iter().enumerate() {
             // df can't exceed the collection size; clamp so idf's
             // df <= n_docs invariant holds under gross-vs-live counts.
             let df = global_df[i].min(global_n);
-            map.insert(t.clone(), bm25::idf(global_n, df));
+            let idf = bm25::idf(global_n, df);
+            map.insert(t.clone(), idf);
+            fresh.push((t.as_str(), idf));
         }
+        cache.insert(manifest_id, column, &fresh);
         Ok(map)
     }
 
@@ -2120,6 +2229,53 @@ mod tests {
             }
         }
         out
+    }
+
+    /// The per-generation global-idf cache must refresh when a commit
+    /// publishes a new manifest: raising a term's corpus-wide df must
+    /// lower its global idf on the SAME handle whose earlier queries
+    /// populated the cache. A stale cache would keep the old idf and
+    /// this score would not move.
+    #[test]
+    fn global_idf_refreshes_after_commit_raises_df() {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        // Segment 1: "alpha" is rare (1 of 4 uniform-length docs).
+        let seg1 = [
+            "alpha shared red d00",
+            "beta shared red d01",
+            "beta shared green d02",
+            "beta shared green d03",
+        ];
+        {
+            let mut w = st.writer().expect("writer");
+            w.append(&build_batch(0, &seg1)).expect("append seg1");
+            w.commit().expect("commit seg1");
+        }
+        let before = all_scored(&st, "alpha", Bm25Stats::Global);
+        let repeat = all_scored(&st, "alpha", Bm25Stats::Global);
+        assert_eq!(before, repeat, "same snapshot must score identically");
+        let before_top = before[0].1;
+
+        // Segment 2: every doc carries "alpha" — global df rises, so
+        // global idf (and every alpha score) must drop after the commit.
+        let seg2 = [
+            "alpha shared red d10",
+            "alpha shared red d11",
+            "alpha shared green d12",
+            "alpha shared green d13",
+        ];
+        {
+            let mut w = st.writer().expect("writer");
+            w.append(&build_batch(0, &seg2)).expect("append seg2");
+            w.commit().expect("commit seg2");
+        }
+        let after = all_scored(&st, "alpha", Bm25Stats::Global);
+        let after_top = after.iter().map(|(_, s)| *s).fold(f32::MIN, f32::max);
+        assert!(
+            after_top < before_top,
+            "df went 1/4 -> 5/8: global idf must drop \
+             (top before {before_top}, top after {after_top})"
+        );
     }
 
     /// Oracle for `Bm25Stats::Global`: a table split across many

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -89,7 +89,7 @@ use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, LargeStringArray};
 use roaring::RoaringBitmap;
 use tokio::sync::OnceCell;
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 /// Fewest should-terms for which a ranged kernel is shipped to the
@@ -874,20 +874,37 @@ impl SupertableReader {
         // table whose maintenance is current, restoring the single fully
         // overlapped dispatch of the per-superfile plan. A load failure
         // degrades to the full query-time wave.
-        let sidecar = self.term_stats_sidecar().await;
+        // An artifact is only usable while every superfile it covers is
+        // still in this manifest. Its sums are aggregates, so a departed
+        // superfile's contribution cannot be subtracted back out — using
+        // it anyway would over-count df and depress idf for the affected
+        // terms. The manifest carry rule drops the reference on any
+        // commit that removes superfiles, which is what makes a stale
+        // artifact unreachable; this check is the belt to that braces,
+        // and it runs in every build because the failure mode is
+        // silently wrong ranking rather than an error. Rejecting the
+        // artifact costs latency, never correctness: `covered` stays
+        // empty, so the wave below reads df from every superfile's own
+        // dictionary. The set build is O(superfiles), the same order as
+        // the presence prune that follows it.
+        let sidecar = self.term_stats_sidecar().await.filter(|s| {
+            let current: HashSet<Uuid> =
+                manifest.superfiles.iter().map(|e| e.superfile_id).collect();
+            let usable = s.covered().iter().all(|id| current.contains(id));
+            if !usable {
+                warn!(
+                    column,
+                    "term-stats artifact covers a superfile this manifest no longer lists; \
+                     ignoring it and reading document frequency from the superfile \
+                     dictionaries instead"
+                );
+            }
+            usable
+        });
         let covered: HashSet<Uuid> = sidecar
             .as_ref()
             .map(|s| s.covered().iter().copied().collect())
             .unwrap_or_default();
-        debug_assert!(
-            {
-                let current: HashSet<Uuid> =
-                    manifest.superfiles.iter().map(|e| e.superfile_id).collect();
-                covered.iter().all(|id| current.contains(id))
-            },
-            "term-stats sidecar covers a removed superfile — the manifest \
-             carry rule must drop the ref on any removal"
-        );
 
         // Presence prune over the missing terms: every superfile whose
         // bloom may contain any of them owes a df contribution — minus the

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -89,7 +89,7 @@ use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, LargeStringArray};
 use roaring::RoaringBitmap;
 use tokio::sync::OnceCell;
-use tracing::{debug, warn};
+use tracing::debug;
 use uuid::Uuid;
 
 /// Fewest should-terms for which a ranged kernel is shipped to the
@@ -874,33 +874,12 @@ impl SupertableReader {
         // table whose maintenance is current, restoring the single fully
         // overlapped dispatch of the per-superfile plan. A load failure
         // degrades to the full query-time wave.
-        // An artifact is only usable while every superfile it covers is
-        // still in this manifest. Its sums are aggregates, so a departed
-        // superfile's contribution cannot be subtracted back out — using
-        // it anyway would over-count df and depress idf for the affected
-        // terms. The manifest carry rule drops the reference on any
-        // commit that removes superfiles, which is what makes a stale
-        // artifact unreachable; this check is the belt to that braces,
-        // and it runs in every build because the failure mode is
-        // silently wrong ranking rather than an error. Rejecting the
-        // artifact costs latency, never correctness: `covered` stays
-        // empty, so the wave below reads df from every superfile's own
-        // dictionary. The set build is O(superfiles), the same order as
-        // the presence prune that follows it.
-        let sidecar = self.term_stats_sidecar().await.filter(|s| {
-            let current: HashSet<Uuid> =
-                manifest.superfiles.iter().map(|e| e.superfile_id).collect();
-            let usable = s.covered().iter().all(|id| current.contains(id));
-            if !usable {
-                warn!(
-                    column,
-                    "term-stats artifact covers a superfile this manifest no longer lists; \
-                     ignoring it and reading document frequency from the superfile \
-                     dictionaries instead"
-                );
-            }
-            usable
-        });
+        // `term_stats_sidecar` hands back an artifact only when its
+        // covered set is still entirely listed by this manifest — it
+        // verifies that once per generation and caches the verdict, so
+        // a stale artifact reads as absent here and this wave falls
+        // back to every superfile's own dictionary.
+        let sidecar = self.term_stats_sidecar().await;
         let covered: HashSet<Uuid> = sidecar
             .as_ref()
             .map(|s| s.covered().iter().copied().collect())

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -349,6 +349,7 @@ mod tests {
             slow_vector_state_content_hash: None,
             slow_vector_state_centroids: None,
             slow_vector_state_graphs: None,
+            term_stats: None,
             parts,
         }
     }

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -5733,6 +5733,18 @@ impl SupertableReader {
         let mut hidden_hits = hidden_hits?;
         let deleted = deleted?;
         let user_entries = user_entries.map_err(QueryError::ManifestLoad)?;
+        // Temporary diagnostic (remove once the post-compact tail fan is
+        // understood): when the undrained fan fires, print which superfile
+        // birth versions the hidden index's drained ranges fail to cover,
+        // so a run that unexpectedly reads user data names the exact gap.
+        if !user_entries.is_empty() {
+            let births: Vec<u64> = user_entries.iter().map(|e| e.birth_version).collect();
+            eprintln!(
+                "[vector-tail] manifest_id={} tail={} births={births:?} drained={drained:?}",
+                self.manifest().get_manifest_id(),
+                user_entries.len(),
+            );
+        }
 
         // Wave 2 only when the resident user list identifies files newer than
         // the hidden watermark.

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -5733,18 +5733,6 @@ impl SupertableReader {
         let mut hidden_hits = hidden_hits?;
         let deleted = deleted?;
         let user_entries = user_entries.map_err(QueryError::ManifestLoad)?;
-        // Temporary diagnostic (remove once the post-compact tail fan is
-        // understood): when the undrained fan fires, print which superfile
-        // birth versions the hidden index's drained ranges fail to cover,
-        // so a run that unexpectedly reads user data names the exact gap.
-        if !user_entries.is_empty() {
-            let births: Vec<u64> = user_entries.iter().map(|e| e.birth_version).collect();
-            eprintln!(
-                "[vector-tail] manifest_id={} tail={} births={births:?} drained={drained:?}",
-                self.manifest().get_manifest_id(),
-                user_entries.len(),
-            );
-        }
 
         // Wave 2 only when the resident user list identifies files newer than
         // the hidden watermark.

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -10264,14 +10264,7 @@ mod tests {
         // Every doc's title contains "alpha" (see build_simple_batch); a match-all term must
         // surface hits from the one-piece index.
         let hits = st
-            .bm25_search(
-                "title",
-                "alpha",
-                10,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
-                None,
-            )
+            .bm25_search("title", "alpha", 10, BoolMode::Or, Bm25Stats::Global, None)
             .expect("bm25 over one-piece commit");
         let n: usize = hits.iter().map(|b| b.num_rows()).sum();
         assert!(n > 0, "single-shard FTS index must return hits");

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -176,6 +176,7 @@ use crate::{
             },
             options_hash,
             part::{self as part_mod, PartId},
+            term_stats,
         },
         query::{
             dispatch::{open_compaction_input, open_reader},
@@ -8675,6 +8676,93 @@ async fn build_hnsw_graph_ref(
         &data_bundle,
     )
     .await
+}
+
+/// Build and publish the global term-stats sidecar over the CURRENT
+/// membership, stamping its reference on a successor manifest (see
+/// `manifest::term_stats` for artifact semantics and the carry rule).
+/// Maintenance-only: optimize calls it after compaction settles, so the
+/// artifact always describes the post-merge superfile set. Safe to lose
+/// to contention — queries fall back to the fused query-time gather
+/// until the next maintenance pass republishes.
+pub(in crate::supertable) async fn stamp_term_stats(
+    inner: &SupertableInner,
+) -> Result<(), BuildError> {
+    let Some(storage) = inner.options.storage.clone() else {
+        return Ok(());
+    };
+    if inner.options.fts_columns.is_empty() {
+        return Ok(());
+    }
+    let max_retries = inner.options.max_commit_retries.max(1);
+    let mut next_id_floor: u64 = 0;
+    for attempt in 0..max_retries {
+        let old = inner.manifest.load_full();
+        let old = if next_id_floor > 0 {
+            Arc::new(old.with_next_manifest_id_floor(next_id_floor))
+        } else {
+            old
+        };
+        let entries = old.get_all_superfiles();
+        if entries.is_empty() {
+            return Ok(());
+        }
+        // Rebuilt per attempt: a competing commit may have changed the
+        // membership, and the artifact must describe exactly the set the
+        // successor manifest publishes.
+        let store = Arc::clone(&old.options.store);
+        let disk_cache = old.options.disk_cache.as_ref().map(Arc::clone);
+        let opt_storage = old.options.storage.as_ref().map(Arc::clone);
+        let mut readers: Vec<(Uuid, Arc<SuperfileReader>)> = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let reader = open_reader(
+                &store,
+                disk_cache.as_ref(),
+                opt_storage.as_ref(),
+                entry,
+                true,
+            )
+            .await
+            .map_err(|e| BuildError::Store(e.to_string()))?;
+            readers.push((entry.superfile_id, reader));
+        }
+        let bytes = term_stats::build(&readers)
+            .await
+            .map_err(|e| BuildError::Store(e.to_string()))?;
+        let reference = term_stats::write(storage.as_ref(), bytes)
+            .await
+            .map_err(|e| BuildError::Store(e.to_string()))?;
+        if old.term_stats_blob() == Some(&reference) {
+            return Ok(());
+        }
+        let new_manifest = old.with_term_stats(reference);
+        let attempted_id = new_manifest.get_manifest_id();
+        let prev_etag = get_current_manifest_etag(&storage, Arc::clone(&old))
+            .await
+            .inspect_err(|e| inner.note_commit_error(e))
+            .map_err(BuildError::from)?;
+        match new_manifest
+            .write(storage.as_ref(), prev_etag.as_deref(), &[])
+            .await
+        {
+            Ok(()) => {
+                inner.manifest.store(Arc::new(new_manifest));
+                return Ok(());
+            }
+            Err(SupertableCommitError::WriteContentionExhausted) if attempt + 1 < max_retries => {
+                next_id_floor = next_id_floor.max(
+                    refresh_and_orphaned_id_floor(inner, &storage, attempted_id)
+                        .await
+                        .map_err(|e| BuildError::Store(e.to_string()))?,
+                );
+                sleep(backoff_delay(attempt)).await;
+            }
+            Err(e) => return Err(BuildError::Store(e.to_string())),
+        }
+    }
+    Err(BuildError::Store(
+        "term-stats publish lost every commit race".into(),
+    ))
 }
 
 /// Publish/refresh the slow-CAS serving state (Commit B, "settle").

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -8715,12 +8715,19 @@ pub(in crate::supertable) async fn stamp_term_stats(
         let opt_storage = old.options.storage.as_ref().map(Arc::clone);
         let mut readers: Vec<(Uuid, Arc<SuperfileReader>)> = Vec::with_capacity(entries.len());
         for entry in entries {
+            // No background fills: this pass reads dictionaries and df
+            // headers only, and a fill here copies EVERY superfile —
+            // including compaction's fresh multi-GiB outputs — into the
+            // disk cache. On real object storage those fills outlive the
+            // optimize call and their reads bleed into whatever runs
+            // next (they surfaced as phantom user-data GETs in cold
+            // measurements that began while a fill was still draining).
             let reader = open_reader(
                 &store,
                 disk_cache.as_ref(),
                 opt_storage.as_ref(),
                 entry,
-                true,
+                false,
             )
             .await
             .map_err(|e| BuildError::Store(e.to_string()))?;

--- a/tests/catalog_public_api.rs
+++ b/tests/catalog_public_api.rs
@@ -35,7 +35,7 @@ const SEARCH_TOP_K: usize = 10;
 const FIRST_BATCH: &[&str] = &["the quick brown fox", "a lazy sleeping dog"];
 /// Titles committed in the second batch, so maintenance has two
 /// superfiles to compact.
-const SECOND_BATCH: &[&str] = &["a red clever fox", "an old grey wolf"];
+const SECOND_BATCH: &[&str] = &["a red clever fox fox", "an old grey wolf"];
 
 fn vector_field(dim: usize) -> DataType {
     DataType::FixedSizeList(
@@ -142,8 +142,10 @@ fn public_surface_search_maintain_query_and_drop() {
         .expect("vector_search");
     assert_eq!(first_title(&knn), FIRST_BATCH[0]);
 
-    // Hybrid: the text leg pins "fox" rows, the vector leg (row 2's
-    // embedding) ranks the second-batch fox above the first.
+    // Hybrid: the text leg pins "fox" rows — the second-batch fox
+    // carries tf=2 so BM25 ranks it first under corpus-wide (global)
+    // statistics — and the vector leg (row 2's own embedding) agrees,
+    // so the combined ranking puts the second-batch fox on top.
     let hybrid = docs
         .hybrid_search(
             "title",

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -173,7 +173,11 @@ async fn bm25_search_sends_json_and_decodes_arrow() {
             "query": "hello",
             "k": 10,
             "mode": "or",
-            "stats": "per_superfile",
+            // A defaulted request sends the CURRENT default explicitly —
+            // "global" since the stats default flipped — rather than
+            // relying on the server's own default (which stays frozen at
+            // its historical meaning for bare/omitted).
+            "stats": "global",
         })))
         .respond_with(
             ResponseTemplate::new(200).set_body_raw(ipc_bytes(&id_batch(vec![1, 2, 3])), ARROW_CT),

--- a/tests/supertable/commit/pointer_atomic.rs
+++ b/tests/supertable/commit/pointer_atomic.rs
@@ -187,6 +187,7 @@ fn empty_list(manifest_id: u64, parts: Vec<ManifestPartEntry>) -> Manifest {
         slow_vector_state_content_hash: None,
         slow_vector_state_centroids: None,
         slow_vector_state_graphs: None,
+        term_stats: None,
         parts,
     }
 }

--- a/tests/supertable/disk_cache/cold_projection.rs
+++ b/tests/supertable/disk_cache/cold_projection.rs
@@ -181,7 +181,7 @@ async fn cold_bm25_projection_pairs_each_hit_with_its_own_row() {
             "fox",
             TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             Some(&["_id", "title", "rating", "score"]),
         )
         .expect("cold bm25");
@@ -206,7 +206,7 @@ async fn cold_bm25_projection_pairs_each_hit_with_its_own_row() {
             "async wolf",
             TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             Some(&["_id", "title", "rating", "score"]),
         )
         .expect("cold bm25 or");

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -37,7 +37,10 @@ use arrow_array::{LargeStringArray, RecordBatch};
 use infino::{
     superfile::{
         builder::FtsConfig,
-        fts::{reader::BoolMode, tokenize::Tokenizer},
+        fts::{
+            reader::{Bm25Stats, BoolMode},
+            tokenize::Tokenizer,
+        },
     },
     supertable::{Supertable, SupertableOptions, query::SuperfileHit},
     test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer, schema_id_title},
@@ -189,10 +192,24 @@ fn supertable_to_global_ids(
 }
 
 fn supertable_search_global(st: &Supertable, query: &str, k: usize, chunk_size: usize) -> Vec<u64> {
+    supertable_search_stats(st, query, k, chunk_size, Bm25Stats::PerSuperfile)
+}
+
+/// OR-mode supertable search under an explicit statistics scope. The
+/// per-superfile oracles below model local-idf scoring, so tests
+/// comparing against them pin `PerSuperfile`; the whole-corpus oracle
+/// arm compares against `Global`.
+fn supertable_search_stats(
+    st: &Supertable,
+    query: &str,
+    k: usize,
+    chunk_size: usize,
+    stats: Bm25Stats,
+) -> Vec<u64> {
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", query, k, BoolMode::Or)
+        .bm25_hits_stats("title", query, k, BoolMode::Or, stats)
         .expect("supertable bm25");
     supertable_to_global_ids(st, hits, chunk_size)
 }
@@ -206,7 +223,7 @@ fn supertable_search_and_global(
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", query, k, BoolMode::And)
+        .bm25_hits_stats("title", query, k, BoolMode::And, Bm25Stats::PerSuperfile)
         .expect("supertable bm25 AND");
     supertable_to_global_ids(st, hits, chunk_size)
 }
@@ -590,6 +607,9 @@ fn oracle_zipfian_corpus_query_shapes_match() {
     let corp = zipfian_corpus(n_docs, 42);
     let infino = build_supertable(&corp, SUPERFILES);
     let oracles = build_oracles(&corp, SUPERFILES);
+    // One oracle over the WHOLE corpus = textbook BM25 with global idf —
+    // the ground truth for the `Global` (default) statistics scope.
+    let global_oracle = build_oracles(&corp, 1);
     let k = ZIPFIAN_TOP_K;
 
     let queries = [
@@ -604,7 +624,10 @@ fn oracle_zipfian_corpus_query_shapes_match() {
     ];
 
     for (label, q) in queries {
-        let inf = supertable_search_global(&infino, q, k, n_docs / SUPERFILES);
+        // Per-superfile arm: local-idf scoring parity against the
+        // per-shard oracles that model it.
+        let inf =
+            supertable_search_stats(&infino, q, k, n_docs / SUPERFILES, Bm25Stats::PerSuperfile);
         let ora = brute_force_top_k(&oracles, q, k);
         let inf_set: HashSet<u64> = inf.iter().copied().collect();
         let ora_set: HashSet<u64> = ora.iter().copied().collect();
@@ -619,6 +642,25 @@ fn oracle_zipfian_corpus_query_shapes_match() {
             common >= threshold,
             "{label}: top-{k} overlap {common}/{target} below 60% threshold; \
              supertable={inf:?} oracle={ora:?}",
+        );
+
+        // Global arm (the default): table-wide idf against the
+        // whole-corpus textbook oracle. Tighter threshold than the
+        // per-superfile arm — global idf matches the oracle exactly and
+        // this corpus has fixed-length docs, so per-superfile avgdl
+        // equals corpus avgdl; only the one-byte doc-length
+        // quantization and tie order remain.
+        let inf_g = supertable_search_stats(&infino, q, k, n_docs / SUPERFILES, Bm25Stats::Global);
+        let ora_g = brute_force_top_k(&global_oracle, q, k);
+        let inf_g_set: HashSet<u64> = inf_g.iter().copied().collect();
+        let ora_g_set: HashSet<u64> = ora_g.iter().copied().collect();
+        let common_g = inf_g_set.intersection(&ora_g_set).count();
+        let target_g = inf_g_set.len().min(ora_g_set.len());
+        let threshold_g = (target_g * 9) / 10;
+        assert!(
+            common_g >= threshold_g,
+            "{label} (global): top-{k} overlap {common_g}/{target_g} below 90% threshold; \
+             supertable={inf_g:?} oracle={ora_g:?}",
         );
     }
 }

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -29,6 +29,7 @@
 #![deny(clippy::unwrap_used)]
 
 use std::{
+    cmp::Reverse,
     collections::HashSet,
     sync::{Arc, LazyLock},
 };
@@ -819,7 +820,7 @@ fn single_term_global_idf_skip_matches_a_single_superfile() {
     // what makes the equality above unambiguous rather than a tie
     // ordering that happened to agree.
     let mut expected: Vec<(u64, usize)> = SKIP_HOT_DOCS.to_vec();
-    expected.sort_by(|a, b| b.1.cmp(&a.1));
+    expected.sort_by_key(|(_, tf)| Reverse(*tf));
     let expected_ids: Vec<u64> = expected
         .iter()
         .take(SKIP_TOP_K)

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -664,3 +664,195 @@ fn oracle_zipfian_corpus_query_shapes_match() {
         );
     }
 }
+
+// ---- single-term global-idf skip path ------------------------------
+//
+// A lone scored term takes the BlockMaxWAND walk, which prunes against
+// per-block upper bounds that were stored with the superfile's LOCAL
+// idf. Under global statistics the walk scores with the corpus idf
+// instead, so it rescales those bounds by `global_idf / local_idf` —
+// the score is linear in idf, which makes the rescale exact. If it were
+// wrong in either direction the walk would drop documents that belong
+// in the top-k or admit ones that do not, and only a fragmented table
+// shows it: on a single superfile local idf *is* the global idf and the
+// rescale is the identity.
+//
+// The fixture below therefore compares a fragmented table against a
+// single-superfile table holding the same corpus, and is built so the
+// comparison is exact and the rescale is never trivial:
+//
+//   * `common`'s local frequency differs in every superfile (all rows,
+//     an eighth, a half), so no superfile's local idf equals the global
+//     one and every walk rescales by a different ratio.
+//   * every document is the same token length, so per-superfile `avgdl`
+//     is identical across the fragmented layout and equal to the single
+//     superfile's — leaving idf as the only thing layout could change.
+//   * the term's frequency within a handful of documents is distinct
+//     (2..=9 against a baseline of 1), so the head of the ranking is
+//     ordered strictly by score, with no ties to make the comparison
+//     ambiguous, and those documents sit in different superfiles so the
+//     cross-superfile merge is part of what is being checked.
+//   * each superfile holds enough matching rows to span several posting
+//     blocks, so the skip table is genuinely consulted rather than the
+//     whole list being scored anyway.
+
+/// Superfiles in the fragmented arm.
+const SKIP_SUPERFILES: usize = 3;
+/// Rows per superfile — several 128-row posting blocks' worth, so the
+/// BlockMaxWAND skip table is exercised rather than bypassed.
+const SKIP_DOCS_PER_SUPERFILE: usize = 384;
+/// Tokens per document, uniform so `avgdl` is layout-independent.
+const SKIP_DOC_LEN: usize = 12;
+/// Top-k for the skip-path comparison: small enough that the walk's
+/// threshold rises early and prunes most blocks.
+const SKIP_TOP_K: usize = 5;
+/// `(global doc id, term frequency)` for the documents that carry a
+/// distinct `common` frequency; every other matching document has
+/// frequency 1.
+///
+/// Placement is the point of this fixture, not decoration. The walk
+/// skips a posting BLOCK whose stored upper bound cannot beat the
+/// running threshold, so a bound that is too low is only observable
+/// when a wrongly skipped block held a document that belongs in the
+/// top-k. Half of the top-k therefore sits deliberately LATE in its
+/// superfile's posting list — id 300 is in the third of the first
+/// superfile's three blocks, id 1068 in the second of the third
+/// superfile's two — while the rest sit in the first block, which fills
+/// the threshold early and makes those later blocks skippable. An
+/// earlier version of this fixture put every high-frequency document in
+/// the first block and passed even with the rescale removed.
+const SKIP_HOT_DOCS: &[(u64, usize)] = &[
+    // superfile 0 (every row matches, three posting blocks)
+    (300, 9),
+    (200, 6),
+    (10, 4),
+    // superfile 1 (every eighth row matches, one posting block)
+    (704, 7),
+    (392, 3),
+    // superfile 2 (every second row matches, two posting blocks)
+    (1068, 8),
+    (780, 5),
+    (900, 2),
+];
+
+/// The fixture corpus: `SKIP_SUPERFILES` blocks of rows in which
+/// `common` appears in every row, every eighth row, and every second
+/// row respectively.
+fn skip_path_corpus() -> Vec<(u64, String)> {
+    let hot: std::collections::HashMap<u64, usize> = SKIP_HOT_DOCS.iter().copied().collect();
+    let mut corpus = Vec::with_capacity(SKIP_SUPERFILES * SKIP_DOCS_PER_SUPERFILE);
+    for segment in 0..SKIP_SUPERFILES {
+        for row in 0..SKIP_DOCS_PER_SUPERFILE {
+            let id = (segment * SKIP_DOCS_PER_SUPERFILE + row) as u64;
+            let matches = match segment {
+                0 => true,
+                1 => row % 8 == 0,
+                _ => row % 2 == 0,
+            };
+            let tf = match matches {
+                false => 0,
+                true => hot.get(&id).copied().unwrap_or(1),
+            };
+            // `tf` copies of the term, filler to a fixed length, then a
+            // unique token so every row is identifiable.
+            let mut tokens: Vec<String> = std::iter::repeat_n("common".to_string(), tf).collect();
+            tokens.extend(std::iter::repeat_n(
+                "pad".to_string(),
+                SKIP_DOC_LEN - tf - 1,
+            ));
+            tokens.push(format!("d{id:05}"));
+            debug_assert_eq!(tokens.len(), SKIP_DOC_LEN);
+            corpus.push((id, tokens.join(" ")));
+        }
+    }
+    corpus
+}
+
+/// `(global id, score)` for a single-term global-stats search.
+fn skip_path_hits(st: &Supertable, k: usize, chunk_size: usize) -> Vec<(u64, f32)> {
+    let hits = st
+        .reader()
+        .expect("reader")
+        .bm25_hits_stats("title", "common", k, BoolMode::Or, Bm25Stats::Global)
+        .expect("single-term global search");
+    let scores: Vec<f32> = hits.iter().map(|h| h.score).collect();
+    supertable_to_global_ids(st, hits, chunk_size)
+        .into_iter()
+        .zip(scores)
+        .collect()
+}
+
+#[test]
+fn single_term_global_idf_skip_matches_a_single_superfile() {
+    let corpus = skip_path_corpus();
+    let fragmented = build_supertable(&corpus, SKIP_SUPERFILES);
+    let single = build_supertable(&corpus, 1);
+    assert_eq!(
+        fragmented.reader().expect("reader").n_superfiles(),
+        SKIP_SUPERFILES,
+        "fragmented arm must actually be fragmented"
+    );
+    assert_eq!(
+        single.reader().expect("reader").n_superfiles(),
+        1,
+        "single arm must be one superfile"
+    );
+
+    // The rescaled walk over three superfiles must return exactly what
+    // the un-rescaled walk over one superfile returns — same documents,
+    // same scores, same order.
+    let fragmented_top = skip_path_hits(&fragmented, SKIP_TOP_K, SKIP_DOCS_PER_SUPERFILE);
+    let single_top = skip_path_hits(&single, SKIP_TOP_K, corpus.len());
+    assert_eq!(
+        fragmented_top.len(),
+        SKIP_TOP_K,
+        "fixture must fill the top-k"
+    );
+    assert_eq!(
+        fragmented_top, single_top,
+        "the single-term global-idf walk ranked a fragmented table differently from one \
+         superfile holding the same corpus — the rescale of the stored block-max bounds \
+         does not match the idf the walk scores with"
+    );
+
+    // The head is ordered strictly by the planted frequencies, which is
+    // what makes the equality above unambiguous rather than a tie
+    // ordering that happened to agree.
+    let mut expected: Vec<(u64, usize)> = SKIP_HOT_DOCS.to_vec();
+    expected.sort_by(|a, b| b.1.cmp(&a.1));
+    let expected_ids: Vec<u64> = expected
+        .iter()
+        .take(SKIP_TOP_K)
+        .map(|(id, _)| *id)
+        .collect();
+    assert_eq!(
+        fragmented_top.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+        expected_ids,
+        "top-k should be the documents with the highest planted term frequency"
+    );
+    for pair in fragmented_top.windows(2) {
+        assert!(
+            pair[0].1 > pair[1].1,
+            "planted frequencies must give strictly decreasing scores, got {:?}",
+            fragmented_top
+        );
+    }
+
+    // The fixture genuinely distinguishes the two statistics scopes: per
+    // superfile, `common` is in every row of the first superfile, so its
+    // local idf collapses to near zero there and that superfile's rows
+    // rank differently. Were this equal, the comparison above would pass
+    // no matter what the rescale did.
+    let per_superfile = st_hits_per_superfile(&fragmented, SKIP_TOP_K, SKIP_DOCS_PER_SUPERFILE);
+    assert_ne!(
+        per_superfile,
+        fragmented_top.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+        "fixture does not distinguish global from per-superfile statistics, so it cannot \
+         be exercising the global-idf override"
+    );
+}
+
+/// Ids from a per-superfile-statistics search, for the contrast check.
+fn st_hits_per_superfile(st: &Supertable, k: usize, chunk_size: usize) -> Vec<u64> {
+    supertable_search_stats(st, "common", k, chunk_size, Bm25Stats::PerSuperfile)
+}

--- a/tests/supertable/query/fanout_floor.rs
+++ b/tests/supertable/query/fanout_floor.rs
@@ -373,14 +373,7 @@ fn fanout_floor_decomposition() {
         // arithmetic `_id` resolve, no Parquet involvement.
         let (ids_p50, ids_flt) = time_p50(|| {
             let b = reader
-                .bm25_search(
-                    "title",
-                    term,
-                    K,
-                    BoolMode::Or,
-                    Bm25Stats::PerSuperfile,
-                    None,
-                )
+                .bm25_search("title", term, K, BoolMode::Or, Bm25Stats::Global, None)
                 .expect("bm25_search");
             std::hint::black_box(b);
         });
@@ -394,7 +387,7 @@ fn fanout_floor_decomposition() {
                     term,
                     K,
                     BoolMode::Or,
-                    Bm25Stats::PerSuperfile,
+                    Bm25Stats::Global,
                     Some(&["_id", "title", "score"]),
                 )
                 .expect("bm25_search");

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -135,7 +135,7 @@ fn bm25_exact_term_loads_only_the_matching_part() {
             "echo",
             BM25_TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             None,
         )
         .expect("bm25");
@@ -187,7 +187,7 @@ fn bm25_term_in_no_part_loads_nothing() {
             "zoo",
             BM25_TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             None,
         )
         .expect("bm25");
@@ -872,7 +872,7 @@ fn eager_mode_query_paths_observationally_unchanged() {
             "alpha",
             BM25_TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             None,
         )
         .expect("bm25");

--- a/tests/supertable/query/id_resolve.rs
+++ b/tests/supertable/query/id_resolve.rs
@@ -104,14 +104,7 @@ fn bare_projection_ids_match_id_page_read_path() {
     // `common` is in every doc → hits span segments; per-doc unique
     // tokens keep scores distinct so rank order is meaningful.
     let bare = reader
-        .bm25_search(
-            "title",
-            "common",
-            K,
-            BoolMode::Or,
-            Bm25Stats::PerSuperfile,
-            None,
-        )
+        .bm25_search("title", "common", K, BoolMode::Or, Bm25Stats::Global, None)
         .expect("bare search");
     assert_eq!(bare.len(), 1, "single merged batch");
     let bare = &bare[0];
@@ -127,7 +120,7 @@ fn bare_projection_ids_match_id_page_read_path() {
             "common",
             K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             Some(&["_id", "title", "score"]),
         )
         .expect("projected search");
@@ -155,7 +148,7 @@ fn bare_projection_ids_match_id_page_read_path() {
             &probe_token,
             PROBE_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             None,
         )
         .expect("bare unique");
@@ -165,7 +158,7 @@ fn bare_projection_ids_match_id_page_read_path() {
             &probe_token,
             PROBE_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             Some(&["_id", "title", "score"]),
         )
         .expect("projected unique");

--- a/tests/supertable/query/mod.rs
+++ b/tests/supertable/query/mod.rs
@@ -15,4 +15,5 @@ mod query_surface;
 pub mod skip_pruning;
 mod stats_fold;
 mod stored_fields;
+mod term_stats;
 pub mod tombstone_filter;

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -127,7 +127,7 @@ fn scoped_fts_stats(st: &Supertable, query: &str) -> OpStats {
     let (hits, stats) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits("title", query, TOP_K, BoolMode::Or)
+            .bm25_hits_stats("title", query, TOP_K, BoolMode::Or, Bm25Stats::PerSuperfile)
             .expect("bm25")
     });
     assert!(!hits.is_empty(), "fixture query {query:?} must match");
@@ -155,13 +155,25 @@ fn a_scoped_bm25_query_reports_its_planned_ranges() {
     let (_, one_term) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+            .bm25_hits_stats(
+                "title",
+                "rust",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+            )
             .expect("bm25")
     });
     let (_, three_terms) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits("title", "rust async web", TOP_K, BoolMode::Or)
+            .bm25_hits_stats(
+                "title",
+                "rust async web",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+            )
             .expect("bm25")
     });
     assert!(
@@ -191,7 +203,13 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
     let (_, one_term) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+            .bm25_hits_stats(
+                "title",
+                "rust",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+            )
             .expect("bm25")
     });
     // Per superfile: one dictionary fetch + one PFOR posting range.
@@ -203,7 +221,13 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
     let (_, three_terms) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits("title", "rust async web", TOP_K, BoolMode::Or)
+            .bm25_hits_stats(
+                "title",
+                "rust async web",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+            )
             .expect("bm25")
     });
     // Per superfile: one dictionary fetch + three PFOR posting ranges.
@@ -253,7 +277,7 @@ fn a_scoped_bm25_query_reports_kernel_cpu() {
             let query = if i % 2 == 0 { "rust" } else { "rust async web" };
             st.reader()
                 .expect("reader")
-                .bm25_hits("title", query, TOP_K, BoolMode::Or)
+                .bm25_hits_stats("title", query, TOP_K, BoolMode::Or, Bm25Stats::PerSuperfile)
                 .expect("bm25");
         }
     });
@@ -283,7 +307,13 @@ fn a_reader_minted_outside_the_scope_records_nothing() {
     let reader = st.reader().expect("reader");
     let (hits, stats) = with_op_stats(|| {
         reader
-            .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+            .bm25_hits_stats(
+                "title",
+                "rust",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+            )
             .expect("bm25")
     });
     assert!(!hits.is_empty());
@@ -303,13 +333,25 @@ fn an_inline_df1_term_plans_no_posting_range() {
     let (_, base) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+            .bm25_hits_stats(
+                "title",
+                "rust",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+            )
             .expect("bm25")
     });
     let (_, with_inline) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits("title", "rust filler0x0", TOP_K, BoolMode::Or)
+            .bm25_hits_stats(
+                "title",
+                "rust filler0x0",
+                TOP_K,
+                BoolMode::Or,
+                Bm25Stats::PerSuperfile,
+            )
             .expect("bm25")
     });
     assert_eq!(
@@ -425,7 +467,7 @@ fn a_scalar_projection_reports_materialized_rows() {
                 "rust",
                 TOP_K,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 Some(&["title"]),
             )
             .expect("projected search")
@@ -444,7 +486,7 @@ fn a_scalar_projection_reports_materialized_rows() {
                 "rust",
                 TOP_K,
                 BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                Bm25Stats::Global,
                 None,
             )
             .expect("bare search")

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -256,41 +256,54 @@ fn fts_work_stats_repeat_identically_on_the_same_table_state() {
     assert_eq!(first, second, "same plan, same table state, same work");
 }
 
-/// Under `Bm25Stats::Global` the idf gather fans over the superfiles'
-/// term dictionaries — but idf is a pure function of the snapshot, so
-/// only the FIRST query per (generation, column, term) may pay that
-/// fan. A repeat query must plan exactly the per-superfile work, and a
-/// commit (new manifest generation) must bring the fan back once.
-#[test]
-fn global_stats_gather_fans_once_per_manifest_generation() {
-    let st = demo_two_superfiles();
-    let global = |st: &Supertable, q: &str| {
-        let (hits, stats) = with_op_stats(|| {
-            st.reader()
-                .expect("reader")
-                .bm25_hits_stats("title", q, TOP_K, BoolMode::Or, Bm25Stats::Global)
-                .expect("bm25")
-        });
-        assert!(!hits.is_empty(), "fixture query {q:?} must match");
-        stats.planned_read_ranges
-    };
-    let per_superfile = scoped_fts_stats(&st, "rust").planned_read_ranges;
+/// One scoped global-stats BM25 query's planned ranges.
+fn global_ranges(st: &Supertable, q: &str, mode: BoolMode) -> u64 {
+    let (hits, stats) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits_stats("title", q, TOP_K, mode, Bm25Stats::Global)
+            .expect("bm25")
+    });
+    assert!(!hits.is_empty(), "fixture query {q:?} must match");
+    stats.planned_read_ranges
+}
 
-    let first = global(&st, "rust");
-    let repeat = global(&st, "rust");
-    assert!(
-        first > per_superfile,
-        "first global query pays the gather fan on top of the \
-         per-superfile plan ({first} vs {per_superfile})"
+/// One scoped per-superfile BM25 query's planned ranges.
+fn per_superfile_ranges(st: &Supertable, q: &str, mode: BoolMode) -> u64 {
+    let (hits, stats) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits_stats("title", q, TOP_K, mode, Bm25Stats::PerSuperfile)
+            .expect("bm25")
+    });
+    assert!(!hits.is_empty(), "fixture query {q:?} must match");
+    stats.planned_read_ranges
+}
+
+/// Under `Bm25Stats::Global`, an OR query's df gather is FUSED with the
+/// query's own reads: the scoring prune set IS the presence set, so the
+/// open wave fetches exactly the dictionary + postings ranges the walk
+/// needs and df rides along for free. The pinned contract: a global OR
+/// query — first for its terms or cache-served — plans EXACTLY the
+/// per-superfile work, on every manifest generation.
+#[test]
+fn global_stats_or_query_plans_exactly_the_per_superfile_work() {
+    let st = demo_two_superfiles();
+    let per_superfile = per_superfile_ranges(&st, "rust", BoolMode::Or);
+
+    let first = global_ranges(&st, "rust", BoolMode::Or);
+    let repeat = global_ranges(&st, "rust", BoolMode::Or);
+    assert_eq!(
+        first, per_superfile,
+        "fused open wave: the first global OR query plans no extra ranges"
     );
     assert_eq!(
         repeat, per_superfile,
-        "repeat query serves idf from the cache: per-superfile plan only"
+        "cache-served repeat plans the per-superfile work too"
     );
 
-    // A commit publishes a new generation: the gather returns exactly
-    // once, then the repeat is cache-served again. The fixture grows a
-    // third superfile, so per-superfile work is re-measured too.
+    // A new manifest generation re-runs the (still fused) wave once and
+    // re-serves from the cache after — the plan equality holds on both.
     let schema = st.options().schema.clone();
     let mut w = st.writer().expect("writer");
     w.append(&title_batch(&segment_titles(0), schema))
@@ -298,16 +311,54 @@ fn global_stats_gather_fans_once_per_manifest_generation() {
     w.commit().expect("commit seg3");
     drop(w);
 
-    let per_superfile_after = scoped_fts_stats(&st, "rust").planned_read_ranges;
-    let first_after = global(&st, "rust");
-    let repeat_after = global(&st, "rust");
-    assert!(
-        first_after > per_superfile_after,
-        "new generation re-gathers ({first_after} vs {per_superfile_after})"
+    let per_superfile_after = per_superfile_ranges(&st, "rust", BoolMode::Or);
+    assert_eq!(
+        global_ranges(&st, "rust", BoolMode::Or),
+        per_superfile_after,
+        "new generation: fused wave still plans no extra ranges"
     );
     assert_eq!(
-        repeat_after, per_superfile_after,
+        global_ranges(&st, "rust", BoolMode::Or),
+        per_superfile_after,
         "cache re-serves under the new generation"
+    );
+}
+
+/// An AND query's presence set can exceed its scoring prune set: a
+/// superfile containing SOME scored term still owes that term's df even
+/// though scoring skips it. That residual is dict-only — bounded, and
+/// gone on the cache-served repeat.
+#[test]
+fn global_stats_and_residual_is_dict_only_and_cached() {
+    let st = demo_two_superfiles();
+    // `filler0x0` lives only in segment 0's superfiles, `rust` in every
+    // superfile — so the AND prune keeps segment 0 only, while segment
+    // 1's superfiles owe `rust`'s df through the residual probe.
+    let q = "rust filler0x0";
+    let per_superfile = per_superfile_ranges(&st, q, BoolMode::And);
+
+    let first = global_ranges(&st, q, BoolMode::And);
+    let repeat = global_ranges(&st, q, BoolMode::And);
+    assert!(
+        first > per_superfile,
+        "the residual superfiles' df probes plan real ranges \
+         ({first} vs {per_superfile})"
+    );
+    // Residual cost: per residual superfile a dictionary fetch plus one
+    // coalesced header fetch — never a postings-body plan. Bounding by
+    // 2 ranges × residual superfiles pins the dict-only shape.
+    let n_superfiles = st.reader().expect("reader").n_superfiles() as u64;
+    let kept_upper_bound = per_superfile / 2; // ≥ dict + 1 range per kept superfile
+    let residual_superfiles = n_superfiles - kept_upper_bound.max(1);
+    assert!(
+        first - per_superfile <= 2 * residual_superfiles,
+        "residual is dict-only, not a postings re-fetch \
+         (extra {} over {residual_superfiles} residual superfiles)",
+        first - per_superfile
+    );
+    assert_eq!(
+        repeat, per_superfile,
+        "cache-served repeat plans the per-superfile work only"
     );
 }
 

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -256,6 +256,61 @@ fn fts_work_stats_repeat_identically_on_the_same_table_state() {
     assert_eq!(first, second, "same plan, same table state, same work");
 }
 
+/// Under `Bm25Stats::Global` the idf gather fans over the superfiles'
+/// term dictionaries — but idf is a pure function of the snapshot, so
+/// only the FIRST query per (generation, column, term) may pay that
+/// fan. A repeat query must plan exactly the per-superfile work, and a
+/// commit (new manifest generation) must bring the fan back once.
+#[test]
+fn global_stats_gather_fans_once_per_manifest_generation() {
+    let st = demo_two_superfiles();
+    let global = |st: &Supertable, q: &str| {
+        let (hits, stats) = with_op_stats(|| {
+            st.reader()
+                .expect("reader")
+                .bm25_hits_stats("title", q, TOP_K, BoolMode::Or, Bm25Stats::Global)
+                .expect("bm25")
+        });
+        assert!(!hits.is_empty(), "fixture query {q:?} must match");
+        stats.planned_read_ranges
+    };
+    let per_superfile = scoped_fts_stats(&st, "rust").planned_read_ranges;
+
+    let first = global(&st, "rust");
+    let repeat = global(&st, "rust");
+    assert!(
+        first > per_superfile,
+        "first global query pays the gather fan on top of the \
+         per-superfile plan ({first} vs {per_superfile})"
+    );
+    assert_eq!(
+        repeat, per_superfile,
+        "repeat query serves idf from the cache: per-superfile plan only"
+    );
+
+    // A commit publishes a new generation: the gather returns exactly
+    // once, then the repeat is cache-served again. The fixture grows a
+    // third superfile, so per-superfile work is re-measured too.
+    let schema = st.options().schema.clone();
+    let mut w = st.writer().expect("writer");
+    w.append(&title_batch(&segment_titles(0), schema))
+        .expect("append seg3");
+    w.commit().expect("commit seg3");
+    drop(w);
+
+    let per_superfile_after = scoped_fts_stats(&st, "rust").planned_read_ranges;
+    let first_after = global(&st, "rust");
+    let repeat_after = global(&st, "rust");
+    assert!(
+        first_after > per_superfile_after,
+        "new generation re-gathers ({first_after} vs {per_superfile_after})"
+    );
+    assert_eq!(
+        repeat_after, per_superfile_after,
+        "cache re-serves under the new generation"
+    );
+}
+
 #[test]
 #[cfg_attr(
     not(target_os = "linux"),

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -316,11 +316,12 @@ fn bm25_and_mode_skip_requires_all_terms_present_in_superfile() {
 
     let before = store.snapshot();
     let _hits = r
-        .bm25_hits(
+        .bm25_hits_stats(
             "title",
             "alpha beta",
             BM25_TOP_K,
             infino::supertable::query::fts::BoolMode::And,
+            infino::Bm25Stats::PerSuperfile,
         )
         .expect("AND query");
 

--- a/tests/supertable/query/stored_fields.rs
+++ b/tests/supertable/query/stored_fields.rs
@@ -104,14 +104,7 @@ fn index_only_column_searches_but_rejects_projection() {
 
     // Ranked search over the index-only column spans both segments.
     let batches = reader
-        .bm25_search(
-            "body",
-            "signal",
-            K,
-            BoolMode::Or,
-            Bm25Stats::PerSuperfile,
-            None,
-        )
+        .bm25_search("body", "signal", K, BoolMode::Or, Bm25Stats::Global, None)
         .expect("bm25 over index-only column");
     let n: usize = batches.iter().map(RecordBatch::num_rows).sum();
     assert_eq!(n, 2, "one signal doc per segment");
@@ -123,7 +116,7 @@ fn index_only_column_searches_but_rejects_projection() {
             "signal",
             K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             Some(&["_id", "title", "rating", "score"]),
         )
         .expect("stored projection");
@@ -138,7 +131,7 @@ fn index_only_column_searches_but_rejects_projection() {
             "signal",
             K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             Some(&["_id", "body", "score"]),
         )
         .expect_err("index-only column must not be projectable");

--- a/tests/supertable/query/term_stats.rs
+++ b/tests/supertable/query/term_stats.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! Global term-stats sidecar behavior over the public surface: optimize
+//! publishes it, global-stats queries read df from it instead of fanning
+//! the query-time gather, appends compose (sidecar + uncovered tail),
+//! and a maintenance republish reflects membership changes — with
+//! ranking always equal to a never-optimized control table holding the
+//! same content.
+
+#![deny(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use infino::{
+    CompactionSettings, OptimizeOptions,
+    runtime_metrics::op_stats::with_op_stats,
+    superfile::{
+        builder::FtsConfig,
+        fts::reader::{Bm25Stats, BoolMode},
+    },
+    supertable::{Supertable, SupertableOptions, storage::LocalFsStorageProvider},
+};
+use tempfile::TempDir;
+
+/// Docs per committed segment; every scored term keeps df ≥ 2 per
+/// segment so nothing rides the inline (df=1) dictionary slot.
+const DOCS_PER_SEGMENT: usize = 40;
+/// Deterministic 2-shard builds.
+const RAYON_POOL_THREADS: usize = 2;
+/// k large enough that no assertion depends on ranking cutoffs.
+const TOP_K: usize = 128;
+
+/// Optimize settings whose compaction is a NO-OP (fill floor at 100%
+/// keeps every superfile), so `optimize` degenerates to the maintenance
+/// passes — in particular the term-stats refresh — without changing the
+/// superfile layout. That keeps the table genuinely fragmented, which is
+/// the shape where the sidecar earns its keep.
+fn stats_only_optimize() -> OptimizeOptions {
+    OptimizeOptions::compact(CompactionSettings {
+        min_fill_percent: 100,
+        min_superfiles_for_merge: u64::MAX,
+        ..CompactionSettings::default()
+    })
+}
+
+fn schema_title() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![Field::new(
+        "title",
+        DataType::LargeUtf8,
+        false,
+    )]))
+}
+
+fn options_with_storage(dir: &TempDir) -> SupertableOptions {
+    let writer_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(RAYON_POOL_THREADS)
+            .build()
+            .expect("writer pool"),
+    );
+    let storage = Arc::new(LocalFsStorageProvider::new(dir.path()).expect("localfs"));
+    SupertableOptions::new(schema_title(), vec![FtsConfig::new("title")], Vec::new())
+        .expect("valid options")
+        .with_writer_pool(writer_pool)
+        .with_storage(storage)
+}
+
+/// One segment's titles: uniform 4-token docs so per-superfile `avgdl`
+/// is layout-independent and global idf is the only ranking variable.
+/// `alpha` df rises with `segment` so cross-segment df genuinely
+/// matters to the sidecar sums.
+fn segment_titles(segment: usize) -> Vec<String> {
+    (0..DOCS_PER_SEGMENT)
+        .map(|i| {
+            let topic = if i % (segment + 2) == 0 {
+                "alpha"
+            } else {
+                "beta"
+            };
+            let band = ["red", "green"][i % 2];
+            format!("{topic} shared {band} s{segment}d{i:02}")
+        })
+        .collect()
+}
+
+fn commit_segment(st: &Supertable, segment: usize) {
+    let titles = segment_titles(segment);
+    let arr: ArrayRef = Arc::new(LargeStringArray::from(
+        titles.iter().map(String::as_str).collect::<Vec<_>>(),
+    ));
+    let batch = RecordBatch::try_new(schema_title(), vec![arr]).expect("batch");
+    let mut w = st.writer().expect("writer");
+    w.append(&batch).expect("append");
+    w.commit().expect("commit");
+}
+
+/// Ranked `(title, score)` rows for a global-stats BM25 query.
+fn global_hits(st: &Supertable, query: &str, mode: BoolMode) -> Vec<(String, f32)> {
+    let batches = st
+        .reader()
+        .expect("reader")
+        .bm25_search(
+            "title",
+            query,
+            TOP_K,
+            mode,
+            Bm25Stats::Global,
+            Some(&["title", "score"]),
+        )
+        .expect("bm25_search");
+    let mut out = Vec::new();
+    for b in batches {
+        let titles = b
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .expect("title col");
+        let scores = b
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow_array::Float32Array>()
+            .expect("score col");
+        for i in 0..b.num_rows() {
+            out.push((titles.value(i).to_string(), scores.value(i)));
+        }
+    }
+    out
+}
+
+/// Planned read ranges for one scoped BM25 query.
+fn planned_ranges(st: &Supertable, query: &str, mode: BoolMode, stats: Bm25Stats) -> u64 {
+    let (hits, op) = with_op_stats(|| {
+        st.reader()
+            .expect("reader")
+            .bm25_hits_stats("title", query, TOP_K, mode, stats)
+            .expect("bm25")
+    });
+    assert!(!hits.is_empty(), "fixture query {query:?} must match");
+    op.planned_read_ranges
+}
+
+/// The whole lifecycle in one narrative: publish, plan-parity, append
+/// tail, republish — ranking always equal to the never-optimized
+/// control.
+#[test]
+fn sidecar_covers_fragmented_table_and_composes_with_tail() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = Supertable::create(options_with_storage(&dir)).expect("create");
+    let ctrl_dir = TempDir::new().expect("tempdir");
+    let control = Supertable::create(options_with_storage(&ctrl_dir)).expect("create control");
+    for segment in 0..2 {
+        commit_segment(&st, segment);
+        commit_segment(&control, segment);
+    }
+    let n_before = st.reader().expect("reader").n_superfiles();
+    assert!(
+        n_before >= 2,
+        "fixture must stay fragmented; got {n_before}"
+    );
+
+    // Stats-only optimize: same layout, sidecar published.
+    st.optimize(&stats_only_optimize()).expect("optimize");
+    assert_eq!(
+        st.reader().expect("reader").n_superfiles(),
+        n_before,
+        "stats-only optimize must not change the layout"
+    );
+
+    // Ranking parity with the never-optimized control (which computes df
+    // through the query-time gather): the sidecar sums must be exactly
+    // the gather's sums.
+    for (query, mode) in [
+        ("alpha", BoolMode::Or),
+        ("alpha shared", BoolMode::And),
+        ("beta red", BoolMode::Or),
+    ] {
+        assert_eq!(
+            global_hits(&st, query, mode),
+            global_hits(&control, query, mode),
+            "sidecar-served ranking must equal the gather-served control for {query:?}"
+        );
+    }
+
+    // Plan parity: with every superfile covered, a first global query —
+    // AND shapes included, whose gather previously paid a dict-only
+    // residual — plans EXACTLY the per-superfile work. (`red` appears
+    // only in half the docs, so the AND prune and presence set genuinely
+    // differ across shards.)
+    let and_q = "alpha red";
+    let per_superfile = planned_ranges(&st, and_q, BoolMode::And, Bm25Stats::PerSuperfile);
+    assert_eq!(
+        planned_ranges(&st, and_q, BoolMode::And, Bm25Stats::Global),
+        per_superfile,
+        "sidecar-covered global AND query plans the per-superfile work"
+    );
+    let or_q = "beta";
+    let per_superfile_or = planned_ranges(&st, or_q, BoolMode::Or, Bm25Stats::PerSuperfile);
+    assert_eq!(
+        planned_ranges(&st, or_q, BoolMode::Or, Bm25Stats::Global),
+        per_superfile_or,
+        "sidecar-covered global OR query plans the per-superfile work"
+    );
+
+    // Appends carry the sidecar and compose with the uncovered tail:
+    // segment 2 raises `alpha`'s corpus df, so global idf must reflect
+    // sidecar + tail together — again equal to the control's gather.
+    commit_segment(&st, 2);
+    commit_segment(&control, 2);
+    for (query, mode) in [("alpha", BoolMode::Or), ("alpha green", BoolMode::And)] {
+        assert_eq!(
+            global_hits(&st, query, mode),
+            global_hits(&control, query, mode),
+            "sidecar + tail must equal the gather-served control for {query:?}"
+        );
+    }
+
+    // A fresh maintenance pass re-covers the tail; plan parity returns
+    // for a term the earlier queries never cached.
+    st.optimize(&stats_only_optimize()).expect("re-optimize");
+    let fresh_q = "green";
+    let per_superfile_fresh = planned_ranges(&st, fresh_q, BoolMode::Or, Bm25Stats::PerSuperfile);
+    assert_eq!(
+        planned_ranges(&st, fresh_q, BoolMode::Or, Bm25Stats::Global),
+        per_superfile_fresh,
+        "re-covered table plans the per-superfile work on a fresh term"
+    );
+}
+
+/// A merging optimize removes superfiles: the carry rule drops the old
+/// reference inside the membership commit and the maintenance pass
+/// republishes over the merged layout — ranking must stay equal to a
+/// control that never optimized (same corpus, global stats are
+/// layout-independent for uniform-length docs).
+#[test]
+fn merging_optimize_republishes_over_new_membership() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = Supertable::create(options_with_storage(&dir)).expect("create");
+    let ctrl_dir = TempDir::new().expect("tempdir");
+    let control = Supertable::create(options_with_storage(&ctrl_dir)).expect("create control");
+    for segment in 0..3 {
+        commit_segment(&st, segment);
+        commit_segment(&control, segment);
+    }
+    // Publish over the fragmented layout first, then merge for real.
+    st.optimize(&stats_only_optimize()).expect("stats optimize");
+    let merging = OptimizeOptions::compact(CompactionSettings {
+        target_superfile_size_mb: 1,
+        min_fill_percent: 1,
+        // The fixture holds a handful of tiny superfiles; trip the
+        // fragment-count trigger so the merge actually fires.
+        min_superfiles_for_merge: 2,
+        ..CompactionSettings::default()
+    });
+    st.optimize(&merging).expect("merging optimize");
+    assert!(
+        st.reader().expect("reader").n_superfiles()
+            < control.reader().expect("reader").n_superfiles(),
+        "merging optimize must have compacted (st {} vs control {})",
+        st.reader().expect("reader").n_superfiles(),
+        control.reader().expect("reader").n_superfiles()
+    );
+    for (query, mode) in [
+        ("alpha", BoolMode::Or),
+        ("alpha shared", BoolMode::And),
+        ("beta green", BoolMode::Or),
+    ] {
+        assert_eq!(
+            global_hits(&st, query, mode),
+            global_hits(&control, query, mode),
+            "post-merge sidecar ranking must equal the control for {query:?}"
+        );
+    }
+}

--- a/tests/supertable/query/term_stats.rs
+++ b/tests/supertable/query/term_stats.rs
@@ -10,18 +10,23 @@
 
 #![deny(clippy::unwrap_used)]
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use arrow_array::{ArrayRef, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
     CompactionSettings, OptimizeOptions,
     runtime_metrics::op_stats::with_op_stats,
+    storage::StorageProvider,
     superfile::{
         builder::FtsConfig,
         fts::reader::{Bm25Stats, BoolMode},
     },
-    supertable::{Supertable, SupertableOptions, storage::LocalFsStorageProvider},
+    supertable::{
+        Supertable, SupertableOptions,
+        reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore},
+        storage::LocalFsStorageProvider,
+    },
 };
 use tempfile::TempDir;
 
@@ -55,13 +60,17 @@ fn schema_title() -> Arc<Schema> {
 }
 
 fn options_with_storage(dir: &TempDir) -> SupertableOptions {
+    let storage = Arc::new(LocalFsStorageProvider::new(dir.path()).expect("localfs"));
+    options_with_storage_provider(storage)
+}
+
+fn options_with_storage_provider(storage: Arc<dyn StorageProvider>) -> SupertableOptions {
     let writer_pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(RAYON_POOL_THREADS)
             .build()
             .expect("writer pool"),
     );
-    let storage = Arc::new(LocalFsStorageProvider::new(dir.path()).expect("localfs"));
     SupertableOptions::new(schema_title(), vec![FtsConfig::new("title")], Vec::new())
         .expect("valid options")
         .with_writer_pool(writer_pool)
@@ -273,4 +282,116 @@ fn merging_optimize_republishes_over_new_membership() {
             "post-merge sidecar ranking must equal the control for {query:?}"
         );
     }
+}
+
+// ---- maintenance must not warm the disk cache -----------------------
+//
+// The stats pass reads dictionaries and df headers only. Opening the
+// superfiles with background fills enabled would copy EVERY superfile
+// into the attached disk cache — including compaction's fresh multi-GiB
+// outputs — and on real object storage those fills outlive `optimize`
+// and their reads bleed into whatever is measured next. The gate: after
+// a stats-only optimize on a fill-capable cache, the cache holds only
+// the chunks the dictionary walks actually touched, a small fraction of
+// the table.
+
+/// Bytes under a directory tree.
+fn dir_bytes(root: &std::path::Path) -> u64 {
+    let mut total = 0;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(meta) = entry.metadata() else { continue };
+            if meta.is_dir() {
+                stack.push(entry.path());
+            } else {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+/// Docs per segment in the cache-hygiene fixture — enough bytes per
+/// superfile that a whole-file background fill is unmistakably larger
+/// than the dictionary/header chunks the stats pass legitimately reads.
+const CACHE_FIXTURE_DOCS_PER_SEGMENT: usize = 8_000;
+/// Segments in the cache-hygiene fixture.
+const CACHE_FIXTURE_SEGMENTS: usize = 3;
+/// Settle bound for any background fills the maintenance pass spawned.
+const FILL_SETTLE_TIMEOUT: Duration = Duration::from_secs(120);
+/// The stats pass may cache the chunks it reads (dictionaries, df
+/// headers); a fill copies whole superfiles. Half the stored bytes
+/// separates the two regimes with wide margin on both sides.
+const CACHE_BYTES_CEILING_FRACTION: f64 = 0.5;
+
+#[test]
+fn stats_only_optimize_does_not_fill_the_disk_cache() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("localfs"));
+
+    // Produce a fragmented table without any cache attached.
+    let producer =
+        Supertable::create(options_with_storage_provider(Arc::clone(&storage))).expect("create");
+    for segment in 0..CACHE_FIXTURE_SEGMENTS {
+        let titles: Vec<String> = (0..CACHE_FIXTURE_DOCS_PER_SEGMENT)
+            .map(|i| {
+                format!(
+                    "alpha shared s{segment}d{i:05} \
+                     filler{:04} filler{:04} filler{:04} filler{:04}",
+                    i % 977,
+                    (i * 7) % 977,
+                    (i * 31) % 977,
+                    (i * 131) % 977,
+                )
+            })
+            .collect();
+        let arr: ArrayRef = Arc::new(LargeStringArray::from(
+            titles.iter().map(String::as_str).collect::<Vec<_>>(),
+        ));
+        let batch = RecordBatch::try_new(schema_title(), vec![arr]).expect("batch");
+        let mut w = producer.writer().expect("writer");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+    }
+    drop(producer);
+    let stored_bytes = dir_bytes(&dir.path().join("data"));
+    assert!(
+        stored_bytes > 0,
+        "fixture must have persisted superfile bytes"
+    );
+
+    // Consumer with a fill-capable disk cache runs the maintenance.
+    let cache_dir = TempDir::new().expect("cache tempdir");
+    let cfg = DiskCacheConfig {
+        cache_root: cache_dir.path().to_path_buf(),
+        disk_budget_bytes: 4 * stored_bytes,
+        cold_fetch_mode: ColdFetchMode::LazyForegroundWithBackgroundFill,
+        verify_crc_on_open: false,
+        ..Default::default()
+    };
+    let cache = DiskCacheStore::new_unpinned(Arc::clone(&storage), cfg).expect("disk cache");
+    let consumer = Supertable::open(options_with_storage_provider(storage).with_disk_cache(cache))
+        .expect("open consumer");
+    consumer
+        .optimize(&stats_only_optimize())
+        .expect("stats-only optimize");
+    // Settle anything the pass spawned, so a regression cannot hide
+    // behind a fill that is merely still running when we measure.
+    consumer
+        .wait_until_warm(FILL_SETTLE_TIMEOUT)
+        .expect("fills settle");
+
+    let cache_bytes = dir_bytes(cache_dir.path());
+    let ceiling = (stored_bytes as f64 * CACHE_BYTES_CEILING_FRACTION) as u64;
+    assert!(
+        cache_bytes < ceiling,
+        "stats-only optimize warmed the disk cache like a query would: \
+         {cache_bytes} cached bytes vs {stored_bytes} stored (ceiling {ceiling}) — \
+         the maintenance open must not spawn background fills"
+    );
 }

--- a/tests/supertable/query/term_stats.rs
+++ b/tests/supertable/query/term_stats.rs
@@ -14,6 +14,7 @@ use std::{sync::Arc, time::Duration};
 
 use arrow_array::{ArrayRef, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
+use datafusion::prelude::{Expr, col, lit};
 use infino::{
     CompactionSettings, OptimizeOptions,
     runtime_metrics::op_stats::with_op_stats,
@@ -393,5 +394,229 @@ fn stats_only_optimize_does_not_fill_the_disk_cache() {
         "stats-only optimize warmed the disk cache like a query would: \
          {cache_bytes} cached bytes vs {stored_bytes} stored (ceiling {ceiling}) — \
          the maintenance open must not spawn background fills"
+    );
+}
+
+// ---- mutations on a covered table ----------------------------------
+//
+// Deletes and updates never rewrite a superfile's dictionary, so the df
+// a covered superfile contributed to the sidecar stays exactly what it
+// was — "gross" df, unchanged until a compaction rebuilds that
+// dictionary. Both tests below assert the same invariant the append
+// tests do (sidecar-served ranking equals a never-optimized control,
+// which derives df from the query-time gather), because that is what
+// makes the sidecar faithful rather than merely fast. Each then pins
+// the gross semantics themselves, so a future change that quietly made
+// mutations net-of-tombstones would fail here rather than surface as a
+// scoring drift.
+
+/// Titles in `segment` whose topic token is `alpha` — the rows the
+/// mutation tests target, chosen because `alpha` df varies per segment
+/// (see [`segment_titles`]) so its idf genuinely depends on the sums.
+fn alpha_titles(segment: usize) -> Vec<String> {
+    segment_titles(segment)
+        .into_iter()
+        .filter(|t| t.starts_with("alpha "))
+        .collect()
+}
+
+/// The same titles with the topic token rewritten to `gamma`, keeping
+/// the 4-token shape so per-superfile `avgdl` is unchanged and idf stays
+/// the only ranking variable.
+fn gamma_rewrites(titles: &[String]) -> Vec<String> {
+    titles
+        .iter()
+        .map(|t| t.replacen("alpha ", "gamma ", 1))
+        .collect()
+}
+
+fn title_batch(titles: &[String]) -> RecordBatch {
+    let arr: ArrayRef = Arc::new(LargeStringArray::from(
+        titles.iter().map(String::as_str).collect::<Vec<_>>(),
+    ));
+    RecordBatch::try_new(schema_title(), vec![arr]).expect("batch")
+}
+
+fn in_list_predicate(titles: &[String]) -> Expr {
+    col("title").in_list(titles.iter().map(|t| lit(t.as_str())).collect(), false)
+}
+
+/// Segments in the mutation fixtures: enough that the mutated segment is
+/// a minority of the corpus, so a df that wrongly went net would move
+/// scores measurably instead of marginally.
+const MUTATION_SEGMENTS: usize = 3;
+
+/// A delete on a covered table hides its rows but leaves every surviving
+/// document's score untouched: the tombstone removes the row from result
+/// sets while its contribution stays in both the sidecar's df sums and
+/// the table's document count.
+#[test]
+fn delete_on_a_covered_table_leaves_surviving_scores_unchanged() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = Supertable::create(options_with_storage(&dir)).expect("create");
+    let ctrl_dir = TempDir::new().expect("tempdir");
+    let control = Supertable::create(options_with_storage(&ctrl_dir)).expect("create control");
+    for segment in 0..MUTATION_SEGMENTS {
+        commit_segment(&st, segment);
+        commit_segment(&control, segment);
+    }
+    st.optimize(&stats_only_optimize()).expect("optimize");
+
+    // Ranking before the delete, over a shape whose idf depends on
+    // `alpha`'s corpus-wide df.
+    let before = global_hits(&st, "alpha shared", BoolMode::Or);
+    assert!(!before.is_empty(), "fixture query must match");
+
+    // Delete the same rows from both tables.
+    let targets = alpha_titles(0);
+    assert!(
+        !targets.is_empty(),
+        "fixture must have alpha rows to delete"
+    );
+    let deleted = st
+        .delete(in_list_predicate(&targets))
+        .expect("delete on covered table");
+    assert_eq!(deleted.matched(), targets.len());
+    control
+        .delete(in_list_predicate(&targets))
+        .expect("delete on control");
+
+    let after = global_hits(&st, "alpha shared", BoolMode::Or);
+    assert_eq!(
+        after,
+        global_hits(&control, "alpha shared", BoolMode::Or),
+        "sidecar-served ranking must equal the gather-served control after a delete"
+    );
+
+    // The deleted rows are gone from the result set...
+    let target_set: std::collections::HashSet<&String> = targets.iter().collect();
+    for (title, _) in &after {
+        assert!(
+            !target_set.contains(title),
+            "deleted row {title:?} resurfaced"
+        );
+    }
+    // ...and every survivor keeps the exact score it had before, which is
+    // only true while df and the document count both stay gross. A df
+    // that dropped with the tombstones would raise idf and move all of
+    // these.
+    assert!(
+        !after.is_empty() && after.len() < before.len(),
+        "delete must have removed some rows and left others to compare ({} then {})",
+        before.len(),
+        after.len()
+    );
+    for row in &after {
+        assert!(
+            before.contains(row),
+            "surviving row {:?} changed score after the delete ({:?} not in the pre-delete \
+             ranking) — df or the document count went net-of-tombstones",
+            row.0,
+            row
+        );
+    }
+}
+
+/// An update is a delete plus an insert, so on a covered table the
+/// superseded row's df stays in the sidecar's sums (its dictionary is
+/// untouched) while the replacement row's df arrives through the
+/// uncovered tail — the term is counted in both, and the gather-served
+/// control agrees exactly. A merging optimize is what finally rewrites
+/// those dictionaries and converges the table onto net statistics.
+#[test]
+fn update_on_a_covered_table_counts_superseded_and_replacement_rows() {
+    let dir = TempDir::new().expect("tempdir");
+    let st = Supertable::create(options_with_storage(&dir)).expect("create");
+    let ctrl_dir = TempDir::new().expect("tempdir");
+    let control = Supertable::create(options_with_storage(&ctrl_dir)).expect("create control");
+    for segment in 0..MUTATION_SEGMENTS {
+        commit_segment(&st, segment);
+        commit_segment(&control, segment);
+    }
+    st.optimize(&stats_only_optimize()).expect("optimize");
+
+    // Rewrite segment 0's `alpha` rows to `gamma`: afterwards `alpha`
+    // survives only in the later segments and `gamma` exists only in the
+    // tail, so both directions of the sum are exercised.
+    let targets = alpha_titles(0);
+    let replacements = gamma_rewrites(&targets);
+    let new_rows = title_batch(&replacements);
+    let updated = st
+        .update(in_list_predicate(&targets), &new_rows)
+        .expect("update on covered table");
+    assert_eq!(updated.matched(), targets.len());
+    control
+        .update(in_list_predicate(&targets), &new_rows)
+        .expect("update on control");
+
+    // Sidecar (covered segments) + tail (the replacement rows) must sum
+    // to exactly what the control's gather computes, for a term left
+    // only in the covered part, a term living only in the tail, and a
+    // term spanning both.
+    for (query, mode) in [
+        ("alpha", BoolMode::Or),
+        ("gamma", BoolMode::Or),
+        ("shared", BoolMode::Or),
+        ("gamma shared", BoolMode::And),
+    ] {
+        assert_eq!(
+            global_hits(&st, query, mode),
+            global_hits(&control, query, mode),
+            "sidecar + tail must equal the gather-served control for {query:?} after an update"
+        );
+    }
+
+    // The superseded rows are invisible to results even though their
+    // statistics remain.
+    let target_set: std::collections::HashSet<&String> = targets.iter().collect();
+    for (title, _) in global_hits(&st, "alpha shared", BoolMode::Or) {
+        assert!(
+            !target_set.contains(&title),
+            "superseded row {title:?} resurfaced after the update"
+        );
+    }
+
+    // Gross, not net: a table built from scratch with the post-update
+    // content holds neither the superseded rows' df nor their document
+    // count, so its idf — and therefore its scores — differ. This is the
+    // intended semantics (matching the query-time gather, and matching
+    // how deletes behave until compaction), so it is pinned rather than
+    // left to drift.
+    let fresh_dir = TempDir::new().expect("tempdir");
+    let fresh = Supertable::create(options_with_storage(&fresh_dir)).expect("create fresh");
+    for segment in 0..MUTATION_SEGMENTS {
+        let titles: Vec<String> = match segment {
+            0 => segment_titles(0)
+                .into_iter()
+                .map(|t| t.replacen("alpha ", "gamma ", 1))
+                .collect(),
+            other => segment_titles(other),
+        };
+        let mut w = fresh.writer().expect("writer");
+        w.append(&title_batch(&titles)).expect("append");
+        w.commit().expect("commit");
+    }
+    let mutated_scores: Vec<f32> = global_hits(&st, "gamma", BoolMode::Or)
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect();
+    let fresh_scores: Vec<f32> = global_hits(&fresh, "gamma", BoolMode::Or)
+        .into_iter()
+        .map(|(_, s)| s)
+        .collect();
+    assert_eq!(
+        mutated_scores.len(),
+        fresh_scores.len(),
+        "both tables must return the same `gamma` rows, so the comparison below is about \
+         scores rather than result-set size"
+    );
+    assert!(
+        !mutated_scores.is_empty(),
+        "fixture must return replacement rows to compare"
+    );
+    assert_ne!(
+        mutated_scores, fresh_scores,
+        "an updated table scored identically to a from-scratch rebuild — the superseded \
+         rows' statistics were dropped before compaction rewrote their dictionaries"
     );
 }

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -34,7 +34,10 @@ use infino::{
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
         builder::FtsConfig,
-        fts::{reader::BoolMode, tokenize::Tokenizer},
+        fts::{
+            reader::{Bm25Stats, BoolMode},
+            tokenize::Tokenizer,
+        },
     },
     supertable::{
         Supertable, SupertableOptions,
@@ -706,5 +709,136 @@ async fn vector_query_backfills_across_superfiles_after_deletes() {
             !deleted_set.contains(title),
             "a tombstoned row ({title}) resurfaced after delete"
         );
+    }
+}
+
+// ---- tombstones and the fan-out's shared score floor ---------------
+//
+// The fan-out shares a top-k floor across superfile kernels, and the
+// phrase (atom) walks both prune against it live and publish their
+// local kth-best into it. A kernel's heap is filtered for tombstones
+// only AFTER the kernel returns — so a superfile whose top phrase docs
+// are all deleted holds a local kth that overstates anything a reader
+// may return, and letting it publish would prune the true survivors in
+// every other superfile. The gate under test: a superfile with any
+// tombstoned row never publishes into the live floor.
+
+/// Phrase repeats in one high-tf title: enough anchors that the doomed
+/// segment's scores tower over every surviving doc's single anchor.
+const DOOMED_PHRASE_REPEATS: usize = 6;
+/// Surviving phrase docs — more than [`FLOOR_TOP_K`], so the expected
+/// result set is full-k even with the doomed segment gone.
+const SURVIVOR_PHRASE_DOCS: usize = 8;
+/// Top-k for the floor-soundness phrase query.
+const FLOOR_TOP_K: usize = 5;
+/// Query repetitions: the unsound publish is a race (the doomed
+/// segment's walk must finish before a survivor's), so the assertion
+/// loops enough times that a regression cannot hide behind scheduling.
+const FLOOR_QUERY_ITERS: usize = 30;
+
+/// Deleting every high-scoring phrase doc in one superfile must not
+/// depress other superfiles' results through the shared floor — under
+/// either BM25 stats mode.
+#[test]
+fn tombstoned_superfile_does_not_raise_the_shared_phrase_floor() {
+    let dir = TempDir::new().expect("tempdir");
+    let storage: Arc<dyn StorageProvider> =
+        Arc::new(LocalFsStorageProvider::new(dir.path()).expect("localfs"));
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "title",
+        DataType::LargeUtf8,
+        false,
+    )]));
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(RAYON_POOL_THREADS)
+            .build()
+            .expect("pool"),
+    );
+    let opts = SupertableOptions::new(
+        Arc::clone(&schema),
+        vec![FtsConfig::new("title").positions(true)],
+        vec![],
+    )
+    .expect("options")
+    .with_writer_pool(pool)
+    .with_storage(storage);
+    let st = Supertable::create(opts).expect("create");
+
+    // Segment A (doomed): identical titles stacking the phrase, so its
+    // kernel-local top-k dwarfs every survivor score AND one predicate
+    // deletes the whole segment.
+    let doomed_title = ["alpha beta"; DOOMED_PHRASE_REPEATS].join(" ");
+    let doomed: Vec<&str> = vec![doomed_title.as_str(); FLOOR_TOP_K];
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(LargeStringArray::from(doomed)) as ArrayRef],
+    )
+    .expect("doomed batch");
+    let mut w = st.writer().expect("writer");
+    w.append(&batch).expect("append doomed");
+    w.commit().expect("commit doomed");
+
+    // Segment B (survivors): the phrase once per doc, distinct tails.
+    let survivor_titles: Vec<String> = (0..SURVIVOR_PHRASE_DOCS)
+        .map(|i| format!("alpha beta tail{i:02}"))
+        .collect();
+    let survivors: Vec<&str> = survivor_titles.iter().map(String::as_str).collect();
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(LargeStringArray::from(survivors)) as ArrayRef],
+    )
+    .expect("survivor batch");
+    w.append(&batch).expect("append survivors");
+    w.commit().expect("commit survivors");
+
+    let pending = w
+        .delete(col("title").eq(lit(doomed_title.as_str())))
+        .expect("delete doomed segment");
+    assert_eq!(pending.matched, FLOOR_TOP_K);
+    w.commit().expect("commit delete");
+    drop(w);
+
+    for stats in [Bm25Stats::Global, Bm25Stats::PerSuperfile] {
+        for _ in 0..FLOOR_QUERY_ITERS {
+            let batches = st
+                .reader()
+                .expect("reader")
+                .bm25_search(
+                    "title",
+                    "\"alpha beta\"",
+                    FLOOR_TOP_K,
+                    BoolMode::Or,
+                    stats,
+                    Some(&["title"]),
+                )
+                .expect("phrase search");
+            let titles: Vec<String> = batches
+                .iter()
+                .flat_map(|b| {
+                    let arr = b
+                        .column(0)
+                        .as_any()
+                        .downcast_ref::<LargeStringArray>()
+                        .expect("title column");
+                    (0..b.num_rows())
+                        .map(|i| arr.value(i).to_string())
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            assert_eq!(
+                titles.len(),
+                FLOOR_TOP_K,
+                "phrase top-k underflowed ({stats:?}): a tombstoned segment's \
+                 kernel scores leaked into the shared floor and pruned the \
+                 surviving docs"
+            );
+            for t in &titles {
+                assert_ne!(
+                    t, &doomed_title,
+                    "a tombstoned row resurfaced in the phrase top-k ({stats:?})"
+                );
+            }
+        }
     }
 }

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -287,14 +287,7 @@ fn run_bm25_queries(st: &Supertable) -> Vec<Vec<i128>> {
         .iter()
         .map(|q| {
             let batches = reader
-                .bm25_search(
-                    "title",
-                    q,
-                    BM25_K,
-                    BoolMode::Or,
-                    Bm25Stats::PerSuperfile,
-                    None,
-                )
+                .bm25_search("title", q, BM25_K, BoolMode::Or, Bm25Stats::Global, None)
                 .unwrap_or_else(|e| panic!("bm25_search({q:?}) failed: {e}"));
             extract_sorted_ids(&batches)
         })

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -507,7 +507,7 @@ async fn supertable_real_azure_round_trip() {
                 "alpha",
                 10,
                 infino::superfile::fts::reader::BoolMode::Or,
-                infino::Bm25Stats::PerSuperfile,
+                infino::Bm25Stats::Global,
                 None,
             )
             .map_err(|e| format!("cold BM25 over real Azure: {e}"))?;

--- a/tests/supertable/storage/smoke_gcs.rs
+++ b/tests/supertable/storage/smoke_gcs.rs
@@ -191,14 +191,7 @@ async fn supertable_real_gcs_round_trip() {
     let bm25 = consumer
         .reader()
         .expect("reader")
-        .bm25_search(
-            "title",
-            "alpha",
-            10,
-            BoolMode::Or,
-            Bm25Stats::PerSuperfile,
-            None,
-        )
+        .bm25_search("title", "alpha", 10, BoolMode::Or, Bm25Stats::Global, None)
         .expect("bm25 over real gcs");
     assert!(!bm25.is_empty(), "cold BM25 must find the alpha docs");
 

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -246,7 +246,7 @@ async fn supertable_real_s3_lazy_vector_and_fts_round_trip() {
                 "alpha",
                 10,
                 infino::superfile::fts::reader::BoolMode::Or,
-                infino::Bm25Stats::PerSuperfile,
+                infino::Bm25Stats::Global,
                 None,
             )
             .map_err(|e| format!("cold BM25 over real S3: {e}"))?;

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -189,7 +189,7 @@ async fn writer_delete_tombstones_matching_rows() {
             "bravo",
             FTS_TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             None,
         )
         .expect("fts");
@@ -272,7 +272,7 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
             "bravo",
             FTS_TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             None,
         )
         .expect("pre-delete fts")
@@ -301,7 +301,7 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
             "bravo",
             FTS_TOP_K,
             BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            Bm25Stats::Global,
             None,
         )
         .expect("post-delete fts")


### PR DESCRIPTION
## Problem

BM25 idf needs each term's document frequency across the whole table. With per-superfile statistics — the current default — each superfile computes idf from its own df, so a fragmented table ranks with as many score scales as it has superfiles and merges them into one top-k. A document's rank then depends on which superfile its commit landed in. On the 10M-doc realistic-corpus quality bench (textbook-BM25 oracle, 18 query shapes × k ∈ {10, 100, 1000}), per-superfile stats collapse on any shape whose df varies across superfiles:

| shape (k=10) | recall, global stats | recall, per-superfile stats |
|---|---|---|
| stopword | 0.90 | 0.00 |
| common | 1.00 | 0.10 |
| three_stopword_or | 0.80 | 0.10 |
| mid | 1.00 | 0.50 |
| rare | 1.00 | 0.60 |

## Solution

`Bm25Stats` defaults to `Global`: every superfile scores with one corpus-wide idf, so scores are comparable by construction. Average document length stays per-superfile — it is baked into each superfile's norm tables, and it is not what breaks comparability; idf is.

Global idf is never stored. Each query computes it from the manifest snapshot it reads: N from the manifest, df per term through three tiers, cheapest first:

- **Idf cache.** The table handle caches idf per (column, term), keyed by manifest generation. A commit changes the generation, so stale entries simply stop matching. No invalidation logic.
- **Term-stats sidecar.** `optimize` writes one small content-addressed artifact per table (`term-stats/stats-<hash>.bin`, an FST of `(column, term) → df` summed over a recorded superfile set; ~4 MiB at 10M docs). A query reads corpus df in one lookup instead of asking every superfile. Appends keep it valid — new superfiles are a small tail the query tops up from their own dictionaries. Removing superfiles (compaction) drops the reference; the next `optimize` rebuilds it. Versioned, GC-integrated, and a failed load falls back to reading dictionaries.
- **Fused gather.** When df must come from superfile dictionaries (no sidecar yet, or the tail), the reads fold into the reads the query already does: each superfile kept for scoring looks up its terms and fetches their postings once, reports df, and reuses those same bytes for scoring. Pruned-but-present superfiles answer with a dictionary lookup only. A global-stats query issues the same reads as a per-superfile query.

Scoring keeps all of its pruning: stored block-max bounds bake in local idf, the score is linear in idf, so multiplying every bound by `global_idf / local_idf` keeps them exact — block skipping, phrase bounds, and the single-term fast path prune as tightly as before. Since scores are now on one scale, superfiles also share their running kth-best live during the search (published only from superfiles with no tombstoned rows, since kernel heaps precede tombstone filtering), so each walk skips work the others have ruled out.

Compatibility:
- Query-time change only; nothing on disk changes for existing tables. Old manifests read byte-identically; the sidecar appears after the next `optimize` (older readers ignore the field).
- Match sets are unchanged — only result *ordering* changes, and only on multi-superfile tables with df skew. `Bm25Stats::PerSuperfile` stays available and is bit-identical to before.
- Three surfaces that had `PerSuperfile` hardwired now follow the default: the SQL `bm25_search` table function, the BM25 leg of `hybrid_search`, and the internal `bm25_hits` kernel. Bindings treat an omitted `stats` as "engine default"; explicit values behave as before.
- Deleted docs keep counting toward df until compaction rewrites dictionaries — the same semantics as before, and as Lucene.

## Quality improvement

10M-doc realistic corpus, 18 shapes × 3 k, graded against the streaming textbook-BM25 oracle:

| | global (this PR's default) | per-superfile (old default) |
|---|---|---|
| mean recall @10 / @100 / @1000 | **0.90 / 0.96 / 0.97** | 0.62 / 0.76 / 0.82 |
| worst shape | **0.80** | 0.00 |
| cells won or tied (of 54) | **52** | — |

A single-superfile or fully compacted table produces identical results under both modes.

## Performance (no regression)

The authority is the CI A/B: both arms build on one VM and run the full battery at 1M docs on the realistic corpus. **Merge gate: PASS — 0 blocking, 0 informational regressions** at the gate's >50%-and->5ms bar. Warm p90, main vs this branch, representative rows:

| Query | main | branch | Δ |
|---|---:|---:|---:|
| single_rare | 310 µs | 195 µs | −37% |
| single_common | 173 µs | 193 µs | +12% |
| ten_term_or | 3.63 ms | 3.23 ms | −11% |
| forty_term_or | 12.30 ms | 12.08 ms | −2% |
| ten_term_and | 1.73 ms | 2.41 ms | +39% |
| must_common_should_common | 677 µs | 698 µs | +3% |
| phrase_two_common | 40.69 ms | 34.07 ms | −16% |
| phrase_two_mixed | 852 µs | 754 µs | −12% |
| phrase_three_common | 38.33 ms | 42.02 ms | +10% |
| phrase_plus_must_term | 43.23 ms | 43.86 ms | +1% |

Read those as a band, not as precision: the same shape swings by tens of percent between runs of identical code on this VM class, which is why the gate requires a regression to clear both 50% and 5 ms before it blocks, and why nothing here approaches it (`ten_term_and`, the widest mover, is a 0.7 ms absolute change). The steadier signal is the aggregate CPU counters, which average many shapes per row: OR search 2.58M → 2.53M cycles, AND search 6.49M → 6.28M, phrase search 227.0k → 227.8k.

Cold adds one fixed cost, and it is the honest price of corpus-wide statistics: a fresh cache fetches the term-statistics artifact once, which the CI cold leg measures as **+3.6 MiB and +1–2 GETs, near-constant across the battery** (for example `three_similar_or` 8.26 → 11.88 MiB, `phrase_three_common` 46.18 → 50.31 MiB). It is paid per cache, not per query, so it amortizes over every query that cache serves — and it replaces a document-frequency gather that would otherwise probe all 75 superfiles' dictionaries. Per-superfile statistics pay neither, because they never compute a corpus-wide figure at all; that is the trade this change makes. Cold latency is reported per shape but not gated, and at one fresh-cache iteration per shape it is a single sample: the CI cold leg is green with no blocking movers.

Warm is where a served workload lives, and there the artifact is already resident: the warm battery measured −3.6% at 10M docs on a maintained table, with the read plan for a covered query identical to the per-superfile plan. A table whose maintenance has not run yet pays a one-time dictionary gather per (term, generation) instead, which the idf cache then retires.

The maintenance itself is a stats-only pass inside `optimize` (dictionary walks and batched header probes — no posting bodies): ~2 minutes at 1M realistic docs on the bench VM, producing the ~4 MiB artifact.

## Testing

- **Oracles**: the zipfian brute-force test has two arms — per-shard oracles vs explicit `PerSuperfile` (unchanged semantics) and a whole-corpus oracle vs `Global` at a 90% recall floor. The 10M quality harness (18 shapes × 3 k) is within gates on both CI arms.
- **Sidecar lifecycle**: on a covered fragmented table, global OR and AND queries plan exactly the per-superfile read ranges (first query included); ranking equals a never-optimized control through publish → tail appends → republish → merging optimize; round-trip and malformed-artifact decode tests.
- **Plan accounting**: op-stats tests pin that the gather fans once per manifest generation and that global plans equal per-superfile plans on covered tables.
- **Live floor soundness**: a regression test deletes every high-scoring phrase doc in one superfile and asserts the survivors still fill the top-k — it fails if a tombstoned superfile is ever allowed to publish into the shared floor.
- **Maintenance cache hygiene**: an intermittent vector-lane failure traced (via per-request read traces on parallel CI dispatches) to the stats pass opening superfiles with background cache fills enabled — whole-table fills outlived `optimize` on real object storage and bled into the next measurement. Fixed (the pass opens readers without fills) and pinned by a regression test that fails if a stats-only optimize ever warms the disk cache like a query would.
- Full suites green (lib 2411, supertable 340+, superfile 190; clippy, fmt); CI: both fts legs, sql, superfile, and vector bench lanes green.

