### PR TITLE
bench: grade the FTS leg on the realistic corpus

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,7 +53,14 @@ jobs:
         # resources and comment markers unique (all legs share one run_id).
         include:
           - { bench: superfile,         docs: "1000000", suffix: sf }
-          - { bench: supertable_fts,    docs: "1000000", suffix: st-fts }
+          # The FTS leg runs the generated realistic text corpus — the one
+          # the quality oracle is calibrated on. The synthetic corpus draws
+          # every battery token from one Zipf, so its "common-word" phrases
+          # pair near-universal terms whose per-superfile idf is degenerate
+          # (~0 and hypersensitive to shard df); grading FTS perf and
+          # quality there rewards scoring artifacts of that degeneracy
+          # instead of behavior on text-shaped term distributions.
+          - { bench: supertable_fts,    docs: "1000000", suffix: st-fts, corpus: realistic }
           - { bench: supertable_vector, docs: "1000000", suffix: st-vec }
           # Non-cosine (L2) leg: exercises the Sq16Adaptive default codec
           # (the cosine leg above stays on the fixed-grid Sq16).


### PR DESCRIPTION
The st-fts bench leg — its perf tables, the warm-p90 merge gate, and the BM25 quality oracle — has been running on the synthetic corpus. That corpus draws every battery token from a single Zipf, so its "common-word" phrase shapes pair two near-universal terms. For terms like that, BM25 idf is nearly zero and hypersensitive to per-superfile document frequency: local idf swings roughly two orders of magnitude across the shards of one table.

Phrase timing on that shape grades artifacts of the degeneracy rather than retrieval behavior on text-shaped term distributions:

- A scorer that mixes per-shard score scales can report phrase latencies several times faster than its own unscored COUNT of the same phrase, by mass-skipping whole shards whose locally-tiny idf keeps every score under the shared top-k bar — speed that comes from ranking incorrectly.
- An honestly-scored walk on the same shape is bound to count-level work, because uniform doc lengths leave the verified anchor count as the only score signal — no bound can separate candidates without doing the position work.

This showed up concretely on #724, where the gate's phrase cells compare exactly those two behaviors.

The `realistic` corpus is the generated text corpus the FTS quality phase is already calibrated on (seeded local generator — no staging dir, ~80s at 1M docs), with text-shaped frequency drift where the degenerate-idf effects do not dominate. Both the perf battery and the quality oracle follow the leg's corpus argument, so the one matrix entry moves both.

The other legs are unchanged, and the A/B gate is unaffected structurally: both arms of a run always share one corpus argument, so comparisons stay within-corpus; only the informational delta against the previous run's tables resets once.