### PR TITLE
README: point the VectorDBBench link at the results viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Supertable FTS; the SQL shapes are `agg_max_title` (metadata), `WHERE key = ?` (
 
 ![Vector search p99 vs vector databases, VectorDBBench Cohere 1M](docs/assets/readme/compare-vdb.svg)
 
-[VectorDBBench](https://zilliz.com/vdbbench-leaderboard?dataset=vectorSearch)
+[VectorDBBench](https://vdbbench-viewer-q6unoyyhua-uc.a.run.app/results)
 ([Repro](https://github.com/infino-ai/retrievalbench))
 
 ![Quantized vector indexes vs embedded libraries, dbpedia-1536 100K, same queries and ground truth](docs/assets/readme/compare-embedded.svg)


### PR DESCRIPTION
The upstream Zilliz VectorDBBench PR that adds Infino's client to the public leaderboard — https://github.com/zilliztech/VectorDBBench/pull/863 — is still pending, so the public board does not yet carry Infino's run. Until it merges, the `VectorDBBench` link under "Against other engines" points readers at a board that has every engine except ours.

This repoints that one link to our hosted results viewer, so the source behind the vector-search comparison chart is actually reachable. One line, README.md:

```
-[VectorDBBench](https://zilliz.com/vdbbench-leaderboard?dataset=vectorSearch)
+[VectorDBBench](https://vdbbench-viewer-q6unoyyhua-uc.a.run.app/results)
```

The viewer link is verified reachable (HTTP 200).

Temporary: revert to the public leaderboard link once #863 lands.
