### PR TITLE
ci: cache the transformers.js model for the node examples job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,22 @@ jobs:
           workspaces: infino-node
       # Build the addon (debug); the examples' `file:../..` dependency links it.
       - run: cd infino-node && npm install && npm run build:debug
+      # Install the examples' deps *before* restoring the model cache: transformers.js
+      # keeps downloaded models under node_modules/@huggingface/transformers/.cache,
+      # and npm would discard a restored cache that sits in an otherwise-empty
+      # node_modules. The `npm install` inside `make node-example` is then a no-op.
+      - run: |
+          for d in infino-node/examples/agent-memory infino-node/examples/hybrid-search-api; do
+            (cd "$d" && npm install)
+          done
+      # Cache the embedding model both examples pull from the Hugging Face Hub, so a
+      # Hub outage (503 on model.onnx) doesn't fail the job on every run.
+      - name: Cache transformers.js models
+        uses: actions/cache@v4
+        with:
+          path: infino-node/examples/*/node_modules/@huggingface/transformers/.cache
+          key: transformers-${{ runner.os }}-${{ hashFiles('infino-node/examples/*/index.mjs') }}
+          restore-keys: transformers-${{ runner.os }}-
       # Run each example end to end (self-asserting; non-zero exit fails the job).
       - run: make node-example
 


### PR DESCRIPTION
## Summary

The "Node examples (end to end)" job downloaded the MiniLM embedding model from the Hugging Face Hub on every run, so a Hub outage failed the job regardless of the change under test. The most recent instance was on #724 (a 503 on `model.onnx`), while the same job passed on `main` minutes later.

This adds an `actions/cache` step for the transformers.js model directory, bringing the node job to parity with the Python examples job, which already caches its Hub assets. An outage now only bites on a cache miss.

## Why the install runs before the cache restore

transformers.js has no setting for its cache location. It stores models under `node_modules/@huggingface/transformers/.cache` inside each example, and npm discards that directory when it installs into an otherwise-empty `node_modules`. Verified locally with a marker file:

| Scenario | Result |
|---|---|
| Restore `.cache` into an empty `node_modules`, then `npm install` | cache wiped |
| `npm install` first, then a second `npm install` with `.cache` present | cache kept |

So the job installs the examples' dependencies first and restores the cache after. The `npm install` inside `make node-example` is then a no-op and leaves the cache in place.

## Testing

- `ci.yml` parses; the job has the expected step order.
- The first run of this PR populates the cache (a miss is expected). The post-job save and a subsequent run's restore are the real check.

No engine code changes, so no bench run.
