### PR TITLE
fts: say global where the BM25 statistics default is documented

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -229,11 +229,11 @@ JSON metrics land in `target/infino-bench/<bench>.json` (local only).
 
 _Host: unknown CPU · 16C/16T · macos/aarch64_
 
-Engine top-k graded against a streaming BM25 oracle over the whole corpus, tie-aware (a hit is any returned doc scoring at least the oracle's k-th score). `recall vs BM25` = `Bm25Stats::Global` against textbook BM25 with exact doc lengths — the user-facing quality, which pays for the one-byte length quantization and per-superfile avgdl. `recall (default stats)` = the same under the default `PerSuperfile` idf. `recall vs engine BM25` = `Global` against BM25 with the engine's stored (quantized) lengths, a hit allowed to fall short of the k-th score by the avgdl residual (5.0% at this scale: the oracle normalizes with the corpus-wide average length, the engine with each superfile's own) — gated at 0.99: below it the kernels disagree with their own formula. `max score Δ` = largest relative gap between an engine score and that reference for the same doc — gated at the same 5.0%.
+Engine top-k graded against a streaming BM25 oracle over the whole corpus, tie-aware (a hit is any returned doc scoring at least the oracle's k-th score). `recall vs BM25` = `Bm25Stats::Global` against textbook BM25 with exact doc lengths — the user-facing quality, which pays for the one-byte length quantization and per-superfile avgdl. `recall (per-superfile stats)` = the same under segment-local `PerSuperfile` idf (the pre-0.7 default). `recall vs engine BM25` = `Global` against BM25 with the engine's stored (quantized) lengths, a hit allowed to fall short of the k-th score by the avgdl residual (5.0% at this scale: the oracle normalizes with the corpus-wide average length, the engine with each superfile's own) — gated at 0.99: below it the kernels disagree with their own formula. `max score Δ` = largest relative gap between an engine score and that reference for the same doc — gated at the same 5.0%.
 
 **k = 10**
 
-| Query | matches | recall vs BM25 | recall (default stats) | recall vs engine BM25 | max score Δ |
+| Query | matches | recall vs BM25 | recall (per-superfile stats) | recall vs engine BM25 | max score Δ |
 | --- | --- | --- | --- | --- | --- |
 | stopword | 8.4M | 0.9000 | 0.0000 | 1.0000 | 0.02% |
 | common | 2.1M | 1.0000 | 0.1000 | 1.0000 | 0.04% |
@@ -256,7 +256,7 @@ Engine top-k graded against a streaming BM25 oracle over the whole corpus, tie-a
 
 **k = 100**
 
-| Query | matches | recall vs BM25 | recall (default stats) | recall vs engine BM25 | max score Δ |
+| Query | matches | recall vs BM25 | recall (per-superfile stats) | recall vs engine BM25 | max score Δ |
 | --- | --- | --- | --- | --- | --- |
 | stopword | 8.4M | 0.8800 | 0.0300 | 1.0000 | 0.03% |
 | common | 2.1M | 0.9500 | 0.4000 | 1.0000 | 0.05% |
@@ -279,7 +279,7 @@ Engine top-k graded against a streaming BM25 oracle over the whole corpus, tie-a
 
 **k = 1000**
 
-| Query | matches | recall vs BM25 | recall (default stats) | recall vs engine BM25 | max score Δ |
+| Query | matches | recall vs BM25 | recall (per-superfile stats) | recall vs engine BM25 | max score Δ |
 | --- | --- | --- | --- | --- | --- |
 | stopword | 8.4M | 0.9160 | 0.0620 | 1.0000 | 0.05% |
 | common | 2.1M | 0.9750 | 0.6860 | 1.0000 | 0.10% |

--- a/benches/utils/fts_quality.rs
+++ b/benches/utils/fts_quality.rs
@@ -33,7 +33,7 @@
 //! | column | definition |
 //! |---|---|
 //! | recall vs BM25 | engine top-k under `Global` graded against T — the user-facing quality, including the quantization and avgdl costs |
-//! | recall (default stats) | the same under `PerSuperfile` — the default mode's sharded-idf drift |
+//! | recall (per-superfile stats) | the same under `PerSuperfile` — the opt-in mode's sharded-idf drift |
 //! | recall vs engine BM25 | engine top-k under `Global` graded against Q, a hit allowed to fall short of the k-th score by the avgdl residual — must be ≈ 1.0; a drop is a kernel or pruning bug. **Gated.** |
 //! | max score Δ | largest relative gap between an engine score and Q for the same document (`Global`). **Gated** at the avgdl residual. |
 //!

--- a/infino-node/infino/index.ts
+++ b/infino-node/infino/index.ts
@@ -21,8 +21,8 @@ const STREAM = "stream";
 export type Metric = "cosine" | "l2sq" | "negdot";
 /** Boolean mode for multi-term FTS queries. */
 export type BoolMode = "or" | "and";
-/** BM25 statistics scope: per-superfile IDF (default) or corpus-wide
- * `"global"` IDF across superfiles. */
+/** BM25 statistics scope: corpus-wide `"global"` IDF across superfiles
+ * (the default) or `"per_superfile"` segment-local IDF. */
 export type Bm25Stats = "per_superfile" | "global";
 /** A row from a query/search when not materializing to Arrow. */
 export type RowRecord = Record<string, unknown>;
@@ -114,7 +114,7 @@ export interface OptimizeOptions {
 
 export interface Bm25SearchOptions {
   mode?: BoolMode;
-  /** BM25 statistics scope: `"per_superfile"` (default) or `"global"`. */
+  /** BM25 statistics scope: `"global"` (default) or `"per_superfile"`. */
   stats?: Bm25Stats;
   /** Columns to return, e.g. `["_id", "score"]`; omit for full rows. */
   projection?: string[];

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -478,13 +478,14 @@ impl Table {
     /// `score` is a similarity (higher is better) — opposite direction
     /// from `vector_search`'s distance. Fuse with `hybrid_search`.
     ///
-    /// `stats` selects the BM25 corpus statistics: `"per_superfile"`
-    /// (default) scores each segment against its own local document
-    /// count and term frequencies — fastest, but ranking drifts as the
-    /// table fragments across many segments. `"global"` scores against
-    /// table-wide statistics gathered across all segments, so a
-    /// fragmented table ranks like a single unified corpus (the accurate
-    /// choice) at the cost of an extra statistics-gathering pass.
+    /// `stats` selects the BM25 corpus statistics: `"global"` (default)
+    /// scores against table-wide statistics gathered across all segments,
+    /// so a fragmented table ranks like a single unified corpus, at the
+    /// cost of a document-frequency gather before scoring.
+    /// `"per_superfile"` scores each segment against its own local
+    /// document count and term frequencies — fastest, and it skips that
+    /// gather, but a term's idf depends on which segment a document
+    /// landed in, so ranking drifts as the table fragments.
     #[pyo3(signature = (column, query, k, mode=None, projection=None, stats=None))]
     fn bm25_search<'py>(
         &self,

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -93,7 +93,7 @@ def test_fts_standard_analyzer_keeps_non_ascii():
 
 def test_bm25_stats_kwarg():
     # `stats` selects the BM25 corpus statistics. Both modes return the
-    # matching docs; the default is per-superfile. Correctness of the
+    # matching docs; the default is global. Correctness of the
     # global ranking is covered by the Rust oracle; here we just exercise
     # the binding and the string parsing.
     db = infino.connect("memory://")

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -77,8 +77,8 @@ pub(crate) struct ClauseLists<'a> {
     pub must_phrases: &'a [Vec<String>],
     pub should_phrases: &'a [Vec<String>],
     pub negative_phrases: &'a [Vec<String>],
-    /// Per-term global idf for [`Bm25Stats::Global`]; `None` scores
-    /// with per-superfile local idf (the default).
+    /// Per-term global idf for [`Bm25Stats::Global`], the default;
+    /// `None` scores with [`Bm25Stats::PerSuperfile`] local idf.
     pub global_idf: Option<&'a GlobalTermIdf>,
     /// Open-wave fetches for the scored terms (global stats): the
     /// cursor builds serve these terms from the memo instead of

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -10673,7 +10673,7 @@ mod tests {
     /// corpus-wide document count and per-term document frequencies are
     /// gathered across every superfile before scoring, so a term's idf —
     /// and a doc's score — does not depend on which superfile the doc
-    /// landed in. The default per-superfile mode never runs that gather;
+    /// landed in. The opt-in per-superfile mode never runs that gather;
     /// this is the global mode's only end-to-end exercise.
     #[test]
     fn bm25_global_stats_scores_across_superfiles() {

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -262,14 +262,23 @@ fn count_dedups_repeated_negatives_and_required_excluded() {
 /// BM25 with GLOBAL statistics gathers corpus-wide document frequencies
 /// across every superfile before scoring. Statistics change SCORES,
 /// never MEMBERSHIP: with `k` covering every match, the global-stats
-/// result holds the same number of rows as the default per-superfile
-/// mode's hit set.
+/// result holds the same number of rows as the per-superfile mode's hit
+/// set. The per-superfile arm is requested explicitly — `bm25_hits`
+/// scores with the crate default, which is `Global`, so relying on it
+/// here would compare global statistics against themselves and assert
+/// nothing.
 #[test]
-fn bm25_global_stats_keeps_the_default_modes_membership() {
+fn bm25_global_stats_keeps_the_per_superfile_membership() {
     let st = demo_two_superfiles();
     let reader = st.reader().expect("reader");
-    let default_hits = reader
-        .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+    let per_superfile_hits = reader
+        .bm25_hits_stats(
+            "title",
+            "rust",
+            TOP_K,
+            BoolMode::Or,
+            Bm25Stats::PerSuperfile,
+        )
         .expect("per-superfile bm25");
     let global = reader
         .bm25_search(
@@ -282,10 +291,10 @@ fn bm25_global_stats_keeps_the_default_modes_membership() {
         )
         .expect("global-stats bm25");
     let global_rows: usize = global.iter().map(|b| b.num_rows()).sum();
-    assert!(!default_hits.is_empty(), "the corpus has rust docs");
+    assert!(!per_superfile_hits.is_empty(), "the corpus has rust docs");
     assert_eq!(
         global_rows,
-        default_hits.len(),
+        per_superfile_hits.len(),
         "global statistics rescore the same match set"
     );
 }


### PR DESCRIPTION
Making `Bm25Stats::Global` the default flipped the behavior but left six places describing the old default. Two of them are the bindings' **published API surface**, and both shipped that way in 0.7.0.

### The user-visible half

- `infino-node/infino/index.ts` — the `Bm25Stats` type comment and `Bm25SearchOptions.stats` both named per-superfile as the default.
- `infino-python/src/lib.rs` — the `bm25_search` docstring named `"per_superfile"` as the default and called it "fastest".

A caller who omits `stats` was told they get segment-local idf while the engine scores with corpus-wide idf — a silent ranking difference, documented backwards, in a release that is already on npm and PyPI.

### The rest of the trail

- `ClauseLists::global_idf` field doc (`src/superfile/fts/reader/core.rs`)
- the doc comment on `bm25_global_stats_scores_across_superfiles` (`src/supertable/query/vector.rs`)
- the Python smoke test's comment
- the FTS quality bench's column legend — the bench's own code was already corrected to emit `recall (per-superfile stats)`, so the module doc and the checked-in table headers were the only stale copies. The numbers under that column are unchanged; only the label was wrong.

### One of them was not just a comment

`bm25_global_stats_keeps_the_default_modes_membership` took its per-superfile arm from `bm25_hits`, which scores with `Bm25Stats::default()` — now `Global`. **The test was comparing global statistics against themselves and asserting nothing.** It has been passing vacuously since the default moved.

It now requests `PerSuperfile` explicitly via `bm25_hits_stats`, so it exercises the cross-mode membership invariant it was written to guard, and is renamed for what it actually compares. Verified failing-to-meaningful: the test passes with a real two-mode comparison.

`infino-python/python/infino/_infino.pyi` is deliberately untouched — it declares the `Literal` but makes no default claim.

### Verified

`cargo fmt --check`, `cargo clippy --all-targets` clean, and `cargo test --test supertable bm25_global_stats` passes.
