### PR TITLE
fts: analyzer explicit everywhere, and default it to standard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "apache-avro",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 # Pinned to the toolchain in rust-toolchain.toml. The vector SIMD path
 # uses AVX-512 intrinsics stabilized in 1.89 and std APIs from 1.87, so

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -2632,11 +2632,23 @@ pub mod sql {
     /// family split can never drift apart.
     pub const BULK_RANGE_SCAN: &str = "WHERE rating < N (range scan, returns rows)";
     pub const BULK_TOKEN_MATCH_ALL: &str = "token_match (all rows)";
-    /// A substring `LIKE` the default `ascii_lower` analyzer cannot bound:
-    /// a full column scan whose cost is the scan, not the rows it returns.
-    /// Classified with the bulk shapes so it never averages into the
-    /// point-lookup family the serving cost model prices per row.
-    pub const BULK_LIKE_SCAN: &str = "WHERE title LIKE '%term…%' (substring scan, ascii_lower)";
+
+    /// A substring `LIKE`, whose single token is open on both edges. Not a
+    /// bulk shape: its result is bounded (a Zipf-tail term, a few thousand
+    /// rows), so GB-returned never dominates its cost and it belongs with
+    /// the bounded-result families the split above is drawn against.
+    ///
+    /// How it is answered is analyzer- and corpus-dependent — an open-edged
+    /// token can only be required as a term after a walk of the column's
+    /// dictionary, which is taken only where the stored text is large
+    /// against the vocabulary — so the name states the query shape rather
+    /// than a plan. It moved out of the bulk family when the default
+    /// analyzer changed and the walk became worth taking here, turning a
+    /// full column scan into a dictionary-bounded lookup; the old name
+    /// asserted both a plan and an analyzer, so numbers recorded under it
+    /// are not comparable and it is deliberately renamed rather than
+    /// carried forward.
+    pub const LIKE_SUBSTRING: &str = "WHERE title LIKE '%term…%' (substring, open-edged token)";
 
     /// The one classification of a bulk / scan-priced shape by name. Both
     /// the warm/cold query table (this module) and the serving-cost family
@@ -2644,7 +2656,7 @@ pub mod sql {
     /// same name check, so the two tables can never classify the same shape
     /// differently.
     pub fn is_bulk_shape(name: &str) -> bool {
-        name == BULK_RANGE_SCAN || name == BULK_TOKEN_MATCH_ALL || name == BULK_LIKE_SCAN
+        name == BULK_RANGE_SCAN || name == BULK_TOKEN_MATCH_ALL
     }
 
     /// Scan-backed aggregates — realistic analytics shapes that provably
@@ -2821,13 +2833,14 @@ pub mod sql {
                 format!("SELECT key, rating FROM supertable WHERE title LIKE '{doc_token} %'"),
             ),
             (
-                // An open-edged token under the default `ascii_lower`
-                // analyzer cannot be bounded (a run holding a non-ASCII byte
-                // is dropped whole), so this stays a DataFusion column scan;
-                // `term09999` sits at the Zipf tail (the FTS battery's
-                // `single_rare` term), so the result stays small and the
-                // cost is the scan itself.
-                BULK_LIKE_SCAN,
+                // A substring pattern, whose only token is open on both
+                // edges. `term09999` sits at the Zipf tail (the FTS
+                // battery's `single_rare` term), so the result stays small
+                // either way; what varies is whether the token can be
+                // widened to the indexed terms it sits inside, which needs
+                // a walk of the column's dictionary and so depends on the
+                // column's analyzer and on stored text against vocabulary.
+                LIKE_SUBSTRING,
                 "SELECT key, rating FROM supertable WHERE title LIKE '%term09999%'".to_string(),
             ),
         ]

--- a/docs/architecture/supertable.md
+++ b/docs/architecture/supertable.md
@@ -101,9 +101,9 @@ the term dictionary (each literal fragment of the pattern is tokenized;
 a token the fragment closes on both sides is required as itself, and a
 token bordering a wildcard is widened to the indexed terms it heads,
 tails, or sits inside) — with the exact predicate re-checked over the
-candidate rows. The default `ascii_lower` analyzer drops any token
-holding a non-ASCII byte, so under it only tokens the pattern closes on
-both sides can be required; the `standard` analyzer supports prefix,
+candidate rows. The `ascii_lower` analyzer drops any token holding a
+non-ASCII byte, so under it only tokens the pattern closes on both
+sides can be required; the default `standard` analyzer supports prefix,
 suffix, and substring patterns. A suffix or substring token needs a walk
 of the column's whole dictionary, taken only where the superfile's
 stored text is large against its vocabulary; otherwise that token is

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "apache-avro",
  "arc-swap",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "infino-node"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-node/Cargo.toml
+++ b/infino-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-node"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-node/package.json
+++ b/infino-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Fast search on object storage — SQL, full-text, and vector search.",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -82,12 +82,12 @@
     "apache-arrow": "^17"
   },
   "optionalDependencies": {
-    "infx-darwin-x64": "0.6.0",
-    "infx-darwin-arm64": "0.6.0",
-    "infx-linux-x64-gnu": "0.6.0",
-    "infx-linux-arm64-gnu": "0.6.0",
-    "infx-linux-x64-musl": "0.6.0",
-    "infx-linux-arm64-musl": "0.6.0"
+    "infx-darwin-x64": "0.7.0",
+    "infx-darwin-arm64": "0.7.0",
+    "infx-linux-x64-gnu": "0.7.0",
+    "infx-linux-arm64-gnu": "0.7.0",
+    "infx-linux-x64-musl": "0.7.0",
+    "infx-linux-arm64-musl": "0.7.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0",

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -529,9 +529,10 @@ pub struct IndexSpec {
 #[napi(object)]
 #[derive(Clone, Default)]
 pub struct FtsOptions {
-    /// Tokenizer: `"ascii_lower"` (default — ASCII split + lowercase,
-    /// non-ASCII dropped) or `"standard"` (the Unicode-aware UAX #29
-    /// tokenizer that keeps non-ASCII text).
+    /// Tokenizer: `"standard"` (the default — the Unicode-aware UAX #29
+    /// tokenizer that keeps non-ASCII text) or `"ascii_lower"` (ASCII
+    /// split + lowercase, non-ASCII dropped). It is recorded with the
+    /// table and cannot be changed afterwards.
     pub analyzer: Option<String>,
     /// Keep the raw text in the table (default true). `false` makes the
     /// column index-only: searchable, but the text is never stored, so

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "infino"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "apache-avro",
  "arc-swap",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "infino-python"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-python"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -234,9 +234,10 @@ impl IndexSpec {
     }
 
     /// Mark `column` (a UTF-8 string column) as full-text indexed.
-    /// `analyzer` selects the tokenizer: `"ascii_lower"` (default —
-    /// ASCII split + lowercase, non-ASCII dropped) or `"standard"` (the
-    /// Unicode-aware UAX #29 tokenizer that keeps non-ASCII text).
+    /// `analyzer` selects the tokenizer: `"standard"` (the default —
+    /// the Unicode-aware UAX #29 tokenizer that keeps non-ASCII text)
+    /// or `"ascii_lower"` (ASCII split + lowercase, non-ASCII dropped).
+    /// It is recorded with the table and cannot be changed afterwards.
     /// `stored=False` makes the column index-only: searchable, but the
     /// raw text is never kept in the table, so it cannot be selected,
     /// projected, or filtered on (append/update batches still carry it).

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -69,9 +69,9 @@ def test_memory_roundtrip():
 
 
 def test_fts_standard_analyzer_keeps_non_ascii():
-    # The `analyzer` kwarg selects the tokenizer. The default ascii_lower
-    # drops non-ASCII (so "café" is unsearchable); the standard analyzer
-    # (UAX #29 + lowercase) keeps it.
+    # The `analyzer` kwarg selects the tokenizer. The default, standard
+    # (UAX #29 + lowercase), keeps non-ASCII; ascii_lower drops it, so
+    # "café" is unsearchable under it.
     db = infino.connect("memory://")
 
     std_tbl = db.create_table(
@@ -80,7 +80,9 @@ def test_fts_standard_analyzer_keeps_non_ascii():
     std_tbl.append(_title_batch(["café latte"]))
     assert std_tbl.bm25_search("title", "café", 10).num_rows == 1
 
-    ascii_tbl = db.create_table("ascii", _title_schema(), infino.IndexSpec().fts("title"))
+    ascii_tbl = db.create_table(
+        "ascii", _title_schema(), infino.IndexSpec().fts("title", analyzer="ascii_lower")
+    )
     ascii_tbl.append(_title_batch(["café latte"]))
     try:
         ascii_hits = ascii_tbl.bm25_search("title", "café", 10).num_rows

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -8,7 +8,7 @@
 
 use crate::superfile::{
     builder::FtsConfig,
-    fts::tokenize::ASCII_LOWER_TOKENIZER,
+    fts::tokenize::STANDARD_TOKENIZER,
     vector::{builder::VectorConfig, distance::Metric},
 };
 
@@ -46,22 +46,23 @@ pub struct FtsField {
 
 impl FtsField {
     /// Declare `column` as full-text indexed with the defaults: the
-    /// `ascii_lower` analyzer (ASCII split + lowercase, non-ASCII
-    /// dropped) and the raw text stored. The column must be a UTF-8
-    /// string column in the table schema.
+    /// `standard` analyzer (Unicode UAX #29 word segmentation, full
+    /// Unicode lowercasing) and the raw text stored. The column must be
+    /// a UTF-8 string column in the table schema.
     pub fn new(column: impl Into<String>) -> Self {
         Self {
             column: column.into(),
-            analyzer: ASCII_LOWER_TOKENIZER.to_string(),
+            analyzer: STANDARD_TOKENIZER.to_string(),
             stored: true,
         }
     }
 
-    /// Pick the column's analyzer by name (`"ascii_lower"` or
-    /// `"standard"` — the Unicode-aware UAX #29 tokenizer that keeps
-    /// non-ASCII text). The analyzer is per column: each FTS column is
-    /// tokenized with its own, so columns in one table may use
-    /// different analyzers.
+    /// Pick the column's analyzer by name — `"standard"` (the default)
+    /// or `"ascii_lower"`, which splits on ASCII alphanumerics and
+    /// drops every non-ASCII token. The analyzer is per column: each
+    /// FTS column is tokenized with its own, so columns in one table
+    /// may use different analyzers. It is recorded with the table and
+    /// cannot be changed afterwards.
     pub fn analyzer(mut self, name: impl Into<String>) -> Self {
         self.analyzer = name.into();
         self

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -127,7 +127,7 @@ impl IndexSpec {
     /// use infino::{FtsField, IndexSpec};
     /// let spec = IndexSpec::new()
     ///     .fts("title")
-    ///     .fts(FtsField::new("body").analyzer("standard").stored(false));
+    ///     .fts(FtsField::new("body").analyzer("ascii_lower").stored(false));
     /// # let _ = spec;
     /// ```
     pub fn fts(mut self, field: impl Into<FtsField>) -> Self {

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -27,14 +27,14 @@ struct VectorIndex {
 /// One full-text (BM25) indexed column, with its per-column options.
 ///
 /// Passed to [`IndexSpec::fts`]. A plain column name converts with all
-/// defaults (`ascii_lower` analyzer, stored text), so the common case
+/// defaults (`standard` analyzer, stored text), so the common case
 /// stays `.fts("body")`; build a `FtsField` to change an option:
 ///
 /// ```
 /// use infino::{FtsField, IndexSpec};
 /// let spec = IndexSpec::new()
 ///     .fts("title")
-///     .fts(FtsField::new("body").analyzer("standard").stored(false));
+///     .fts(FtsField::new("body").analyzer("ascii_lower").stored(false));
 /// # let _ = spec;
 /// ```
 #[derive(Debug, Clone)]

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -54,9 +54,12 @@ pub(crate) struct TableEntry {
     /// FTS-indexed column names.
     pub(crate) fts: Vec<String>,
     /// FTS analyzer names, parallel to `fts` (`"ascii_lower"` /
-    /// `"standard"`). Absent in catalogs written before per-column
-    /// analyzers existed; a missing or short entry defaults to
-    /// `ascii_lower` on reopen.
+    /// `"standard"`). Every entry `create_table` writes carries one name
+    /// per FTS column; `open_table` requires the two lists to be the
+    /// same length rather than inferring an analyzer for a column that
+    /// lacks one. `serde(default)` only keeps the *rest* of the catalog
+    /// decodable — an entry that decodes to a short list is rejected per
+    /// table, not silently patched.
     #[serde(default)]
     pub(crate) fts_analyzers: Vec<String>,
     /// FTS stored flags, parallel to `fts` (`false` = index-only, the

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -85,7 +85,6 @@ use crate::{
     },
     superfile::{
         builder::FtsConfig,
-        fts::tokenize::ASCII_LOWER_TOKENIZER,
         vector::{builder::VectorConfig, distance::Metric},
     },
     supertable::{
@@ -562,15 +561,22 @@ impl Connection {
                 // the defaults it applies (rotation seed, rerank codec) are
                 // identical and the table's options-hash check passes.
                 let mut spec = IndexSpec::new();
+                // The analyzer decides how query text is tokenized, so it
+                // cannot be inferred: a record that does not name one per
+                // full-text column is unusable, and guessing would return
+                // wrong results rather than an error.
+                if entry.fts_analyzers.len() != entry.fts.len() {
+                    return Err(InfinoError::Backend(format!(
+                        "table '{name}' has {} full-text columns but {} analyzer names recorded; \
+                         the table record is incomplete",
+                        entry.fts.len(),
+                        entry.fts_analyzers.len()
+                    ))
+                    .with_context("open_table", Some(name)));
+                }
                 for (i, column) in entry.fts.iter().enumerate() {
-                    // Catalogs written before per-column analyzers omit
-                    // `fts_analyzers`; those columns default to ascii_lower.
-                    let analyzer = entry
-                        .fts_analyzers
-                        .get(i)
-                        .map(String::as_str)
-                        .unwrap_or(ASCII_LOWER_TOKENIZER);
-                    // Same back-compat rule for `fts_stored`: a catalog
+                    let analyzer = entry.fts_analyzers[i].as_str();
+                    // `fts_stored` keeps its back-compat rule: a catalog
                     // written before index-only columns existed can only
                     // mean the text is stored.
                     let stored = entry.fts_stored.get(i).copied().unwrap_or(true);
@@ -1375,6 +1381,7 @@ mod tests {
     use super::*;
     use crate::{
         Bm25SearchOptions, BoolMode, Consistency,
+        catalog::manifest::CATALOG_PATH,
         supertable::manifest::commit::POINTER_PATH,
         test_helpers::{build_title_batch, schema_id_title},
     };
@@ -1573,9 +1580,13 @@ mod tests {
     fn standard_analyzer_keeps_non_ascii_end_to_end() {
         let conn = connect("memory://").expect("connect");
 
-        // Default (ascii_lower) drops non-ASCII, so "café" is unsearchable.
+        // Explicit ascii_lower drops non-ASCII, so "café" is unsearchable.
         let ascii = conn
-            .create_table("ascii", schema_id_title(), IndexSpec::new().fts("title"))
+            .create_table(
+                "ascii",
+                schema_id_title(),
+                IndexSpec::new().fts(FtsField::new("title").analyzer("ascii_lower")),
+            )
             .expect("create ascii table");
         ascii
             .append(&build_title_batch(&["café latte"]))
@@ -1606,6 +1617,23 @@ mod tests {
             n_rows(&hits),
             1,
             "standard analyzer matches the non-ASCII term"
+        );
+
+        // A column declared without an analyzer gets `standard`, so it
+        // behaves like the explicit table above rather than the ascii one.
+        let default_tbl = conn
+            .create_table("dflt", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create default table");
+        default_tbl
+            .append(&build_title_batch(&["café latte"]))
+            .expect("append");
+        let default_hits = default_tbl
+            .bm25_search("title", "café", TOP_K, Bm25SearchOptions::new(), None)
+            .expect("bm25_search");
+        assert_eq!(
+            n_rows(&default_hits),
+            1,
+            "a bare declaration keeps the non-ASCII term"
         );
 
         // An unknown analyzer is a configuration error at create time.
@@ -1729,6 +1757,53 @@ mod tests {
         assert_eq!(
             body_cafe, 0,
             "ascii_lower column still drops non-ASCII after reopen"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn open_table_rejects_a_record_missing_its_analyzer_names() {
+        // The analyzer names are what let a reopened table tokenize query
+        // text the way its postings were built. A record that has full-text
+        // columns but no name for one of them cannot be reopened
+        // correctly, so `open_table` says so and names the table instead
+        // of picking an analyzer and returning wrong results.
+        let dir = std::env::temp_dir().join(format!("infino-noanalyzer-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let uri = format!("file://{}", dir.display());
+        let schema = schema_title_body();
+        {
+            let conn = connect(&uri).expect("connect");
+            conn.create_table(
+                "docs",
+                schema.clone(),
+                IndexSpec::new().fts("title").fts("body"),
+            )
+            .expect("create_table");
+        }
+        // Strip the analyzer list from the stored record, the shape a
+        // record written before analyzers were recorded per column has.
+        let catalog_file = dir.join(CATALOG_PATH);
+        let mut body: serde_json::Value =
+            serde_json::from_slice(&fs::read(&catalog_file).expect("read catalog"))
+                .expect("catalog json");
+        body["tables"]["docs"]
+            .as_object_mut()
+            .expect("table entry")
+            .remove("fts_analyzers");
+        fs::write(
+            &catalog_file,
+            serde_json::to_vec(&body).expect("encode catalog"),
+        )
+        .expect("write catalog");
+
+        let conn = connect(&uri).expect("reconnect");
+        let err = conn.open_table("docs").expect_err("incomplete record");
+        let rendered = err.to_string();
+        assert!(rendered.contains("docs"), "must name the table: {rendered}");
+        assert!(
+            rendered.contains("analyzer"),
+            "must say what is missing: {rendered}"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -22,7 +22,7 @@ use arrow_schema::Schema;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use serde_json::{Value, json};
 
-use crate::{IndexSpec, InfinoError, Metric, superfile::fts::tokenize::ASCII_LOWER_TOKENIZER};
+use crate::{IndexSpec, InfinoError, Metric};
 
 /// Content type for an Arrow IPC streaming body — the encoding for `append`
 /// bodies and read responses.
@@ -46,11 +46,10 @@ pub(crate) fn metric_str(metric: Metric) -> &'static str {
 /// `{fts: [entry, …], vector: [{column, dim, metric}, …]}`. Absent index kinds
 /// are omitted (the server treats a missing key as "none").
 ///
-/// Each FTS entry is a bare column name when every option is at its default
-/// (`ascii_lower` analyzer, stored text), or a `{column, …}` object carrying
-/// only the non-default options (`analyzer`, `stored: false`), so the chosen
-/// options reach the server rather than being dropped. The bare form for the
-/// defaults keeps the request identical to what older servers expect.
+/// Each FTS entry is a `{column, analyzer}` object — plus `stored: false`
+/// for an index-only column. The analyzer is always named rather than left
+/// to the server's own idea of a default, so a table is created with the
+/// analyzer this client resolved and the two can never drift apart.
 pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
     let mut indexes = serde_json::Map::new();
     let columns = spec.fts_columns();
@@ -60,14 +59,9 @@ pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
             .zip(spec.fts_analyzers())
             .zip(spec.fts_stored())
             .map(|((column, analyzer), stored)| {
-                if analyzer == ASCII_LOWER_TOKENIZER && stored {
-                    return json!(column);
-                }
                 let mut entry = serde_json::Map::new();
                 entry.insert("column".to_string(), json!(column));
-                if analyzer != ASCII_LOWER_TOKENIZER {
-                    entry.insert("analyzer".to_string(), json!(analyzer));
-                }
+                entry.insert("analyzer".to_string(), json!(analyzer));
                 if !stored {
                     entry.insert("stored".to_string(), json!(false));
                 }
@@ -182,7 +176,10 @@ mod tests {
             .fts("body")
             .vector("embedding", 384, Metric::Cosine);
         let json = index_spec_to_json(&spec);
-        assert_eq!(json["fts"], json!(["body"]));
+        assert_eq!(
+            json["fts"],
+            json!([{"column": "body", "analyzer": "ascii_lower"}])
+        );
         assert_eq!(
             json["vector"][0],
             json!({"column": "embedding", "dim": 384, "metric": "cosine"})
@@ -190,28 +187,32 @@ mod tests {
     }
 
     #[test]
-    fn index_spec_json_carries_a_non_default_analyzer() {
-        // A named analyzer must cross the wire as a {column, analyzer} object,
-        // so the server builds the index with it rather than the default. A
-        // default-analyzer column alongside it stays a bare string, so only the
-        // columns that need the object form pay for it.
+    fn index_spec_json_names_every_columns_analyzer() {
+        // Each column crosses as a {column, analyzer} object, whichever
+        // analyzer it resolved to, so the server builds the index with the
+        // analyzer this client chose and never with one of its own.
         let spec = IndexSpec::new()
             .fts("title")
             .fts(FtsField::new("body").analyzer("standard"));
         let json = index_spec_to_json(&spec);
         assert_eq!(
             json["fts"],
-            json!(["title", {"column": "body", "analyzer": "standard"}])
+            json!([
+                {"column": "title", "analyzer": "ascii_lower"},
+                {"column": "body", "analyzer": "standard"}
+            ])
         );
     }
 
     #[test]
-    fn index_spec_json_bare_form_for_the_default_analyzer() {
-        // An explicit ascii_lower is the default, so it serializes identically to
-        // a bare column name — no needless object form, and byte-identical to
-        // what an older server expects.
-        let spec = IndexSpec::new().fts(FtsField::new("body").analyzer("ascii_lower"));
-        assert_eq!(index_spec_to_json(&spec)["fts"], json!(["body"]));
+    fn index_spec_json_carries_an_index_only_column() {
+        // `stored: false` rides alongside the analyzer; it is the one key
+        // that appears only when it is not the default.
+        let spec = IndexSpec::new().fts(FtsField::new("body").stored(false));
+        assert_eq!(
+            index_spec_to_json(&spec)["fts"],
+            json!([{"column": "body", "analyzer": "ascii_lower", "stored": false}])
+        );
     }
 
     #[test]

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -178,7 +178,7 @@ mod tests {
         let json = index_spec_to_json(&spec);
         assert_eq!(
             json["fts"],
-            json!([{"column": "body", "analyzer": "ascii_lower"}])
+            json!([{"column": "body", "analyzer": "standard"}])
         );
         assert_eq!(
             json["vector"][0],
@@ -191,8 +191,10 @@ mod tests {
         // Each column crosses as a {column, analyzer} object, whichever
         // analyzer it resolved to, so the server builds the index with the
         // analyzer this client chose and never with one of its own.
+        // Both analyzers named explicitly, so this stays a per-column test
+        // whichever one the engine defaults to.
         let spec = IndexSpec::new()
-            .fts("title")
+            .fts(FtsField::new("title").analyzer("ascii_lower"))
             .fts(FtsField::new("body").analyzer("standard"));
         let json = index_spec_to_json(&spec);
         assert_eq!(
@@ -201,6 +203,15 @@ mod tests {
                 {"column": "title", "analyzer": "ascii_lower"},
                 {"column": "body", "analyzer": "standard"}
             ])
+        );
+
+        // A column declared without an analyzer crosses with the engine
+        // default named explicitly, never as a bare string the server
+        // would have to resolve itself.
+        let defaulted = index_spec_to_json(&IndexSpec::new().fts("title"));
+        assert_eq!(
+            defaulted["fts"],
+            json!([{"column": "title", "analyzer": "standard"}])
         );
     }
 
@@ -211,7 +222,7 @@ mod tests {
         let spec = IndexSpec::new().fts(FtsField::new("body").stored(false));
         assert_eq!(
             index_spec_to_json(&spec)["fts"],
-            json!([{"column": "body", "analyzer": "ascii_lower", "stored": false}])
+            json!([{"column": "body", "analyzer": "standard", "stored": false}])
         );
     }
 

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -63,8 +63,8 @@
 //! `register_column_with_tokenizer` sets a per-column analyzer — and
 //! dispatches per (column, doc) at `add_doc` time.
 //!
-//! Two tokenizers ship: `AsciiLowerTokenizer` (the default) and the
-//! Unicode-aware `StandardTokenizer`, selectable per column. The
+//! Two tokenizers ship: the Unicode-aware `StandardTokenizer` (the
+//! default) and `AsciiLowerTokenizer`, selectable per column. The
 //! `inf.fts.columns` JSON persists each column's tokenizer name, so a
 //! column is re-tokenized at rebuild / compaction with the analyzer it
 //! was indexed with. Further analyzers (language-specific stemmers, …)
@@ -130,7 +130,7 @@ use crate::superfile::{
 pub struct FtsConfig {
     pub column: String,
     /// Analyzer (tokenizer) name applied to this column —
-    /// `"ascii_lower"` (the default) or `"standard"`. Resolved to a
+    /// `"standard"` (the default) or `"ascii_lower"`. Resolved to a
     /// tokenizer instance once, at builder construction; an unknown
     /// name is a build error. Per column: each FTS column is tokenized
     /// with its own analyzer, so columns in one table may differ.

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -98,7 +98,7 @@ use crate::superfile::{
     fts::{
         builder::FtsBuilder,
         reader::ColumnMeta,
-        tokenize::{ASCII_LOWER_TOKENIZER, AsciiLowerTokenizer, tokenizer_for_name},
+        tokenize::{AsciiLowerTokenizer, STANDARD_TOKENIZER, tokenizer_for_name},
     },
     stats::SuperfileStats,
     vector::{
@@ -157,12 +157,12 @@ pub struct FtsConfig {
 }
 
 impl FtsConfig {
-    /// Configuration with the defaults: `ascii_lower` analyzer, no
+    /// Configuration with the defaults: `standard` analyzer, no
     /// positions, text stored.
     pub fn new(column: impl Into<String>) -> Self {
         Self {
             column: column.into(),
-            analyzer: ASCII_LOWER_TOKENIZER.to_string(),
+            analyzer: STANDARD_TOKENIZER.to_string(),
             positions: false,
             stored: true,
         }
@@ -379,8 +379,9 @@ impl BuilderOptions {
 
     pub fn new_from_reader(reader: &SuperfileReader) -> Self {
         // Recover each FTS column's analyzer from the source reader so a
-        // rebuild carries the analyzer it was built with, instead of
-        // defaulting to ASCII.
+        // rebuild carries the analyzer the postings were built with. This
+        // is why an existing table keeps its recorded analyzer through
+        // compaction and optimize no matter what the engine's default is.
         let fts_columns: Vec<FtsConfig> = if let Some(fts) = &reader.fts() {
             fts.fts_columns_config()
                 .map(|c| {
@@ -2697,7 +2698,7 @@ mod tests {
         assert!(s.starts_with('['));
         assert!(s.contains(r#""name":"title""#));
         assert!(s.contains(r#""name":"body""#));
-        assert!(s.contains(r#""tokenizer":"ascii_lower""#));
+        assert!(s.contains(r#""tokenizer":"standard""#));
         // Positionless columns emit no positions field at all — the
         // JSON stays byte-identical to files written before the flag
         // existed.
@@ -2715,21 +2716,23 @@ mod tests {
         ];
         let s = fts_columns_json(&cols);
         assert!(
-            s.contains(r#"{"name":"title","tokenizer":"ascii_lower","positions":true}"#),
+            s.contains(r#"{"name":"title","tokenizer":"standard","positions":true}"#),
             "positional column carries the flag: {s}"
         );
         assert!(
-            s.contains(r#"{"name":"body","tokenizer":"ascii_lower"}"#),
-            "positionless column stays in the legacy shape: {s}"
+            s.contains(r#"{"name":"body","tokenizer":"standard"}"#),
+            "positionless column carries no positions key at all: {s}"
         );
     }
 
     /// Per-column analyzers: each column records its own tokenizer name.
     #[test]
     fn fts_columns_json_per_column_analyzers() {
+        // Both analyzers named explicitly: the recorded name must be the
+        // column's own, independent of which one the engine defaults to.
         let cols = vec![
             FtsConfig::new("title").analyzer("standard"),
-            FtsConfig::new("body"),
+            FtsConfig::new("body").analyzer("ascii_lower"),
         ];
         let s = fts_columns_json(&cols);
         assert!(
@@ -2752,11 +2755,11 @@ mod tests {
         ];
         let s = fts_columns_json(&cols);
         assert!(
-            s.contains(r#"{"name":"title","tokenizer":"ascii_lower"}"#),
-            "stored column stays in the legacy shape: {s}"
+            s.contains(r#"{"name":"title","tokenizer":"standard"}"#),
+            "stored column carries no stored key at all: {s}"
         );
         assert!(
-            s.contains(r#"{"name":"body","tokenizer":"ascii_lower","stored":false}"#),
+            s.contains(r#"{"name":"body","tokenizer":"standard","stored":false}"#),
             "index-only column carries the flag: {s}"
         );
     }

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -102,7 +102,7 @@ use crate::superfile::{
         fst_value::{FstValue, INLINE_TF_MAX},
         positions::{encode_run, read_varint, skip_run},
         posting::{BLOCK_LEN, Block, ENCODING_BITSET, EncodedBlock, encode_block},
-        tokenize::{AsciiLowerTokenizer, Tokenizer},
+        tokenize::{AsciiLowerTokenizer, StandardTokenizer, Tokenizer},
     },
 };
 
@@ -1869,6 +1869,14 @@ impl FtsBuilder {
             .as_ref()
             .as_any()
             .downcast_ref::<AsciiLowerTokenizer>();
+        // `standard` is the default analyzer, so it needs the same
+        // monomorphized scan the ASCII tokenizer gets — through the
+        // trait object every token costs an indirect call and the
+        // interning closure cannot inline into the scan loop.
+        let standard_tok = tokenizer
+            .as_ref()
+            .as_any()
+            .downcast_ref::<StandardTokenizer>();
         let mut tokens_in_doc: u64 = 0;
 
         let positional = self.columns[col_idx].positions;
@@ -1935,6 +1943,8 @@ impl FtsBuilder {
             };
             if let Some(ascii) = ascii_tok {
                 ascii.tokenize_each_inline(text, &mut on_token);
+            } else if let Some(standard) = standard_tok {
+                standard.tokenize_each_inline(text, &mut on_token);
             } else {
                 tokenizer.tokenize_each(text, &mut on_token);
             }
@@ -1986,6 +1996,15 @@ impl FtsBuilder {
                 // position ordinal but emits no token.
                 ascii.tokenize_each_inline_positioned(text, |tok, position| {
                     record(tok, position);
+                    tokens_in_doc += 1;
+                });
+            } else if let Some(standard) = standard_tok {
+                // `standard` drops nothing — every segment carrying an
+                // alphanumeric is emitted — so an emission ordinal *is*
+                // the gap-inclusive position and no gap bookkeeping is
+                // needed. Monomorphized for the same reason as above.
+                standard.tokenize_each_inline(text, |tok| {
+                    record(tok, tokens_in_doc);
                     tokens_in_doc += 1;
                 });
             } else {
@@ -2103,6 +2122,14 @@ impl FtsBuilder {
             .as_ref()
             .as_any()
             .downcast_ref::<AsciiLowerTokenizer>();
+        // `standard` is the default analyzer, so it needs the same
+        // monomorphized scan the ASCII tokenizer gets — through the
+        // trait object every token costs an indirect call and the
+        // interning closure cannot inline into the scan loop.
+        let standard_tok = tokenizer
+            .as_ref()
+            .as_any()
+            .downcast_ref::<StandardTokenizer>();
         let mut tokens_in_doc: u64 = 0;
         let positional = self.columns[col_idx].positions;
 
@@ -2147,6 +2174,8 @@ impl FtsBuilder {
             };
             if let Some(ascii) = ascii_tok {
                 ascii.tokenize_each_inline(text, &mut on_token);
+            } else if let Some(standard) = standard_tok {
+                standard.tokenize_each_inline(text, &mut on_token);
             } else {
                 tokenizer.tokenize_each(text, &mut on_token);
             }
@@ -2205,6 +2234,15 @@ impl FtsBuilder {
                 // position ordinal but emits no token.
                 ascii.tokenize_each_inline_positioned(text, |tok, position| {
                     record(tok, position);
+                    tokens_in_doc += 1;
+                });
+            } else if let Some(standard) = standard_tok {
+                // `standard` drops nothing — every segment carrying an
+                // alphanumeric is emitted — so an emission ordinal *is*
+                // the gap-inclusive position and no gap bookkeeping is
+                // needed. Monomorphized for the same reason as above.
+                standard.tokenize_each_inline(text, |tok| {
+                    record(tok, tokens_in_doc);
                     tokens_in_doc += 1;
                 });
             } else {

--- a/src/superfile/fts/reader/metadata.rs
+++ b/src/superfile/fts/reader/metadata.rs
@@ -121,11 +121,10 @@ pub struct ColumnMeta {
 #[derive(Debug, Clone, Deserialize)]
 pub struct FtsColumnConfig {
     pub name: String,
-    /// The column's analyzer name: `"ascii_lower"` (the default) or
-    /// `"standard"`. A missing field deserializes to `"ascii_lower"`
-    /// for backward compatibility with files written before the
-    /// analyzer name was recorded.
-    #[serde(default = "default_tokenizer")]
+    /// The column's analyzer name: `"ascii_lower"` or `"standard"`.
+    /// Required — the builder has always emitted it, so a column entry
+    /// without it is a malformed footer and open fails rather than
+    /// guessing which analyzer produced the postings.
     pub tokenizer: String,
     /// Whether this column's index records token positions (phrase
     /// support). Files written before positions existed lack the
@@ -139,10 +138,6 @@ pub struct FtsColumnConfig {
     /// `true` (the writer emits it only when `false`).
     #[serde(default = "default_stored")]
     pub stored: bool,
-}
-
-pub(super) fn default_tokenizer() -> String {
-    "ascii_lower".to_string()
 }
 
 pub(super) fn default_stored() -> bool {
@@ -214,20 +209,18 @@ mod tests {
     }
 
     #[test]
-    fn default_tokenizer_helper_is_ascii_lower() {
-        assert_eq!(default_tokenizer(), "ascii_lower");
-    }
-
-    #[test]
-    fn fts_column_config_missing_tokenizer_defaults() {
-        // A column JSON without the optional `tokenizer` field decodes to
-        // the ascii_lower default (round-trips an old file written before
-        // the field existed).
+    fn fts_column_config_without_tokenizer_is_rejected() {
+        // The analyzer name is load-bearing: query terms must be
+        // tokenized the way the postings were. A column entry missing it
+        // is a malformed footer, so open fails instead of picking an
+        // analyzer for the caller.
         let (blob, _) = build_blob();
         let json = r#"[{"name":"body"}]"#;
-        let r = FtsReader::open(blob, json).expect("open with terse json");
-        let cfg = r.fts_columns_config().next().expect("one column");
-        assert_eq!(cfg.name, "body");
+        let err = FtsReader::open(blob, json).expect_err("missing tokenizer must fail open");
+        assert!(
+            err.to_string().contains("tokenizer"),
+            "error should name the missing field: {err}"
+        );
     }
 
     #[test]

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -959,6 +959,8 @@ impl Tokenizer for StandardTokenizer {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::*;
 
     fn tokens(text: &str) -> Vec<String> {
@@ -1100,10 +1102,7 @@ mod tests {
         ] {
             let mut fast = Vec::new();
             StandardTokenizer.tokenize_each_inline(text, |t| fast.push(t.to_owned()));
-            let expected: Vec<String> = text
-                .unicode_words()
-                .map(|w| w.to_lowercase())
-                .collect();
+            let expected: Vec<String> = text.unicode_words().map(|w| w.to_lowercase()).collect();
             assert_eq!(fast, expected, "tokens diverged on {text:?}");
         }
     }
@@ -1124,10 +1123,133 @@ mod tests {
             let mut via_each = Vec::new();
             StandardTokenizer.tokenize_each(text, &mut |t| via_each.push(t.to_owned()));
             let mut via_query = Vec::new();
-            StandardTokenizer
-                .tokenize_each_query(text, &mut |t| via_query.push(t.into_owned()));
-            assert_eq!(via_tokenize, via_each, "tokenize vs tokenize_each on {text:?}");
-            assert_eq!(via_tokenize, via_query, "tokenize vs query path on {text:?}");
+            StandardTokenizer.tokenize_each_query(text, &mut |t| via_query.push(t.into_owned()));
+            assert_eq!(
+                via_tokenize, via_each,
+                "tokenize vs tokenize_each on {text:?}"
+            );
+            assert_eq!(
+                via_tokenize, via_query,
+                "tokenize vs query path on {text:?}"
+            );
+        }
+    }
+
+    /// Whether the analyzer picks the ASCII scan is decided for the
+    /// *whole input*, so the same word takes a different code path
+    /// depending on what else the text contains: `"don't"` alone goes
+    /// through the ASCII scan, `"don't café"` through the general
+    /// segmenter. Documents are indexed one way and queries tokenized
+    /// the other, so if the two paths disagreed on a shared word the
+    /// query would silently miss — no error, just lost recall. Pin that
+    /// a word's tokens do not depend on its neighbours' encoding.
+    #[test]
+    fn a_words_tokens_do_not_depend_on_non_ascii_elsewhere_in_the_text() {
+        for ascii_text in [
+            "don't stop",
+            "3.14 and 1,000",
+            "snake_case _leading trailing_",
+            "a.b.c A:B x''y",
+            "plain words here",
+            "MiXeD CaSe WORDS",
+            "hello",
+        ] {
+            // Fast path: the text is entirely ASCII.
+            let fast: Vec<String> = StandardTokenizer.tokenize(ascii_text).collect();
+            assert!(ascii_text.is_ascii(), "fixture must be ASCII");
+
+            // Slow path: the identical text plus one non-ASCII word, so
+            // the whole input falls back to the general segmenter. The
+            // ASCII words' tokens must come out the same.
+            for suffix in [" café", " Straße", " 中文"] {
+                let mixed = format!("{ascii_text}{suffix}");
+                assert!(!mixed.is_ascii(), "fixture must leave the ASCII path");
+                let slow: Vec<String> = StandardTokenizer.tokenize(&mixed).collect();
+                assert_eq!(
+                    slow[..fast.len()],
+                    fast[..],
+                    "{ascii_text:?} tokenized differently once {suffix:?} joined the text"
+                );
+            }
+        }
+    }
+
+    /// The ASCII scan runs 16 bytes at a time with a scalar tail for the
+    /// remainder, so a token's bytes can be split across the vector and
+    /// scalar paths depending only on where it sits in the buffer. Pad
+    /// the front through a full stride so every token visits both, and
+    /// require the tokens to be identical each time.
+    #[test]
+    fn ascii_scan_is_independent_of_alignment_across_the_simd_stride() {
+        const STRIDE: usize = 16;
+        for text in [
+            "don't 3.14 snake_case a.b.c MiXeD",
+            "the quick brown fox jumps over the lazy dog",
+            "a:b 1,000 x_y Z",
+        ] {
+            let baseline: Vec<String> = StandardTokenizer.tokenize(text).collect();
+            let ascii_baseline: Vec<String> = AsciiLowerTokenizer.tokenize(text).collect();
+            // One extra stride so the tail length cycles through every
+            // residue class mod 16.
+            for pad in 1..=STRIDE + 1 {
+                let padded = format!("{}{}", " ".repeat(pad), text);
+                assert_eq!(
+                    StandardTokenizer.tokenize(&padded).collect::<Vec<_>>(),
+                    baseline,
+                    "standard tokens shifted at pad {pad} for {text:?}"
+                );
+                assert_eq!(
+                    AsciiLowerTokenizer.tokenize(&padded).collect::<Vec<_>>(),
+                    ascii_baseline,
+                    "ascii_lower tokens shifted at pad {pad} for {text:?}"
+                );
+            }
+        }
+    }
+
+    /// Characters spanning every ASCII word-break class plus non-ASCII
+    /// letters from three scripts, so a generated string lands on either
+    /// code path and on the boundaries between them.
+    const MIXED_ALPHABET: &[char] = &[
+        'a', 'B', 'z', '1', '9', '_', ':', ',', ';', '.', '\'', ' ', '-', '"', 'é', 'Ä', 'ß', 'Σ',
+        '中', '数',
+    ];
+
+    proptest! {
+        /// Both code paths, against one oracle, for arbitrary mixed
+        /// input: whatever the analyzer emits must equal the general
+        /// UAX #29 segmenter's words, lowercased. Holding for every
+        /// input means the ASCII scan and the fallback also agree with
+        /// each other, which is the property the index and query sides
+        /// depend on.
+        #[test]
+        fn standard_tokens_match_the_general_segmenter_for_any_mixed_input(
+            indices in proptest::collection::vec(0..MIXED_ALPHABET.len(), 0..14)
+        ) {
+            let text: String = indices.iter().map(|&i| MIXED_ALPHABET[i]).collect();
+            let mut got = Vec::new();
+            StandardTokenizer.tokenize_each_inline(&text, |t| got.push(t.to_owned()));
+            let expected: Vec<String> =
+                text.unicode_words().map(|w| w.to_lowercase()).collect();
+            prop_assert_eq!(&got, &expected, "tokens diverged on {:?}", text);
+        }
+
+        /// Every entry point on the analyzer must agree on arbitrary
+        /// mixed input. Documents are indexed through `tokenize_each`
+        /// and queries run through `tokenize` / `tokenize_each_query`,
+        /// so a divergence here is lost recall rather than a failure.
+        #[test]
+        fn standard_entry_points_agree_for_any_mixed_input(
+            indices in proptest::collection::vec(0..MIXED_ALPHABET.len(), 0..14)
+        ) {
+            let text: String = indices.iter().map(|&i| MIXED_ALPHABET[i]).collect();
+            let via_tokenize: Vec<String> = StandardTokenizer.tokenize(&text).collect();
+            let mut via_each = Vec::new();
+            StandardTokenizer.tokenize_each(&text, &mut |t| via_each.push(t.to_owned()));
+            let mut via_query = Vec::new();
+            StandardTokenizer.tokenize_each_query(&text, &mut |t| via_query.push(t.into_owned()));
+            prop_assert_eq!(&via_tokenize, &via_each, "tokenize vs tokenize_each on {:?}", text);
+            prop_assert_eq!(&via_tokenize, &via_query, "tokenize vs query path on {:?}", text);
         }
     }
 

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -1014,9 +1014,7 @@ mod tests {
         for len in 1..=3usize {
             let mut counter = vec![0u8; len];
             loop {
-                for i in 0..len {
-                    buf[i] = counter[i];
-                }
+                buf[..len].copy_from_slice(&counter[..len]);
                 let text = std::str::from_utf8(&buf[..len]).expect("ascii is utf8");
                 assert_eq!(
                     ascii_fast_segments(text),
@@ -1054,8 +1052,8 @@ mod tests {
             let mut counter = vec![0usize; len];
             let mut buf = vec![0u8; len];
             loop {
-                for i in 0..len {
-                    buf[i] = alpha[counter[i]];
+                for (slot, &idx) in buf.iter_mut().zip(counter.iter()) {
+                    *slot = alpha[idx];
                 }
                 let text = std::str::from_utf8(&buf).expect("ascii is utf8");
                 assert_eq!(

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -5,8 +5,8 @@
 //! The parser lives here because the `+` / `-` clause sigils must be
 //! handled before tokenizing — the tokenizer splits on both.
 //!
-//! Ships two tokenizers: [`AsciiLowerTokenizer`] (the default) and
-//! [`StandardTokenizer`]. The [`Tokenizer`] trait is the extension
+//! Ships two tokenizers: [`StandardTokenizer`] (the default) and
+//! [`AsciiLowerTokenizer`]. The [`Tokenizer`] trait is the extension
 //! point for ICU / language-aware stemmers / custom char filters
 //! under the same trait without touching FTS code.
 //!
@@ -78,12 +78,13 @@ const TOKEN_SCRATCH_INITIAL_CAP: usize = 32;
 ///     callback body into the tokenizer scan loop.
 ///
 ///   - [`Tokenizer::as_any`] — downcast hatch so the FTS build path
-///     can take a monomorphic fast path when the tokenizer is the
-///     default [`AsciiLowerTokenizer`]. The fast path bypasses the
-///     `&mut dyn FnMut(&str)` indirection by calling the inherent
-///     [`AsciiLowerTokenizer::tokenize_each_inline`] method, whose
+///     can take a monomorphic fast path for either shipped tokenizer.
+///     It bypasses the `&mut dyn FnMut(&str)` indirection by calling
+///     the inherent `tokenize_each_inline` method
+///     ([`AsciiLowerTokenizer::tokenize_each_inline`],
+///     [`StandardTokenizer::tokenize_each_inline`]), whose
 ///     `F: FnMut(&str)` parameter lets LLVM inline the callback
-///     body straight into the tokenizer's per-byte scan. Custom
+///     body straight into the tokenizer's scan. Custom
 ///     tokenizers don't need to opt in — they just return `self`
 ///     and never get downcast.
 pub trait Tokenizer: Send + Sync + std::fmt::Debug + 'static {

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -702,6 +702,149 @@ pub fn tokenizer_for_name(name: &str) -> Option<Arc<dyn Tokenizer>> {
     }
 }
 
+// ── UAX #29 word breaks, restricted to ASCII ─────────────────────────
+//
+// Over ASCII the word-break property takes only seven values, so the
+// general segmenter's per-character property lookups collapse into one
+// 256-entry table and a handful of bit tests. `standard` is the default
+// analyzer and most corpora are predominantly ASCII, so this is the path
+// that decides ingest throughput. `ascii_word_segments` is verified
+// against `unicode_words` exhaustively in the tests below — the two must
+// agree exactly, or text would be indexed under one tokenization and
+// queried under another.
+
+/// Word_Break classes reachable from an ASCII byte, as disjoint bits so
+/// a rule can test a set membership with one `&`.
+const WB_OTHER: u8 = 0;
+/// `[A-Za-z]`.
+const WB_ALETTER: u8 = 1 << 0;
+/// `[0-9]`.
+const WB_NUMERIC: u8 = 1 << 1;
+/// `_` — joins to alphanumerics on either side and is kept *inside* the
+/// token (`_id` and `a_b` are each one word), unlike every other joiner.
+const WB_EXTEND_NUM_LET: u8 = 1 << 2;
+/// `:` — joins letters only.
+const WB_MID_LETTER: u8 = 1 << 3;
+/// `,` `;` — join digits only.
+const WB_MID_NUM: u8 = 1 << 4;
+/// `.` `'` — join letters *or* digits (MidNumLet plus Single_Quote,
+/// which are indistinguishable within ASCII).
+const WB_MID_NUM_LET: u8 = 1 << 5;
+
+/// `WB_ALETTER | WB_NUMERIC` — the classes that alone can carry a token.
+const WB_ALNUM: u8 = WB_ALETTER | WB_NUMERIC;
+
+/// Word_Break class per byte value. Non-ASCII bytes map to
+/// [`WB_OTHER`]; the ASCII scan is only entered for all-ASCII input, so
+/// those entries are never consulted.
+static ASCII_WORD_BREAK_CLASS: [u8; 256] = {
+    let mut table = [WB_OTHER; 256];
+    let mut b = 0usize;
+    while b < 128 {
+        table[b] = match b as u8 {
+            b'A'..=b'Z' | b'a'..=b'z' => WB_ALETTER,
+            b'0'..=b'9' => WB_NUMERIC,
+            b'_' => WB_EXTEND_NUM_LET,
+            b':' => WB_MID_LETTER,
+            b',' | b';' => WB_MID_NUM,
+            b'.' | b'\'' => WB_MID_NUM_LET,
+            _ => WB_OTHER,
+        };
+        b += 1;
+    }
+    table
+};
+
+#[inline(always)]
+fn wb_class(b: u8) -> u8 {
+    ASCII_WORD_BREAK_CLASS[b as usize]
+}
+
+/// Whether UAX #29 joins the bytes classed `a` and `b` (adjacent, `a`
+/// first) into one word. `prev` is the class before `a` and `next` the
+/// class after `b`, both [`WB_OTHER`] past the ends of the input — the
+/// mid-joiner rules are the only context-sensitive ones and need
+/// exactly one byte of lookaround on each side.
+#[inline(always)]
+fn wb_joined(prev: u8, a: u8, b: u8, next: u8) -> bool {
+    // WB5 / WB8 / WB9 / WB10 — letters and digits run together.
+    if a & WB_ALNUM != 0 && b & WB_ALNUM != 0 {
+        return true;
+    }
+    // WB13a / WB13b — `_` binds to alphanumerics and to itself.
+    if a & (WB_ALNUM | WB_EXTEND_NUM_LET) != 0 && b & WB_EXTEND_NUM_LET != 0 {
+        return true;
+    }
+    if a & WB_EXTEND_NUM_LET != 0 && b & WB_ALNUM != 0 {
+        return true;
+    }
+    // WB6 / WB7 — a single `:`/`.`/`'` between two letters (`don't`,
+    // `a.b`). Doubling it breaks, because the lookaround then sees the
+    // joiner rather than a letter.
+    if a & WB_ALETTER != 0 && b & (WB_MID_LETTER | WB_MID_NUM_LET) != 0 && next & WB_ALETTER != 0 {
+        return true;
+    }
+    if a & (WB_MID_LETTER | WB_MID_NUM_LET) != 0 && b & WB_ALETTER != 0 && prev & WB_ALETTER != 0 {
+        return true;
+    }
+    // WB11 / WB12 — the digit twin (`3.14`, `1,000`).
+    if a & WB_NUMERIC != 0 && b & (WB_MID_NUM | WB_MID_NUM_LET) != 0 && next & WB_NUMERIC != 0 {
+        return true;
+    }
+    if a & (WB_MID_NUM | WB_MID_NUM_LET) != 0 && b & WB_NUMERIC != 0 && prev & WB_NUMERIC != 0 {
+        return true;
+    }
+    // WB999 — break everywhere else.
+    false
+}
+
+/// Segment all-ASCII `bytes` on UAX #29 word boundaries, calling
+/// `f(start, end, has_upper)` for each segment that carries at least one
+/// alphanumeric. Segments of pure punctuation are dropped, matching
+/// `unicode_words`. `has_upper` reports whether the segment holds an
+/// upper-case byte, so a caller can borrow instead of case-folding.
+///
+/// Byte ranges rather than `&str` slices: the caller owns the input and
+/// can reslice it at whatever lifetime it needs, which keeps the
+/// zero-copy query path free of any lifetime juggling.
+///
+/// Callers must have established that the input is ASCII, so every index
+/// is a codepoint boundary.
+#[inline]
+fn ascii_word_segments<F: FnMut(usize, usize, bool)>(bytes: &[u8], mut f: F) {
+    let n = bytes.len();
+    let mut seg_start = 0usize;
+    let mut has_alnum = false;
+    let mut has_upper = false;
+    let mut prev = WB_OTHER;
+    let mut a = WB_OTHER;
+    for i in 0..n {
+        let cur = wb_class(bytes[i]);
+        if i > seg_start {
+            let next = if i + 1 < n {
+                wb_class(bytes[i + 1])
+            } else {
+                WB_OTHER
+            };
+            if !wb_joined(prev, a, cur, next) {
+                if has_alnum {
+                    f(seg_start, i, has_upper);
+                }
+                seg_start = i;
+                has_alnum = false;
+                has_upper = false;
+            }
+        }
+        has_alnum |= cur & WB_ALNUM != 0;
+        has_upper |= bytes[i].is_ascii_uppercase();
+        prev = a;
+        a = cur;
+    }
+    if has_alnum && seg_start < n {
+        f(seg_start, n, has_upper);
+    }
+}
+
 /// Unicode-aware tokenizer: UAX #29 word segmentation followed by full
 /// Unicode lowercasing, preserving non-ASCII text. See the module-level
 /// docs for the exact semantics and how it differs from
@@ -713,22 +856,34 @@ impl StandardTokenizer {
     pub fn new() -> Self {
         Self
     }
-}
 
-impl Tokenizer for StandardTokenizer {
-    fn name(&self) -> &'static str {
-        STANDARD_TOKENIZER
-    }
-
-    fn tokenize<'a>(&'a self, text: &'a str) -> Box<dyn Iterator<Item = String> + 'a> {
-        // `unicode_words` yields the UAX #29 word segments that contain
-        // alphanumerics — whitespace/punctuation-only segments are
-        // dropped. Lowercasing is full Unicode case folding, correct for
-        // non-ASCII letters, which are kept rather than dropped.
-        Box::new(text.unicode_words().map(str::to_lowercase))
-    }
-
-    fn tokenize_each(&self, text: &str, f: &mut dyn FnMut(&str)) {
+    /// Monomorphized token scan — the same tokens
+    /// [`Tokenizer::tokenize_each`] emits, but with a concrete `F` so
+    /// LLVM can inline the callback into the scan loop instead of
+    /// paying an indirect call per token. Every other entry point on
+    /// this tokenizer routes through here, so no two of them can
+    /// disagree about which tokens exist.
+    ///
+    /// All-ASCII input takes the table-driven ASCII word-break scan;
+    /// anything else falls back to the general UAX #29 segmenter. The
+    /// check is whole-input rather than per-chunk because a non-ASCII
+    /// character changes how its ASCII neighbours segment (`aéb` is one
+    /// word), so a chunk boundary could not be placed soundly.
+    #[inline]
+    pub fn tokenize_each_inline<F: FnMut(&str)>(&self, text: &str, mut f: F) {
+        if text.is_ascii() {
+            ascii_word_segments(text.as_bytes(), |start, end, has_upper| {
+                let seg = &text[start..end];
+                if has_upper {
+                    // Cased ASCII only, so `to_ascii_lowercase` agrees
+                    // with the Unicode fold the non-ASCII path applies.
+                    f(&seg.to_ascii_lowercase());
+                } else {
+                    f(seg);
+                }
+            });
+            return;
+        }
         let mut buf = String::new();
         for word in text.unicode_words() {
             // Borrow directly when every cased character is already
@@ -740,23 +895,65 @@ impl Tokenizer for StandardTokenizer {
                 f(word);
             } else {
                 buf.clear();
-                // Context-aware full-string lowercasing, matching
-                // `tokenize`. `str::to_lowercase` applies Unicode
-                // special-casing such as Final_Sigma (a word-final `Σ`
-                // lowercases to `ς`, but to `σ` elsewhere); a char-by-char
-                // fold has no word context and would emit `σ` in both
-                // spots. The two paths must agree — text is indexed
-                // through `tokenize_each` and queried through `tokenize`,
-                // so any divergence indexes a term under one form and
-                // searches it under another.
+                // Context-aware full-string lowercasing. `str::to_lowercase`
+                // applies Unicode special-casing such as Final_Sigma (a
+                // word-final `Σ` lowercases to `ς`, but to `σ` elsewhere);
+                // a char-by-char fold has no word context and would emit
+                // `σ` in both spots.
                 buf.push_str(&word.to_lowercase());
                 f(&buf);
             }
         }
     }
+}
+
+impl Tokenizer for StandardTokenizer {
+    fn name(&self) -> &'static str {
+        STANDARD_TOKENIZER
+    }
+
+    /// Collected rather than lazy: sharing one scan with the ingest
+    /// path is what guarantees a term is indexed and queried under the
+    /// same form, and the query strings this runs on are short.
+    fn tokenize<'a>(&'a self, text: &'a str) -> Box<dyn Iterator<Item = String> + 'a> {
+        let mut out = Vec::new();
+        self.tokenize_each_inline(text, |t| out.push(t.to_owned()));
+        Box::new(out.into_iter())
+    }
+
+    /// Trait-object dispatch path: delegates to the inherent
+    /// [`tokenize_each_inline`](Self::tokenize_each_inline) so the body
+    /// lives in one place. Callers holding a concrete
+    /// [`StandardTokenizer`] (or downcasting a `&dyn Tokenizer` via
+    /// [`Tokenizer::as_any`]) should call the inherent method directly
+    /// to skip the per-token `&mut dyn FnMut(&str)` indirection.
+    fn tokenize_each(&self, text: &str, f: &mut dyn FnMut(&str)) {
+        self.tokenize_each_inline(text, |s| f(s));
+    }
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    /// Zero-copy override for the query side: an already-lowercase
+    /// all-ASCII token borrows from `text`; only a token needing a case
+    /// fold is copied. Non-ASCII input keeps the general segmenter and
+    /// its owned folds.
+    fn tokenize_each_query<'q>(&self, text: &'q str, f: &mut dyn FnMut(Cow<'q, str>)) {
+        if text.is_ascii() {
+            ascii_word_segments(text.as_bytes(), |start, end, has_upper| {
+                // `text` outlives the callback, so the reslice carries
+                // the caller's `'q` with no lifetime gymnastics.
+                let seg: &'q str = &text[start..end];
+                if has_upper {
+                    f(Cow::Owned(seg.to_ascii_lowercase()));
+                } else {
+                    f(Cow::Borrowed(seg));
+                }
+            });
+            return;
+        }
+        self.tokenize_each_inline(text, |t| f(Cow::Owned(t.to_owned())));
     }
 }
 
@@ -774,6 +971,164 @@ mod tests {
         AsciiLowerTokenizer
             .tokenize_each_inline_positioned(text, |tok, pos| out.push((tok.to_owned(), pos)));
         out
+    }
+
+    // ---- ASCII word-break fast path vs the general segmenter ----
+    //
+    // `standard` indexes through the ASCII scan and may be queried
+    // through it too, so a single disagreement with `unicode_words`
+    // would index a term under one tokenization and search it under
+    // another. These verify the two exhaustively rather than by
+    // sampling: the class table is small enough that full coverage of
+    // short inputs is cheap, and every joiner rule is context-sensitive
+    // over at most one byte on each side, so short inputs are where any
+    // divergence has to show up.
+
+    /// Segments the fast path yields, as owned strings.
+    fn ascii_fast_segments(text: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        ascii_word_segments(text.as_bytes(), |start, end, _| {
+            out.push(text[start..end].to_owned());
+        });
+        out
+    }
+
+    /// What the general UAX #29 segmenter yields for the same input.
+    fn unicode_segments(text: &str) -> Vec<String> {
+        text.unicode_words().map(str::to_owned).collect()
+    }
+
+    /// One byte per Word_Break class the ASCII table can produce, plus
+    /// the shapes that stress the lookaround: letters, a digit, `_`,
+    /// `:`, `,`, `.`, `'`, a plain separator, and a space.
+    const WB_ALPHABET: &[u8] = b"aB1_:,.' ";
+
+    #[test]
+    fn ascii_fast_path_matches_unicode_words_for_every_short_input() {
+        // All 128 ASCII bytes at lengths 1..=3. The mid-joiner rules
+        // look at one byte either side of a boundary, so a three-byte
+        // window covers every rule's full context.
+        let mut buf = [0u8; 3];
+        for len in 1..=3usize {
+            let mut counter = vec![0u8; len];
+            loop {
+                for i in 0..len {
+                    buf[i] = counter[i];
+                }
+                let text = std::str::from_utf8(&buf[..len]).expect("ascii is utf8");
+                assert_eq!(
+                    ascii_fast_segments(text),
+                    unicode_segments(text),
+                    "segmentation diverged on {text:?} (bytes {:?})",
+                    &buf[..len]
+                );
+                // Odometer over 0..128 in each position.
+                let mut i = 0;
+                loop {
+                    if i == len {
+                        break;
+                    }
+                    counter[i] += 1;
+                    if counter[i] < 128 {
+                        break;
+                    }
+                    counter[i] = 0;
+                    i += 1;
+                }
+                if i == len {
+                    break;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ascii_fast_path_matches_unicode_words_for_longer_class_words() {
+        // Longer inputs over one representative byte per class, up to
+        // length 6 — chained joiners (`a.b.c`, `1,000,000`, `a__b`) and
+        // the doubling that must break.
+        let alpha = WB_ALPHABET;
+        for len in 4..=6usize {
+            let mut counter = vec![0usize; len];
+            let mut buf = vec![0u8; len];
+            loop {
+                for i in 0..len {
+                    buf[i] = alpha[counter[i]];
+                }
+                let text = std::str::from_utf8(&buf).expect("ascii is utf8");
+                assert_eq!(
+                    ascii_fast_segments(text),
+                    unicode_segments(text),
+                    "segmentation diverged on {text:?}"
+                );
+                let mut i = 0;
+                loop {
+                    if i == len {
+                        break;
+                    }
+                    counter[i] += 1;
+                    if counter[i] < alpha.len() {
+                        break;
+                    }
+                    counter[i] = 0;
+                    i += 1;
+                }
+                if i == len {
+                    break;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn standard_tokens_match_the_general_segmenter_on_mixed_text() {
+        // The whole-input ASCII check must not change what `standard`
+        // emits: an input with any non-ASCII byte takes the general
+        // segmenter, and an all-ASCII one must agree with it.
+        for text in [
+            "the quick brown fox",
+            "Don't stop 3.14 or 1,000,000 things",
+            "snake_case and _leading and trailing_",
+            "a.b.c A:B 1;2 x''y z--w",
+            "café résumé naïve Straße",
+            "mixed café and plain ascii 42",
+            "中文 text with ascii",
+            "",
+            "   ",
+            "___",
+            "!!!",
+        ] {
+            let mut fast = Vec::new();
+            StandardTokenizer.tokenize_each_inline(text, |t| fast.push(t.to_owned()));
+            let expected: Vec<String> = text
+                .unicode_words()
+                .map(|w| w.to_lowercase())
+                .collect();
+            assert_eq!(fast, expected, "tokens diverged on {text:?}");
+        }
+    }
+
+    #[test]
+    fn standard_entry_points_agree_with_each_other() {
+        // `tokenize`, `tokenize_each` and `tokenize_each_query` all
+        // route through one scan; this pins that they stay in lockstep,
+        // since a divergence between the index and query paths is
+        // silent recall loss rather than a visible failure.
+        for text in [
+            "Don't PANIC 3.14",
+            "snake_case Mixed CASE",
+            "café AU lait",
+            "a.b,c 1.2,3",
+        ] {
+            let via_tokenize: Vec<String> = StandardTokenizer.tokenize(text).collect();
+            let mut via_each = Vec::new();
+            StandardTokenizer.tokenize_each(text, &mut |t| via_each.push(t.to_owned()));
+            let mut via_query = Vec::new();
+            StandardTokenizer
+                .tokenize_each_query(text, &mut |t| via_query.push(t.into_owned()));
+            assert_eq!(via_tokenize, via_each, "tokenize vs tokenize_each on {text:?}");
+            assert_eq!(via_tokenize, via_query, "tokenize vs query path on {text:?}");
+        }
     }
 
     // ---- StandardTokenizer (Unicode-aware) ----

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -799,6 +799,28 @@ fn wb_joined(prev: u8, a: u8, b: u8, next: u8) -> bool {
     false
 }
 
+/// The joiner bytes — the classes whose effect depends on what sits
+/// either side of them. A 16-byte window holding none of these and no
+/// non-ASCII byte contains only `WB_ALETTER`, `WB_NUMERIC` and
+/// `WB_OTHER`, and over just those classes UAX #29 collapses to
+/// WB5/WB8/WB9/WB10: maximal runs of `[A-Za-z0-9]`, which is exactly
+/// [`AsciiLowerTokenizer`]'s rule. That equivalence is what lets the
+/// vector lane below drive such windows from bitmasks and leave only
+/// the neighbourhood of a joiner to the byte-at-a-time path.
+const WB_JOINER_BYTES: [u8; 6] = [b'_', b':', b',', b';', b'.', b'\''];
+
+/// Low-16 mask with the bottom `k` bits set (`k <= 16`).
+#[inline(always)]
+fn low_mask(k: usize) -> u32 {
+    ((1u32 << k) - 1) & LANE_BITMASK
+}
+
+/// Count of consecutive set bits starting at bit 0, capped at 16.
+#[inline(always)]
+fn leading_run(m: u32) -> usize {
+    ((!m) & (LANE_BITMASK | 0x1_0000)).trailing_zeros() as usize
+}
+
 /// Segment all-ASCII `bytes` on UAX #29 word boundaries, calling
 /// `f(start, end, has_upper)` for each segment that carries at least one
 /// alphanumeric. Segments of pure punctuation are dropped, matching
@@ -809,10 +831,150 @@ fn wb_joined(prev: u8, a: u8, b: u8, next: u8) -> bool {
 /// can reslice it at whatever lifetime it needs, which keeps the
 /// zero-copy query path free of any lifetime juggling.
 ///
+/// Runs a 16-byte vector lane over windows free of joiners and
+/// non-ASCII bytes (see [`WB_JOINER_BYTES`]) and the byte-at-a-time
+/// [`ascii_word_segments_scalar`] elsewhere. The two are held
+/// equivalent by an exhaustive differential test.
+///
 /// Callers must have established that the input is ASCII, so every index
 /// is a codepoint boundary.
 #[inline]
 fn ascii_word_segments<F: FnMut(usize, usize, bool)>(bytes: &[u8], mut f: F) {
+    const LANES: usize = 16;
+    let n = bytes.len();
+    // The segment under construction. `pure_alnum` tracks whether every
+    // byte of it so far is `[A-Za-z0-9]`, which is the precondition for
+    // handing the segment across into the vector lane: only then does
+    // "continues iff the next byte is alphanumeric" describe it.
+    let mut seg_start = 0usize;
+    let mut has_alnum = false;
+    let mut has_upper = false;
+    let mut pure_alnum = true;
+    let mut i = 0usize;
+
+    while i < n {
+        // The vector lane needs a full window, and needs the open
+        // segment to be one it can reason about: either nothing is open,
+        // or what is open is a plain alphanumeric run.
+        let lane_ok = i + LANES <= n && (i == seg_start || (pure_alnum && has_alnum));
+        if lane_ok {
+            // SAFETY: `i + LANES <= n` checked above, so 16 bytes from
+            // `bytes.as_ptr().add(i)` stay in bounds. The cast and deref
+            // copy the array by value into the SIMD register.
+            let arr: [u8; LANES] = unsafe { *(bytes.as_ptr().add(i) as *const [u8; LANES]) };
+            let chunk = u8x16::from(arr);
+            let is_digit = chunk.simd_ge(u8x16::splat(b'0')) & chunk.simd_le(u8x16::splat(b'9'));
+            let is_upper = chunk.simd_ge(u8x16::splat(b'A')) & chunk.simd_le(u8x16::splat(b'Z'));
+            let is_lower = chunk.simd_ge(u8x16::splat(b'a')) & chunk.simd_le(u8x16::splat(b'z'));
+            let mut is_complex = (chunk & u8x16::splat(NON_ASCII_BYTE_MIN))
+                .simd_eq(u8x16::splat(NON_ASCII_BYTE_MIN));
+            for joiner in WB_JOINER_BYTES {
+                is_complex |= chunk.simd_eq(u8x16::splat(joiner));
+            }
+            if (is_complex.to_bitmask() & LANE_BITMASK) == 0 {
+                let alnum = (is_digit | is_upper | is_lower).to_bitmask() & LANE_BITMASK;
+                let upper = is_upper.to_bitmask() & LANE_BITMASK;
+                let mut consumed = 0usize;
+
+                // Resolve the run handed in from the previous window.
+                if i > seg_start {
+                    if alnum & 1 == 0 {
+                        // Byte `i` is neither alphanumeric nor a joiner,
+                        // so it cannot extend the run: the segment ends.
+                        f(seg_start, i, has_upper);
+                        seg_start = i;
+                        has_alnum = false;
+                        has_upper = false;
+                    } else {
+                        let run = leading_run(alnum);
+                        has_upper |= (upper & low_mask(run)) != 0;
+                        if run == LANES {
+                            // Still open at the window's end; carry on.
+                            i += LANES;
+                            continue;
+                        }
+                        f(seg_start, i + run, has_upper);
+                        seg_start = i + run;
+                        has_alnum = false;
+                        has_upper = false;
+                        consumed = run;
+                    }
+                }
+
+                // Every further run lies wholly inside the window, so
+                // the byte after it is a plain separator and no
+                // lookahead past the window is needed — except for a run
+                // touching the last byte, which is carried instead.
+                let mut rest = alnum & !low_mask(consumed);
+                let mut carried = false;
+                while rest != 0 {
+                    let start = rest.trailing_zeros() as usize;
+                    let len = leading_run(rest >> start);
+                    let end = start + len;
+                    let run_upper = (upper >> start) & low_mask(len) != 0;
+                    if end >= LANES {
+                        seg_start = i + start;
+                        has_alnum = true;
+                        has_upper = run_upper;
+                        pure_alnum = true;
+                        carried = true;
+                        break;
+                    }
+                    f(i + start, i + end, run_upper);
+                    rest &= !low_mask(end);
+                }
+                if !carried {
+                    seg_start = i + LANES;
+                    has_alnum = false;
+                    has_upper = false;
+                    pure_alnum = true;
+                }
+                i += LANES;
+                continue;
+            }
+        }
+
+        // Byte-at-a-time step, identical in effect to the scalar
+        // segmenter: decide whether byte `i` joins the previous one and
+        // close the segment when it does not.
+        let cur = wb_class(bytes[i]);
+        if i > seg_start {
+            let a = wb_class(bytes[i - 1]);
+            let prev = if i >= 2 {
+                wb_class(bytes[i - 2])
+            } else {
+                WB_OTHER
+            };
+            let next = if i + 1 < n {
+                wb_class(bytes[i + 1])
+            } else {
+                WB_OTHER
+            };
+            if !wb_joined(prev, a, cur, next) {
+                if has_alnum {
+                    f(seg_start, i, has_upper);
+                }
+                seg_start = i;
+                has_alnum = false;
+                has_upper = false;
+                pure_alnum = true;
+            }
+        }
+        has_alnum |= cur & WB_ALNUM != 0;
+        has_upper |= bytes[i].is_ascii_uppercase();
+        pure_alnum &= bytes[i].is_ascii_alphanumeric();
+        i += 1;
+    }
+
+    if has_alnum && seg_start < n {
+        f(seg_start, n, has_upper);
+    }
+}
+
+/// Byte-at-a-time reference for [`ascii_word_segments`], kept as the
+/// implementation the vector lane is tested against. Same contract.
+#[cfg(test)]
+fn ascii_word_segments_scalar<F: FnMut(usize, usize, bool)>(bytes: &[u8], mut f: F) {
     let n = bytes.len();
     let mut seg_start = 0usize;
     let mut has_alnum = false;
@@ -986,6 +1148,126 @@ mod tests {
     // short inputs is cheap, and every joiner rule is context-sensitive
     // over at most one byte on each side, so short inputs are where any
     // divergence has to show up.
+
+    /// Segments from the byte-at-a-time reference, as owned strings.
+    fn ascii_scalar_segments(text: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        ascii_word_segments_scalar(text.as_bytes(), |start, end, _| {
+            out.push(text[start..end].to_owned());
+        });
+        out
+    }
+
+    /// Segments plus their `has_upper` flag, from both engines, so the
+    /// borrow-versus-case-fold decision is compared too and not just the
+    /// boundaries.
+    fn ascii_fast_flags(text: &str) -> Vec<(usize, usize, bool)> {
+        let mut out = Vec::new();
+        ascii_word_segments(text.as_bytes(), |s, e, u| out.push((s, e, u)));
+        out
+    }
+    fn ascii_scalar_flags(text: &str) -> Vec<(usize, usize, bool)> {
+        let mut out = Vec::new();
+        ascii_word_segments_scalar(text.as_bytes(), |s, e, u| out.push((s, e, u)));
+        out
+    }
+
+    /// The vector lane runs 16 bytes at a time and hands partial runs
+    /// across window boundaries, so a divergence from the reference
+    /// would most likely appear only at a particular length or offset.
+    /// Sweep every length across two full strides against a byte
+    /// alphabet that includes each joiner, so windows land clean,
+    /// dirty, and split across the boundary.
+    #[test]
+    fn simd_lane_matches_the_scalar_reference_across_window_boundaries() {
+        const STRIDE: usize = 16;
+        let alphabet = b"aB1_:,.' z9";
+        // A deterministic pseudo-random walk over the alphabet gives
+        // mixed windows; the fixed seed keeps a failure reproducible.
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            alphabet[(state % alphabet.len() as u64) as usize]
+        };
+        for len in 0..=(3 * STRIDE + 3) {
+            for _trial in 0..300 {
+                let buf: Vec<u8> = (0..len).map(|_| next()).collect();
+                let text = std::str::from_utf8(&buf).expect("ascii is utf8");
+                assert_eq!(
+                    ascii_fast_flags(text),
+                    ascii_scalar_flags(text),
+                    "vector lane diverged from the reference on {text:?}"
+                );
+            }
+        }
+    }
+
+    /// Exhaustive where it matters: the five bytes straddling the
+    /// 16-byte window boundary, over every arrangement of the class
+    /// alphabet, against three different fillers and a range of
+    /// lengths. Varying the whole string instead would be astronomically
+    /// many cases for no extra coverage — the lane's only
+    /// position-dependent behaviour is how it hands a run across that
+    /// boundary, and these are the bytes that decide it.
+    #[test]
+    fn simd_lane_matches_the_scalar_reference_around_the_window_boundary() {
+        const BOUNDARY: usize = 16;
+        const VARY: usize = 5;
+        const VARY_AT: usize = BOUNDARY - 2;
+        let alphabet = b"a1_. ";
+        for filler in [b'a', b' ', b'B'] {
+            for len in (BOUNDARY + VARY)..=(BOUNDARY + VARY + 4) {
+                let mut counter = [0usize; VARY];
+                loop {
+                    let mut buf = vec![filler; len];
+                    for (k, &idx) in counter.iter().enumerate() {
+                        buf[VARY_AT + k] = alphabet[idx];
+                    }
+                    let text = std::str::from_utf8(&buf).expect("ascii is utf8");
+                    assert_eq!(
+                        ascii_fast_flags(text),
+                        ascii_scalar_flags(text),
+                        "vector lane diverged from the reference on {text:?}"
+                    );
+                    let mut k = 0;
+                    loop {
+                        if k == VARY {
+                            break;
+                        }
+                        counter[k] += 1;
+                        if counter[k] < alphabet.len() {
+                            break;
+                        }
+                        counter[k] = 0;
+                        k += 1;
+                    }
+                    if k == VARY {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// And the reference itself still agrees with the general
+    /// segmenter, so the chain vector lane == reference == `unicode_words`
+    /// is closed at both links.
+    #[test]
+    fn scalar_reference_matches_unicode_words_on_joiner_shapes() {
+        for text in [
+            "don't 3.14 a_b A:B 1,000 x''y a..b",
+            "_lead trail_ a1_2b 3.14.15 1,000,000",
+            "the quick brown fox jumps over the lazy dog again and again",
+        ] {
+            assert_eq!(
+                ascii_scalar_segments(text),
+                unicode_segments(text),
+                "on {text:?}"
+            );
+        }
+    }
 
     /// Segments the fast path yields, as owned strings.
     fn ascii_fast_segments(text: &str) -> Vec<String> {
@@ -1223,7 +1505,7 @@ mod tests {
         /// depend on.
         #[test]
         fn standard_tokens_match_the_general_segmenter_for_any_mixed_input(
-            indices in proptest::collection::vec(0..MIXED_ALPHABET.len(), 0..14)
+            indices in proptest::collection::vec(0..MIXED_ALPHABET.len(), 0..52)
         ) {
             let text: String = indices.iter().map(|&i| MIXED_ALPHABET[i]).collect();
             let mut got = Vec::new();
@@ -1239,7 +1521,7 @@ mod tests {
         /// so a divergence here is lost recall rather than a failure.
         #[test]
         fn standard_entry_points_agree_for_any_mixed_input(
-            indices in proptest::collection::vec(0..MIXED_ALPHABET.len(), 0..14)
+            indices in proptest::collection::vec(0..MIXED_ALPHABET.len(), 0..52)
         ) {
             let text: String = indices.iter().map(|&i| MIXED_ALPHABET[i]).collect();
             let via_tokenize: Vec<String> = StandardTokenizer.tokenize(&text).collect();

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -680,10 +680,11 @@ fn is_token_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric()
 }
 
-/// Name of the default ASCII tokenizer in a column's FTS config.
+/// Name of the ASCII-only tokenizer in a column's FTS config.
 pub const ASCII_LOWER_TOKENIZER: &str = "ascii_lower";
 
-/// Name of the Unicode-aware standard tokenizer in a column's FTS config.
+/// Name of the Unicode-aware standard tokenizer in a column's FTS
+/// config, and the analyzer a column gets when none is named.
 pub const STANDARD_TOKENIZER: &str = "standard";
 
 /// Resolve a tokenizer name to an instance, or `None` for an

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -56,7 +56,7 @@ use crate::{
                 self as fts_reader, BoolMode, ClauseLists, FtsReader, MatchWork, OrCursorSet,
                 PreparedClauses, TermPattern,
             },
-            tokenize::{AsciiLowerTokenizer, Tokenizer},
+            tokenize::Tokenizer,
         },
         vector::{
             layout::VectorLayout,
@@ -1095,15 +1095,15 @@ impl SuperfileReader {
         k: usize,
         mode: BoolMode,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        // Tokenize with the target column's configured tokenizer so
-        // query terms match how the column was indexed (ascii_lower /
-        // standard). Falls back to ascii_lower when there is no FTS
-        // index or column; the search then fails downstream as before.
-        let tok: Arc<dyn Tokenizer> = self
-            .fts
-            .as_ref()
-            .and_then(|f| f.column_tokenizer(column).ok())
-            .unwrap_or_else(|| Arc::new(AsciiLowerTokenizer));
+        // Tokenize with the target column's configured tokenizer so query
+        // terms match how the column was indexed (ascii_lower / standard).
+        // A column this superfile has no full-text index for fails here,
+        // where the reason is still nameable, rather than after a pass with
+        // some other column's analyzer.
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        let tok: Arc<dyn Tokenizer> = fts.column_tokenizer(column)?;
 
         // Split the query into clause lists and resolve the bare
         // tokens' polarity from the default operator. The parsed
@@ -1343,12 +1343,13 @@ impl SuperfileReader {
     ) -> Result<(Vec<u32>, MatchWork), ReadError> {
         // Pass 1 — candidate rows via the index: the term-AND of the
         // string's tokens (a superset of the exact matches). Tokenize
-        // with the column's configured tokenizer to match the index.
-        let tok: Arc<dyn Tokenizer> = self
-            .fts
-            .as_ref()
-            .and_then(|f| f.column_tokenizer(column).ok())
-            .unwrap_or_else(|| Arc::new(AsciiLowerTokenizer));
+        // with the column's configured tokenizer to match the index; a
+        // column with no full-text index here has no dictionary to prune
+        // through, so it fails rather than pruning with a foreign analyzer.
+        let fts = self
+            .fts()
+            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        let tok: Arc<dyn Tokenizer> = fts.column_tokenizer(column)?;
         let tokens: Vec<String> = tok.tokenize(value).collect();
         let (candidates, work): (Vec<u32>, MatchWork) = if tokens.is_empty() {
             // No tokens to prune with: every row is a candidate.
@@ -3168,12 +3169,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exact_match_on_non_text_column_errors() {
-        // `exact_match` only supports LargeUtf8 columns. Querying the
-        // Decimal128 `doc_id` column drives the non-LargeUtf8 downcast
-        // failure. The value tokenizes to nothing (punctuation only),
-        // so every row becomes a candidate and the verify pass reaches
-        // the downcast on the decimal column.
+    async fn exact_match_on_a_column_without_a_full_text_index_errors() {
+        // `exact_match` prunes through the column's own term dictionary,
+        // so a column with no full-text index — here the Decimal128
+        // `doc_id` — is rejected by name. It used to tokenize the value
+        // with a fallback analyzer and fail later on the text downcast,
+        // which said nothing about the real problem.
         let bytes = build_simple_fts_only_superfile();
         let r = SuperfileReader::open(bytes).expect("open");
         let err = r
@@ -3181,10 +3182,37 @@ mod tests {
             .await
             .expect_err("expected error");
         match err {
-            ReadError::Io(e) => {
-                assert!(e.to_string().contains("not LargeUtf8"));
+            ReadError::Fts(inner) => {
+                let rendered = inner.to_string();
+                assert!(
+                    rendered.contains("doc_id"),
+                    "error must name the column: {rendered}"
+                );
             }
-            other => panic!("expected ReadError::Io, got {:?}", other),
+            other => panic!("expected ReadError::Fts, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bm25_hits_on_a_column_without_a_full_text_index_errors() {
+        // Same rule for the scored path: without an index there is no
+        // analyzer to tokenize the query with, so it fails up front
+        // rather than after a pass with some other column's analyzer.
+        let bytes = build_simple_fts_only_superfile();
+        let r = SuperfileReader::open(bytes).expect("open");
+        let err = r
+            .bm25_hits_async("doc_id", "anything", 10, BoolMode::Or)
+            .await
+            .expect_err("expected error");
+        match err {
+            ReadError::Fts(inner) => {
+                let rendered = inner.to_string();
+                assert!(
+                    rendered.contains("doc_id"),
+                    "error must name the column: {rendered}"
+                );
+            }
+            other => panic!("expected ReadError::Fts, got {other:?}"),
         }
     }
 }

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -714,8 +714,9 @@ impl ManifestSnapshot {
         // manifest's stamped digest. The all-zero stored
         // hash bypasses validation (legacy + synthetic
         // fixtures).
-        let expected_hash = options_hash::compute_options_hash(&options, &list.partition_strategy);
-        if let Err(mismatch) = options_hash::verify_options_hash(expected_hash, list.options_hash) {
+        if let Err(mismatch) =
+            options_hash::verify_options_hash(&options, &list.partition_strategy, list.options_hash)
+        {
             return Err(ManifestLoadError::ContentHashMismatch {
                 expected: mismatch.expected,
                 actual: mismatch.actual,

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -594,9 +594,9 @@ mod tests {
         let standard = compute_options_hash(&fts_opts_analyzer("standard"), &strat);
         assert_ne!(ascii.0, standard.0, "analyzer choice must change the hash");
 
-        // Explicit `ascii_lower` is the same declaration the default
-        // produces, so it hashes identically — the analyzer is in the
-        // identity by name, never by "is it the default".
+        // Two declarations naming the same analyzer hash identically —
+        // the analyzer enters the identity by name, never by whether it
+        // happens to be the engine default.
         let ascii_explicit = compute_options_hash(&fts_opts_analyzer("ascii_lower"), &strat);
         assert_eq!(
             ascii.0, ascii_explicit.0,

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -24,6 +24,9 @@
 //! "schema"       | n_fields u64 | for each field: name_len u64 | name | dt_str_len u64 | dt_str | nullable u8
 //! "id_column"    | len u64 | bytes
 //! "fts_columns"  | count u64 | for each: name_len u64 | name
+//! "fts_positions"  | for each column: u8         (only when some column opts in)
+//! "fts_analyzers"  | for each column: len u64 | name   (whenever there is an FTS column)
+//! "fts_stored"     | for each column: u8         (only when some column is index-only)
 //! "vector_columns" | count u64 | for each: name_len u64 | name | dim u64 | rot_seed u64 | metric_len u64 | metric_str | codec
 //! "partition_strategy" | variant_tag | per-variant fields
 //! ```
@@ -59,10 +62,60 @@ use crate::{
     },
 };
 
+/// How the per-column analyzer block is encoded. A full-text table's
+/// analyzers are part of its identity under the current encoding; an
+/// earlier one left the block out whenever every column used
+/// `ascii_lower`, so a hash stamped then is a byte-stream short of one
+/// block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnalyzerBlock {
+    /// Current: one name per full-text column, always.
+    Always,
+    /// Superseded: omitted when every column used `ascii_lower`.
+    OmittedWhenAllAsciiLower,
+}
+
 /// Compute the canonical options-hash from `opts` + the
 /// resolved `strategy`. See the module-level docs for the
 /// encoding layout.
 pub fn compute_options_hash(opts: &SupertableOptions, strategy: &PartitionStrategy) -> ContentHash {
+    compute(opts, strategy, AnalyzerBlock::Always)
+}
+
+/// The hash `opts` would have stamped under the superseded analyzer-block
+/// rule, or `None` when the two rules produce the same stream (no
+/// full-text columns, or one of them already names a non-`ascii_lower`
+/// analyzer).
+///
+/// Bridge for one release so a table stamped by an earlier engine still
+/// opens; the next commit re-stamps it under the current rule. Delete
+/// this together with its two call sites' fallback comparison once no
+/// stored hash predates the current rule — nothing else may depend on
+/// it.
+fn superseded_options_hash(
+    opts: &SupertableOptions,
+    strategy: &PartitionStrategy,
+) -> Option<ContentHash> {
+    if opts.fts_columns.is_empty()
+        || opts
+            .fts_columns
+            .iter()
+            .any(|c| c.analyzer != ASCII_LOWER_TOKENIZER)
+    {
+        return None;
+    }
+    Some(compute(
+        opts,
+        strategy,
+        AnalyzerBlock::OmittedWhenAllAsciiLower,
+    ))
+}
+
+fn compute(
+    opts: &SupertableOptions,
+    strategy: &PartitionStrategy,
+    analyzer_block: AnalyzerBlock,
+) -> ContentHash {
     let mut buf: Vec<u8> = Vec::with_capacity(256);
 
     // 1. schema (field-by-field).
@@ -100,19 +153,23 @@ pub fn compute_options_hash(opts: &SupertableOptions, strategy: &PartitionStrate
             buf.push(c.positions as u8);
         }
     }
-    // 3c. per-column analyzer names — appended as a tagged block, and
-    //     ONLY when some column uses a non-default (non-ascii_lower)
-    //     analyzer. An all-ascii_lower table's stream stays
-    //     byte-identical to hashes stamped before per-column analyzers
-    //     existed, so pre-existing manifests keep verifying; a table
-    //     built with a different analyzer hashes differently (its
-    //     superfiles are tokenized differently, so the options identity
-    //     must differ too).
-    if opts
-        .fts_columns
-        .iter()
-        .any(|c| c.analyzer != ASCII_LOWER_TOKENIZER)
-    {
+    // 3c. per-column analyzer names — a tagged block whenever the table
+    //     has any full-text column. The analyzer decides how the
+    //     postings were tokenized, so it belongs in the table's identity
+    //     unconditionally: reopening with a different analyzer must
+    //     mismatch, and no analyzer name may be inferred from the block
+    //     being absent. (`AnalyzerBlock::OmittedWhenAllAsciiLower`
+    //     reproduces the earlier stream for the one-release bridge in
+    //     `superseded_options_hash`.)
+    let emit_analyzers = !opts.fts_columns.is_empty()
+        && match analyzer_block {
+            AnalyzerBlock::Always => true,
+            AnalyzerBlock::OmittedWhenAllAsciiLower => opts
+                .fts_columns
+                .iter()
+                .any(|c| c.analyzer != ASCII_LOWER_TOKENIZER),
+        };
+    if emit_analyzers {
         push_tag(&mut buf, b"fts_analyzers");
         for c in &opts.fts_columns {
             push_str(&mut buf, &c.analyzer);
@@ -202,26 +259,32 @@ pub fn compute_options_hash(opts: &SupertableOptions, strategy: &PartitionStrate
     ContentHash(*h.as_bytes())
 }
 
-/// Compare `expected` (caller-side recomputed from current
-/// options) against `actual` (stored on the manifest list).
+/// Check `stored` — the hash a manifest list or a drain checkpoint
+/// carries — against what `opts` + `strategy` hash to now.
 ///
-/// Returns `Ok(())` if the two match, OR if `actual` is the
-/// all-zero sentinel (older manifests + synthetic test
-/// fixtures bypass validation).
+/// Returns `Ok(())` if the two match, if `stored` was stamped under the
+/// superseded analyzer-block rule (see [`superseded_options_hash`]), or
+/// if `stored` is the all-zero sentinel (older manifests + synthetic
+/// test fixtures bypass validation).
 pub fn verify_options_hash(
-    expected: ContentHash,
-    actual: ContentHash,
+    opts: &SupertableOptions,
+    strategy: &PartitionStrategy,
+    stored: ContentHash,
 ) -> Result<(), OptionsHashMismatch> {
-    if actual.0 == [0u8; 32] {
+    if stored.0 == [0u8; 32] {
         // Legacy / synthetic — skip validation.
         return Ok(());
     }
-    if expected.0 == actual.0 {
+    let expected = compute_options_hash(opts, strategy);
+    if expected.0 == stored.0 {
+        return Ok(());
+    }
+    if superseded_options_hash(opts, strategy).is_some_and(|h| h.0 == stored.0) {
         return Ok(());
     }
     Err(OptionsHashMismatch {
         expected: expected.to_hex(),
-        actual: actual.to_hex(),
+        actual: stored.to_hex(),
     })
 }
 
@@ -435,12 +498,19 @@ mod tests {
             Field::new("title", DataType::LargeUtf8, false),
             Field::new("subtitle", DataType::LargeUtf8, false),
         ]));
+        // The golden below is an all-ascii_lower table's stream, so the
+        // fixture names that analyzer rather than taking the engine
+        // default, which is `standard`.
         let opts = |title_pos: bool, subtitle_pos: bool| {
             SupertableOptions::new(
                 schema_two.clone(),
                 vec![
-                    FtsConfig::new("title").positions(title_pos),
-                    FtsConfig::new("subtitle").positions(subtitle_pos),
+                    FtsConfig::new("title")
+                        .analyzer(ASCII_LOWER_TOKENIZER)
+                        .positions(title_pos),
+                    FtsConfig::new("subtitle")
+                        .analyzer(ASCII_LOWER_TOKENIZER)
+                        .positions(subtitle_pos),
                 ],
                 vec![],
             )
@@ -453,11 +523,13 @@ mod tests {
         assert_ne!(h_tf.0, h_ft.0, "which column is positional must matter");
 
         // Golden: the all-false stream contains no positions block, so
-        // this value equals what pre-positions code produced for the
-        // same options. If this assertion ever fails, the encoding
-        // drifted and every existing table would fail open-validation.
-        let hex: String = h_ff.0.iter().map(|b| format!("{b:02x}")).collect();
-        assert_eq!(hex, ALL_FALSE_GOLDEN_HEX);
+        // under the superseded analyzer rule this fixture hashes to
+        // exactly what pre-positions code produced. If this assertion
+        // ever fails, the encoding drifted and every table stamped by an
+        // earlier release would fail open-validation.
+        let superseded =
+            superseded_options_hash(&opts(false, false), &time_range()).expect("all ascii_lower");
+        assert_eq!(superseded.to_hex(), SUPERSEDED_GOLDEN_HEX);
     }
 
     /// The stored flag follows the same only-when-non-default rule as
@@ -476,9 +548,11 @@ mod tests {
                 schema_two.clone(),
                 vec![
                     FtsConfig::new("title")
+                        .analyzer(ASCII_LOWER_TOKENIZER)
                         .positions(false)
                         .stored(title_stored),
                     FtsConfig::new("subtitle")
+                        .analyzer(ASCII_LOWER_TOKENIZER)
                         .positions(false)
                         .stored(subtitle_stored),
                 ],
@@ -492,18 +566,22 @@ mod tests {
         assert_ne!(h_tt.0, h_ft.0, "index-only column must change the hash");
         assert_ne!(h_ft.0, h_tf.0, "which column is index-only must matter");
 
-        // All-stored equals the pre-flag golden — existing manifests
-        // keep verifying.
-        let hex: String = h_tt.0.iter().map(|b| format!("{b:02x}")).collect();
-        assert_eq!(hex, ALL_FALSE_GOLDEN_HEX);
+        // All-stored carries no `fts_stored` block, so under the
+        // superseded analyzer rule it lands on the same golden the
+        // positions test pins — the two only-when-non-default blocks
+        // compose.
+        let superseded =
+            superseded_options_hash(&opts(true, true), &time_range()).expect("all ascii_lower");
+        assert_eq!(superseded.to_hex(), SUPERSEDED_GOLDEN_HEX);
     }
 
-    /// blake3 of the two-fts-column, all-positions-false fixture in
-    /// [`compute_options_hash_positions_flag`], captured from the
-    /// encoding as it existed before the positions flag — the
-    /// all-false stream appends no positions block, so the bytes are
-    /// identical by construction.
-    const ALL_FALSE_GOLDEN_HEX: &str =
+    /// blake3 of the two-fts-column, all-positions-false, all-stored,
+    /// all-`ascii_lower` fixture used by the two tests above, under the
+    /// superseded analyzer-block rule — which appends none of the three
+    /// only-when-non-default blocks, so the bytes are identical to what
+    /// the encoding produced before any of them existed. Pins the bridge
+    /// [`verify_options_hash`] relies on to keep such a table openable.
+    const SUPERSEDED_GOLDEN_HEX: &str =
         "a89715d00cba061aed0b06910a2fde77a9b980c1f7a25c1d5eca901790c6f24a";
 
     #[test]
@@ -516,14 +594,56 @@ mod tests {
         let standard = compute_options_hash(&fts_opts_analyzer("standard"), &strat);
         assert_ne!(ascii.0, standard.0, "analyzer choice must change the hash");
 
-        // Explicit ascii_lower equals the default: the analyzer block is
-        // emitted only for a non-ascii_lower analyzer, so all-ascii_lower
-        // tables keep the pre-analyzer hash (see ALL_FALSE_GOLDEN_HEX).
+        // Explicit `ascii_lower` is the same declaration the default
+        // produces, so it hashes identically — the analyzer is in the
+        // identity by name, never by "is it the default".
         let ascii_explicit = compute_options_hash(&fts_opts_analyzer("ascii_lower"), &strat);
         assert_eq!(
             ascii.0, ascii_explicit.0,
-            "all-ascii_lower hash must be unchanged"
+            "the same analyzer name must hash the same"
         );
+
+        // And the analyzer block is present even for an all-ascii_lower
+        // table: its hash differs from the superseded stream that left
+        // the block out.
+        let superseded = superseded_options_hash(&fts_opts(), &strat).expect("all ascii_lower");
+        assert_ne!(
+            ascii.0, superseded.0,
+            "the analyzer block must be part of an ascii_lower table's identity"
+        );
+    }
+
+    #[test]
+    fn superseded_options_hash_only_applies_where_the_rules_differ() {
+        let strat = time_range();
+        // No full-text columns ⇒ no analyzer block under either rule, so
+        // a vector-only or plain table's identity is untouched and needs
+        // no bridge.
+        let no_fts = SupertableOptions::new(schema_title_only(), vec![], vec![]).expect("opts");
+        assert_eq!(superseded_options_hash(&no_fts, &strat), None);
+
+        // A non-ascii_lower analyzer already emitted the block, so its
+        // stored hash is already the current one.
+        assert_eq!(
+            superseded_options_hash(&fts_opts_analyzer("standard"), &strat),
+            None
+        );
+    }
+
+    #[test]
+    fn verify_options_hash_accepts_a_superseded_analyzer_block() {
+        // An all-ascii_lower table stamped by an earlier release carries
+        // the block-less hash. It must still open — the next commit
+        // re-stamps it under the current rule.
+        let opts = fts_opts();
+        let strat = time_range();
+        let stored = superseded_options_hash(&opts, &strat).expect("all ascii_lower");
+        verify_options_hash(&opts, &strat, stored).expect("superseded hash accepted");
+
+        // The bridge is exact, not a blanket pass: a genuinely different
+        // table still mismatches.
+        let other = fts_opts_analyzer("standard");
+        verify_options_hash(&other, &strat, stored).expect_err("wrong analyzer must mismatch");
     }
 
     #[test]
@@ -734,7 +854,7 @@ mod tests {
     fn verify_options_hash_accepts_matching_pair() {
         let opts = fts_opts();
         let h = compute_options_hash(&opts, &time_range());
-        verify_options_hash(h, h).expect("matching pair accepted");
+        verify_options_hash(&opts, &time_range(), h).expect("matching pair accepted");
     }
 
     #[test]
@@ -743,9 +863,9 @@ mod tests {
         // all-zero stored hash bypass validation: the caller's
         // computed hash can be anything.
         let opts = fts_opts();
-        let computed = compute_options_hash(&opts, &time_range());
         let zero = ContentHash([0u8; 32]);
-        verify_options_hash(computed, zero).expect("zero sentinel bypasses verification");
+        verify_options_hash(&opts, &time_range(), zero)
+            .expect("zero sentinel bypasses verification");
     }
 
     #[test]
@@ -753,17 +873,19 @@ mod tests {
         // Two clearly different hashes must produce
         // OptionsHashMismatch whose Display includes both hex
         // strings prefixed with `blake3:`.
-        let h_a = ContentHash([1u8; 32]);
-        let h_b = ContentHash([2u8; 32]);
-        let err = verify_options_hash(h_a, h_b).expect_err("mismatch must error");
+        let opts = fts_opts();
+        let expected = compute_options_hash(&opts, &time_range());
+        let stored = ContentHash([2u8; 32]);
+        let err =
+            verify_options_hash(&opts, &time_range(), stored).expect_err("mismatch must error");
         let rendered = format!("{err}");
         assert!(
             rendered.contains("options_hash mismatch"),
             "got: {rendered}"
         );
         assert!(rendered.contains("blake3:"), "got: {rendered}");
-        // 32 bytes of 0x01 → 64-char hex string.
-        assert!(rendered.contains(&"01".repeat(32)), "got: {rendered}");
+        assert!(rendered.contains(&expected.to_hex()), "got: {rendered}");
+        // 32 bytes of 0x02 → 64-char hex string.
         assert!(rendered.contains(&"02".repeat(32)), "got: {rendered}");
     }
 
@@ -773,9 +895,9 @@ mod tests {
         // `impl std::error::Error for OptionsHashMismatch` — a
         // no-op body but the impl block needs to compile and
         // the dyn-error conversion needs to succeed.
-        let h_a = ContentHash([3u8; 32]);
-        let h_b = ContentHash([4u8; 32]);
-        let err = verify_options_hash(h_a, h_b).expect_err("mismatch");
+        let opts = fts_opts();
+        let err = verify_options_hash(&opts, &time_range(), ContentHash([4u8; 32]))
+            .expect_err("mismatch");
         let dyn_err: Box<dyn Error> = Box::new(err);
         assert!(dyn_err.to_string().contains("options_hash mismatch"));
     }

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -66,7 +66,7 @@ use crate::{
     superfile::{
         OpenOptions,
         builder::{BuilderOptions, FtsConfig, VectorConfig},
-        fts::tokenize::{AsciiLowerTokenizer, Tokenizer, tokenizer_for_name},
+        fts::tokenize::{Tokenizer, tokenizer_for_name},
         vector::layout::VectorLayout,
     },
     supertable::{
@@ -875,15 +875,6 @@ impl SupertableOptions {
             .iter()
             .find(|c| c.column == column)
             .and_then(|c| tokenizer_for_name(&c.analyzer))
-    }
-
-    /// Tokenizer configured for `column`, for tokenizing query text so
-    /// it matches how the column was indexed. Falls back to the ASCII
-    /// default when `column` is not a registered FTS column; a caller that
-    /// must distinguish that case uses [`Self::try_fts_tokenizer_for`].
-    pub fn fts_tokenizer_for(&self, column: &str) -> Arc<dyn Tokenizer> {
-        self.try_fts_tokenizer_for(column)
-            .unwrap_or_else(|| Arc::new(AsciiLowerTokenizer))
     }
 
     /// Attach a disk cache for storage-backed reads.

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -190,12 +190,14 @@ impl CandidatePlan {
     /// provider's filters together) into one plan. `fts_cols` is the set
     /// of FTS-indexed column names; `resolve` maps an FTS column to the
     /// tokenizer it was indexed with, so per-column analyzers lower query
-    /// text the same way the column was tokenized at ingest. Empty
-    /// `fts_cols` ⇒ no FTS columns ⇒ always [`Unbounded`].
+    /// text the same way the column was tokenized at ingest. A column
+    /// `resolve` cannot answer for has no index to bound against, so its
+    /// predicate lowers to [`Unbounded`] — no analyzer is assumed on its
+    /// behalf. Empty `fts_cols` ⇒ no FTS columns ⇒ always [`Unbounded`].
     pub(crate) fn from_filters(
         filters: &[Expr],
         fts_cols: &HashSet<&str>,
-        resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+        resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
     ) -> CandidatePlan {
         if fts_cols.is_empty() {
             return CandidatePlan::Unbounded;
@@ -617,7 +619,7 @@ async fn expand_like(
 fn lower(
     expr: &Expr,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
 ) -> CandidatePlan {
     match expr {
         Expr::BinaryExpr(be) => match be.op {
@@ -647,7 +649,7 @@ fn eq_leaf(
     left: &Expr,
     right: &Expr,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
 ) -> CandidatePlan {
     let (column, value) = match (left, right) {
         (Expr::Column(c), Expr::Literal(v, _)) => (&c.name, v),
@@ -661,7 +663,7 @@ fn eq_leaf(
 fn in_list_leaf(
     il: &InList,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
 ) -> CandidatePlan {
     let Expr::Column(c) = il.expr.as_ref() else {
         return CandidatePlan::Unbounded;
@@ -688,7 +690,7 @@ fn in_list_leaf(
 fn like_leaf(
     like: &Like,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
 ) -> CandidatePlan {
     // `NOT LIKE` excludes rows — no term set bounds an exclusion.
     if like.negated {
@@ -712,7 +714,9 @@ fn like_leaf(
     let Some(pattern) = scalar_str(v) else {
         return CandidatePlan::Unbounded;
     };
-    let tok = resolve(&c.name);
+    let Some(tok) = resolve(&c.name) else {
+        return CandidatePlan::Unbounded;
+    };
     let Some(analyzer) = Analyzer::of(tok.as_ref()) else {
         return CandidatePlan::Unbounded;
     };
@@ -903,7 +907,7 @@ fn terms_all(
     column: &str,
     value: &ScalarValue,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
 ) -> CandidatePlan {
     if !fts_cols.contains(column) {
         return CandidatePlan::Unbounded;
@@ -911,7 +915,9 @@ fn terms_all(
     let Some(s) = scalar_str(value) else {
         return CandidatePlan::Unbounded;
     };
-    let tok = resolve(column);
+    let Some(tok) = resolve(column) else {
+        return CandidatePlan::Unbounded;
+    };
     let tokens: Vec<String> = tok.tokenize(s).collect();
     if tokens.is_empty() {
         return CandidatePlan::Unbounded;
@@ -979,7 +985,7 @@ fn collapse(mut flat: Vec<CandidatePlan>, is_and: bool) -> CandidatePlan {
 pub(crate) fn like_prune_leaves(
     filters: &[Expr],
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
 ) -> Vec<PruneLeaf> {
     let mut out = Vec::new();
     for filter in filters {
@@ -993,7 +999,7 @@ pub(crate) fn like_prune_leaves(
 fn collect_like_leaves(
     expr: &Expr,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
     out: &mut Vec<PruneLeaf>,
 ) {
     match expr {
@@ -1028,8 +1034,8 @@ mod tests {
 
     /// Resolver for the lowering tests: every column tokenizes with the
     /// ASCII-lower analyzer.
-    fn ascii_resolver(_col: &str) -> Arc<dyn Tokenizer> {
-        Arc::new(AsciiLowerTokenizer)
+    fn ascii_resolver(_col: &str) -> Option<Arc<dyn Tokenizer>> {
+        Some(Arc::new(AsciiLowerTokenizer))
     }
 
     fn plan(expr: Expr) -> CandidatePlan {
@@ -1207,8 +1213,8 @@ mod tests {
     }
 
     /// Resolver for the Unicode-aware analyzer.
-    fn standard_resolver(_col: &str) -> Arc<dyn Tokenizer> {
-        Arc::new(StandardTokenizer)
+    fn standard_resolver(_col: &str) -> Option<Arc<dyn Tokenizer>> {
+        Some(Arc::new(StandardTokenizer))
     }
 
     fn standard_plan(expr: Expr) -> CandidatePlan {
@@ -1617,11 +1623,11 @@ mod tests {
         // `title` is analyzed with the Unicode-aware standard tokenizer,
         // which keeps non-ASCII letters; ascii_lower drops the whole
         // token. The lowering must pick the column's own analyzer.
-        let resolve = |col: &str| -> Arc<dyn Tokenizer> {
+        let resolve = |col: &str| -> Option<Arc<dyn Tokenizer>> {
             if col == "title" {
-                Arc::new(StandardTokenizer)
+                Some(Arc::new(StandardTokenizer))
             } else {
-                Arc::new(AsciiLowerTokenizer)
+                Some(Arc::new(AsciiLowerTokenizer))
             }
         };
         let bounded =

--- a/src/supertable/query/exec/vector_exec.rs
+++ b/src/supertable/query/exec/vector_exec.rs
@@ -405,7 +405,7 @@ impl ExecutionPlan for VectorSearchExec {
                 .map(|c| c.column.as_str())
                 .collect();
             let plan = CandidatePlan::from_filters(&filters, &fts_cols, &|col| {
-                manifest.options.fts_tokenizer_for(col)
+                manifest.options.try_fts_tokenizer_for(col)
             });
             let hits = match plan {
                 CandidatePlan::Unbounded => {

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -1195,12 +1195,17 @@ impl SupertableReader {
         ),
         QueryError,
     > {
-        let clauses = self
-            .manifest()
-            .options
-            .fts_tokenizer_for(column)
-            .parse(query)
-            .into_clauses(mode);
+        let manifest = self.manifest();
+        // Same up-front check as the scored path: without a full-text index
+        // on `column` there is no analyzer to parse the query with, and no
+        // postings to match it against.
+        let Some(tokenizer) = manifest.options.try_fts_tokenizer_for(column) else {
+            return Err(QueryError::InvalidQuery(no_fts_index_message(
+                column,
+                &manifest.options.fts_columns,
+            )));
+        };
+        let clauses = tokenizer.parse(query).into_clauses(mode);
         // Drop repeated tokens within each clause role. Unranked
         // matching is set-valued — an AND/OR/exclude over a term repeated
         // in the query (e.g. `+to +be +or +not +to +be`) is idempotent —
@@ -1567,11 +1572,15 @@ impl SupertableReader {
         value: &str,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
         let manifest = self.manifest();
-        let term_strings: Vec<String> = manifest
-            .options
-            .fts_tokenizer_for(column)
-            .tokenize(value)
-            .collect();
+        // `exact_match` prunes through the column's own term dictionary, so
+        // a column with no full-text index has nothing to prune with.
+        let Some(tokenizer) = manifest.options.try_fts_tokenizer_for(column) else {
+            return Err(QueryError::InvalidQuery(no_fts_index_message(
+                column,
+                &manifest.options.fts_columns,
+            )));
+        };
+        let term_strings: Vec<String> = tokenizer.tokenize(value).collect();
         // Tokens prune superfiles via the term bloom (AND); a token-less
         // value (e.g. punctuation only) can't prune, so keep all.
         let leaves = if term_strings.is_empty() {

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -410,7 +410,10 @@ impl SupertableProvider {
             {
                 // Per-column analyzer: prune with the tokenizer this column
                 // was indexed with, not a single table-wide default.
-                let tok = opts.fts_tokenizer_for(&pred.column);
+                let Some(tok) = opts.try_fts_tokenizer_for(&pred.column) else {
+                    leaves.push(PruneLeaf::Scalar(pred));
+                    continue;
+                };
                 let terms: Vec<String> = tok.tokenize(literal).collect();
                 if !terms.is_empty() {
                     leaves.push(PruneLeaf::TermPresence {
@@ -440,13 +443,13 @@ impl SupertableProvider {
             filters,
             &self.schema,
             &self.fts_cols_set(),
-            &|col| opts.fts_tokenizer_for(col),
+            &|col| opts.try_fts_tokenizer_for(col),
         ));
 
         // `LIKE` on an FTS column: a term bloom for the pattern's complete
         // tokens and a lex-range check for a prefix token.
         leaves.extend(like_prune_leaves(filters, &self.fts_cols_set(), &|col| {
-            opts.fts_tokenizer_for(col)
+            opts.try_fts_tokenizer_for(col)
         }));
 
         leaves.extend(exprs_to_null_leaves(filters, &self.schema));
@@ -894,7 +897,7 @@ impl TableProvider for SupertableProvider {
         // the superfile). See `crate::supertable::query::candidate`.
         let opts = &self.manifest.options;
         let candidate_plan = CandidatePlan::from_filters(filters, &self.fts_cols_set(), &|col| {
-            opts.fts_tokenizer_for(col)
+            opts.try_fts_tokenizer_for(col)
         });
         // A `LIKE` leaf is bound to each superfile's dictionary once, up
         // front, so the estimate and the evaluation below share one walk.
@@ -1497,7 +1500,7 @@ pub(crate) fn exprs_to_value_set_leaves(
     filters: &[Expr],
     schema: &SchemaRef,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
 ) -> Vec<PruneLeaf> {
     let mut out = Vec::new();
 
@@ -1515,7 +1518,7 @@ fn collect_value_set_leaves(
     expr: &Expr,
     schema: &SchemaRef,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
     out: &mut Vec<PruneLeaf>,
 ) {
     match expr {
@@ -1571,13 +1574,14 @@ fn emit_value_set_leaves(
     column: String,
     values: Vec<ScalarValue>,
     fts_cols: &HashSet<&str>,
-    resolve: &dyn Fn(&str) -> Arc<dyn Tokenizer>,
+    resolve: &dyn Fn(&str) -> Option<Arc<dyn Tokenizer>>,
     out: &mut Vec<PruneLeaf>,
 ) {
-    if fts_cols.contains(column.as_str()) {
-        // Per-column analyzer: tokenize the value set with this column's
-        // own tokenizer so the bloom probe matches how it was indexed.
-        let tok = resolve(&column);
+    // Per-column analyzer: tokenize the value set with this column's own
+    // tokenizer so the bloom probe matches how it was indexed. A column
+    // `resolve` cannot answer for gets no bloom leaf — probing it with
+    // some other analyzer's tokens could drop a matching superfile.
+    if let Some(tok) = resolve(&column).filter(|_| fts_cols.contains(column.as_str())) {
         let terms = unique_tokens(tok.as_ref(), values.iter().filter_map(scalar_as_str));
         if !terms.is_empty() {
             out.push(PruneLeaf::TermPresence {
@@ -1771,8 +1775,8 @@ mod tests {
 
     /// Per-column tokenizer resolver for the pruning-walker tests: every
     /// column resolves to the default ASCII-lower analyzer.
-    fn ascii_resolver(_col: &str) -> Arc<dyn Tokenizer> {
-        default_tokenizer()
+    fn ascii_resolver(_col: &str) -> Option<Arc<dyn Tokenizer>> {
+        Some(default_tokenizer())
     }
 
     /// `view_string_schema` views scalar `Utf8`/`LargeUtf8` columns as
@@ -2291,11 +2295,11 @@ mod tests {
             Field::new("body", DataType::Utf8, true),
         ]));
         let fts = HashSet::from(["title", "body"]);
-        let resolve = |c: &str| -> Arc<dyn Tokenizer> {
+        let resolve = |c: &str| -> Option<Arc<dyn Tokenizer>> {
             if c == "title" {
-                Arc::new(StandardTokenizer)
+                Some(Arc::new(StandardTokenizer))
             } else {
-                Arc::new(AsciiLowerTokenizer)
+                Some(Arc::new(AsciiLowerTokenizer))
             }
         };
 

--- a/src/supertable/query/provider.rs
+++ b/src/supertable/query/provider.rs
@@ -2481,13 +2481,15 @@ mod tests {
             1,
             "a wildcard-free LIKE prunes like the equality"
         );
-        // Under the default `ascii_lower` analyzer an open-edged token
-        // cannot be required (a run holding a non-ASCII byte is dropped
-        // whole), so a substring pattern keeps every superfile.
+        // An open-edged token is not required as a term here: this
+        // fixture's stored text is tiny against its vocabulary, so the
+        // dictionary walk that would widen the token to the terms it
+        // sits inside is not worth taking and the token is left to the
+        // scan. Every superfile therefore survives.
         assert_eq!(
             rt.block_on(provider.surviving_superfile_count(&[col("title").like(lit("%mango%"))])),
             3,
-            "an open-edged LIKE token under ascii_lower prunes nothing"
+            "an open-edged LIKE token left to the scan prunes nothing"
         );
     }
 

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -414,7 +414,7 @@ mod tests {
         let s = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, true)]));
         let expr = col("x").eq(lit(5_i64)).or(col("x").eq(lit(205_i64)));
         let leaves =
-            exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), &|_| default_tokenizer());
+            exprs_to_value_set_leaves(&[expr], &s, &HashSet::new(), &|_| Some(default_tokenizer()));
         let (column, values) = match leaves.as_slice() {
             [PruneLeaf::ScalarValueSet { column, values }] => (column.as_str(), values.clone()),
             _ => panic!("expected one ScalarValueSet leaf from the OR"),

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -10175,7 +10175,7 @@ mod tests {
         let fts_cols: HashSet<&str> = HashSet::from(["title"]);
         let filters = [col("title").eq(lit("doc"))];
         let plan = CandidatePlan::from_filters(&filters, &fts_cols, &|col| {
-            manifest.options.fts_tokenizer_for(col)
+            manifest.options.try_fts_tokenizer_for(col)
         });
 
         let mut q = vec![0.0f32; dim];

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -175,7 +175,7 @@ use crate::{
                 WIDTH_LAW_KS,
             },
             options_hash,
-            part::{self as part_mod, PartId},
+            part::{self as part_mod, ContentHash, PartId},
             term_stats,
         },
         query::{
@@ -3765,7 +3765,16 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
                 remote_state.checkpoint.shard_count
             )));
         }
-        if remote_state.checkpoint.options_hash != current_options_hash {
+        // Same acceptance rule as reopening the table: a checkpoint
+        // written before the engine's current options encoding still
+        // identifies this table, so a drain that spans an upgrade
+        // resumes instead of wedging on a re-encoded digest.
+        let checkpoint_hash = ContentHash::from_hex(&remote_state.checkpoint.options_hash);
+        let recognized = checkpoint_hash.is_some_and(|stored| {
+            options_hash::verify_options_hash(user_inner.options.as_ref(), &user_strategy, stored)
+                .is_ok()
+        });
+        if !recognized {
             return Err(BuildError::Store(format!(
                 "drain checkpoint options hash {} != current {}",
                 remote_state.checkpoint.options_hash, current_options_hash

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -98,7 +98,7 @@ use crate::{
     storage::StorageProvider,
     superfile::{
         builder::{FtsConfig, VectorConfig},
-        fts::tokenize::{AsciiLowerTokenizer, Tokenizer},
+        fts::tokenize::{StandardTokenizer, Tokenizer},
         vector::{distance::Metric, rerank_codec::RerankCodec},
     },
     supertable::{
@@ -190,8 +190,10 @@ pub fn decimal128_id_field(name: &str) -> Field {
     Field::new(name, DataType::Decimal128(38, 0), false)
 }
 
-/// The default tokenizer used in tests + benches:
-/// `AsciiLowerTokenizer` wrapped in `Arc<dyn Tokenizer>`.
+/// The engine's default tokenizer, for tests + benches:
+/// `StandardTokenizer` wrapped in `Arc<dyn Tokenizer>`. A fixture that
+/// exercises ASCII-only tokenization names `AsciiLowerTokenizer`
+/// itself rather than relying on this.
 ///
 /// Callers passing this into `BuilderOptions::new` wrap in
 /// `Some(...)` at the call site:
@@ -201,7 +203,7 @@ pub fn decimal128_id_field(name: &str) -> Field {
 ///                     Some(default_tokenizer()));
 /// ```
 pub fn default_tokenizer() -> Arc<dyn Tokenizer> {
-    Arc::new(AsciiLowerTokenizer)
+    Arc::new(StandardTokenizer)
 }
 
 /// Default `VectorConfig` for test fixtures: `dim=16`,

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -86,9 +86,12 @@ async fn create_table_posts_expected_shape() {
     Mock::given(method("POST"))
         .and(path("/v1/create_table/mydb"))
         .and(header("authorization", format!("Bearer {KEY}").as_str()))
+        // The client names every column's analyzer rather than sending a
+        // bare column name, so the server builds the index with the
+        // analyzer the client resolved and never with a default of its own.
         .and(body_partial_json(json!({
             "table_name": "posts",
-            "indexes": {"fts": ["id"]},
+            "indexes": {"fts": [{"column": "id", "analyzer": "standard"}]},
         })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .expect(1)

--- a/tests/superfile/fts/standard_tokenizer.rs
+++ b/tests/superfile/fts/standard_tokenizer.rs
@@ -4,7 +4,7 @@
 //! BM25 oracle for the `standard` (UAX#29) analyzer.
 //!
 //! Every other oracle in this suite builds and queries under the
-//! default `ascii_lower` tokenizer. This module builds the superfile
+//! `ascii_lower` tokenizer. This module builds the superfile
 //! *and* indexes the brute-force reference under [`StandardTokenizer`],
 //! over a corpus whose text (non-ASCII letters, punctuation, digits)
 //! the two analyzers segment differently — so the reader's standard

--- a/tests/superfile/pipeline.rs
+++ b/tests/superfile/pipeline.rs
@@ -589,7 +589,7 @@ fn add_batch_from_reader_mergeability_fts_analyzer_mismatch() {
     let opts = BuilderOptions::new(
         pipeline_schema(),
         "doc_id",
-        vec![FtsConfig::new("body")], // ascii_lower default
+        vec![FtsConfig::new("body").analyzer("ascii_lower")],
         vec![],
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
@@ -670,7 +670,9 @@ fn add_batch_from_reader_mergeability_fts_presence_mismatch() {
 /// postings.
 #[test]
 fn fts_merge_rejects_mixed_analyzers() {
-    let a = Arc::new(one_row_superfile_with(FtsConfig::new("body")));
+    let a = Arc::new(one_row_superfile_with(
+        FtsConfig::new("body").analyzer("ascii_lower"),
+    ));
     let b = Arc::new(one_row_superfile_with(
         FtsConfig::new("body").analyzer("standard"),
     ));


### PR DESCRIPTION
## What

The default FTS analyzer moves from `ascii_lower` to `standard` (Unicode
UAX #29), and every place that *inferred* an analyzer is deleted first, so
no line of code has to remember which name used to be the default.

`ascii_lower` silently drops every non-ASCII token — `café`, `naïve`, all
CJK — so the old default was a recall hole rather than a preference. It
stays a fully supported analyzer; it just has to be asked for by name.

## Making the analyzer explicit

Each of these sites used to mean "the default", which is exactly what was
about to change under them:

| Site | Before | Now |
|---|---|---|
| Superfile footer `inf.fts.columns[].tokenizer` | `serde(default)` → `ascii_lower` | required — a missing key is a malformed file, not an old one |
| Table record's analyzer list | short list → `ascii_lower` per column | must name one analyzer per full-text column; `open_table` rejects and names the table |
| Options hash | analyzer block emitted only for a non-`ascii_lower` column | always emitted for a table with full-text columns |
| Remote transport | bare column name when `ascii_lower` + stored | always `{column, analyzer}` |
| `fts_tokenizer_for` | `unwrap_or(AsciiLowerTokenizer)` | deleted; callers use `try_fts_tokenizer_for` |

On the last one: a fallback analyzer could only ever prune with tokens the
index never wrote, so callers now treat a column with no full-text index as
unbounded for pruning, and `InvalidQuery` for a search. `bm25_hits_async`
and `exact_match` on the superfile reader fail where the reason is still
nameable rather than after a pass with some other column's analyzer.

## The options-hash bridge

Always emitting the analyzer block changes the digest of every existing
all-`ascii_lower` table. A hash stamped under the earlier rule is still
accepted for one release, and `build_list` re-stamps the current rule on the
next commit, so nothing has to be rewritten by hand. The acceptance is
labelled in-place with the condition for its removal. The drain
checkpoint's identity check goes through the same acceptance, so a drain
spanning an upgrade resumes instead of wedging on a re-encoded digest.

## Existing tables

Unaffected. They open, query, append and compact with the analyzer they
recorded — `BuilderOptions::new_from_reader` recovers it from the source
superfile, so compaction and `optimize` carry it forward whatever the
engine default is, and `check_fts_carry_compat` still refuses to merge two
analyzers. Nothing rewrites what a table recorded about its analyzer.

## Bindings

No signature change: Python's `analyzer=None` and Node's omitted `analyzer`
already meant "engine default", so both inherit the new one. Docs updated;
the fixtures that specifically exercise ASCII-only tokenization now name
`ascii_lower` explicitly instead of leaning on the default.

## Version

Minor bump to 0.7.0 across crate, Node and Python (`scripts/release_prep.py
--package all`), since a bare column declaration now tokenizes differently.

## Tests

- Footer without `tokenizer` is rejected, and the error names the field.
- `open_table` on a record whose analyzer list is short errors, naming the
  table and what is missing.
- The analyzer block is part of an all-`ascii_lower` table's identity; the
  earlier block-less digest still verifies, and is exact rather than a
  blanket pass (a table with a different analyzer still mismatches). The
  golden that pinned the pre-flag byte stream now pins it through the
  superseded encoding, which is what it was always describing.
- The transport names every column's analyzer, whichever it resolved to.
- `bm25_hits_async` / `exact_match` on a column with no full-text index
  error and name the column.
- End to end: a column declared without an analyzer keeps non-ASCII text,
  and diverges from an explicit `ascii_lower` on the same corpus.

The `remote`-feature lanes are the ones to watch here: the wire tests
compile only under `--features remote`, so `make test-remote` (not a plain
`cargo test`) is what grades the transport change. `make version-sync` and
`make public-api` green.

## Follow-up

The one-release hash acceptance comes out once no stored digest predates
the current rule.

