### PR TITLE
bench: fit the realistic FTS cell — warm/cold legs, 3 cold iterations

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -60,7 +60,12 @@ jobs:
           # (~0 and hypersensitive to shard df); grading FTS perf and
           # quality there rewards scoring artifacts of that degeneracy
           # instead of behavior on text-shaped term distributions.
-          - { bench: supertable_fts,    docs: "1000000", suffix: st-fts, corpus: realistic }
+          # The realistic corpus is heavier per arm than synthetic — larger
+          # docs make the fresh-cache cold battery ~1.5-2 min per shape —
+          # and the leg times both A/B arms on one VM: one arm alone runs
+          # ~55 min, so the reusable workflow's 60-minute default lands mid
+          # baseline arm. Ceiling sized for two arms plus provision/compile.
+          - { bench: supertable_fts,    docs: "1000000", suffix: st-fts, corpus: realistic, timeout_minutes: "170" }
           - { bench: supertable_vector, docs: "1000000", suffix: st-vec }
           # Non-cosine (L2) leg: exercises the Sq16Adaptive default codec
           # (the cosine leg above stays on the fixed-grid Sq16).
@@ -86,6 +91,8 @@ jobs:
       metric: ${{ matrix.metric }}
       corpus: ${{ matrix.corpus }}
       corpus_dir: ${{ matrix.corpus_dir }}
+      # Per-leg ceiling; legs without one keep the callee's default.
+      timeout_minutes: ${{ matrix.timeout_minutes || '60' }}
       ref: ${{ github.event.pull_request.head.sha }}
       name_suffix: -${{ matrix.suffix }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -60,13 +60,16 @@ jobs:
           # (~0 and hypersensitive to shard df); grading FTS perf and
           # quality there rewards scoring artifacts of that degeneracy
           # instead of behavior on text-shaped term distributions.
-          # The realistic corpus is heavier per arm than synthetic (~6x the
-          # stored bytes at equal docs, and cold measurement pays per byte):
-          # the leg times both A/B arms on one VM and an arm alone ran ~55
-          # minutes at 5 cold iterations, so the reusable workflow's
-          # 60-minute default landed mid baseline arm. Ceiling sized for
-          # two arms at 3 cold iterations plus VM provision and compile.
-          - { bench: supertable_fts,    docs: "1000000", suffix: st-fts, corpus: realistic, timeout_minutes: "110" }
+          # The FTS cell runs as two legs split by read phase. The realistic
+          # corpus is ~6x the synthetic bytes at equal docs and cold
+          # measurement pays per byte, so one combined leg overran the
+          # 60-minute default mid baseline arm; splitting lets the
+          # gate-bearing warm leg (build + quality + warm) report in under
+          # an hour while the byte-bound cold battery runs in parallel on
+          # its own VM. Ceilings are sized per leg for two A/B arms plus
+          # VM provision and compile.
+          - { bench: supertable_fts_warm, docs: "1000000", suffix: st-fts-warm, corpus: realistic, timeout_minutes: "75" }
+          - { bench: supertable_fts_cold, docs: "1000000", suffix: st-fts-cold, corpus: realistic, timeout_minutes: "100" }
           - { bench: supertable_vector, docs: "1000000", suffix: st-vec }
           # Non-cosine (L2) leg: exercises the Sq16Adaptive default codec
           # (the cosine leg above stays on the fixed-grid Sq16).

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -60,12 +60,13 @@ jobs:
           # (~0 and hypersensitive to shard df); grading FTS perf and
           # quality there rewards scoring artifacts of that degeneracy
           # instead of behavior on text-shaped term distributions.
-          # The realistic corpus is heavier per arm than synthetic — larger
-          # docs make the fresh-cache cold battery ~1.5-2 min per shape —
-          # and the leg times both A/B arms on one VM: one arm alone runs
-          # ~55 min, so the reusable workflow's 60-minute default lands mid
-          # baseline arm. Ceiling sized for two arms plus provision/compile.
-          - { bench: supertable_fts,    docs: "1000000", suffix: st-fts, corpus: realistic, timeout_minutes: "170" }
+          # The realistic corpus is heavier per arm than synthetic (~6x the
+          # stored bytes at equal docs, and cold measurement pays per byte):
+          # the leg times both A/B arms on one VM and an arm alone ran ~55
+          # minutes at 5 cold iterations, so the reusable workflow's
+          # 60-minute default landed mid baseline arm. Ceiling sized for
+          # two arms at 3 cold iterations plus VM provision and compile.
+          - { bench: supertable_fts,    docs: "1000000", suffix: st-fts, corpus: realistic, timeout_minutes: "110" }
           - { bench: supertable_vector, docs: "1000000", suffix: st-vec }
           # Non-cosine (L2) leg: exercises the Sq16Adaptive default codec
           # (the cosine leg above stays on the fixed-grid Sq16).

--- a/.github/workflows/supertable-bench-azure.yml
+++ b/.github/workflows/supertable-bench-azure.yml
@@ -201,6 +201,13 @@ jobs:
             superfile)                 args="superfile";         reports="superfile_fts superfile_vector sql" ;;
             supertable|supertable_all) args="supertable";        reports="supertable supertable_fts supertable_vector supertable_sql" ;;
             supertable_fts)            args="supertable fts";    reports="supertable_fts" ;;
+            # The FTS cell split by read phase, so the gate-bearing warm
+            # lane reports fast while the byte-bound cold battery runs on
+            # its own VM. Both keep `build`: the ingest metrics gate the
+            # post-compact lifecycle, and the warm half carries the
+            # quality oracle.
+            supertable_fts_warm)       args="supertable fts build warm quality"; reports="supertable_fts" ;;
+            supertable_fts_cold)       args="supertable fts build cold";         reports="supertable_fts" ;;
             supertable_vector)         args="supertable vector"; reports="supertable_vector" ;;
             supertable_sql)            args="supertable sql";    reports="supertable_sql" ;;
             all)                       args="all";               reports="supertable supertable_fts supertable_vector supertable_sql superfile_fts superfile_vector sql" ;;

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -905,7 +905,14 @@ pub fn run() {
 // ─── Per-modality query runners ───────────────────────────────────────────
 
 const WARM_ITERS: usize = 20;
-const COLD_ITERS: usize = 5;
+// 3, down from 5: each iteration is a fresh-cache open against the object
+// store, so cold latency scales with stored bytes — on the realistic FTS
+// corpus (~6x the synthetic bytes at equal docs) five iterations put one
+// A/B arm alone near the hour. Three keeps an outlier-discarding median
+// (cold latency is informational — the merge gate reads warm p90 only),
+// and every deterministic cold assertion (GET counts, byte ceilings, cost
+// tables) is per-iteration and unaffected by the count.
+const COLD_ITERS: usize = 3;
 const TOP_K: usize = 10;
 
 /// Selected phases for a per-modality supertable runner.


### PR DESCRIPTION
The realistic-corpus FTS leg's first run was cancelled at the reusable workflow's 60-minute default, mid baseline arm: the realistic corpus stores ~6x the synthetic bytes at equal doc count (952.9 MiB vs 5.38 GiB at 1M — varied vocabulary means text pages that barely compress, a larger term dictionary, wider postings), and cold measurement re-pays those bytes on every fresh-cache iteration. Three changes make the cell fit:

**The FTS cell runs as two legs split by read phase.** `st-fts-warm` (build + quality oracle + warm battery) is the only leg whose warm p90 can block a merge, and lands in roughly 50 minutes; `st-fts-cold` (build + cold battery) carries the byte-bound fresh-cache measurement in parallel on its own VM. Both keep the build phase, since the ingest metrics gate the post-compact lifecycle. A leg with no warm columns produces no gate verdict and passes by design (the summary warns instead of failing). Vector, sql, and superfile cells are unchanged.

**3 cold iterations (was 5), all legs.** Cold latency is informational — the merge gate reads warm p90 only, and the gate policy already excludes cold latency as object-store noise. Three iterations keep an outlier-discarding median, and every deterministic cold assertion (GET counts, byte ceilings, cost tables) is per-iteration and unaffected.

**Per-leg timeout knob.** 75 minutes for st-fts-warm, 100 for st-fts-cold; every other leg keeps the callee's 60-minute default.