### PR TITLE
fts: per-column BM25 parameters, declared and overridable per query

### DIFF
--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -43,7 +43,7 @@ use arrow_array::{FixedSizeListArray, Float32Array, LargeStringArray, RecordBatc
 use arrow_schema::{DataType, Field, Schema};
 use futures::future::join_all;
 use infino::{
-    VectorSearchOptions,
+    Bm25SearchOptions, VectorSearchOptions,
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
         builder::{FtsConfig, VectorConfig},
@@ -326,7 +326,7 @@ async fn reader_loop(
                     QUERY_FIELD,
                     QUERY_TERM,
                     TOP_K,
-                    infino::Bm25SearchOptions::new(),
+                    Bm25SearchOptions::new(),
                     None,
                 )
                 .expect("bm25_search"),

--- a/benches/utils/concurrent.rs
+++ b/benches/utils/concurrent.rs
@@ -47,7 +47,6 @@ use infino::{
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
         builder::{FtsConfig, VectorConfig},
-        fts::reader::{Bm25Stats, BoolMode},
         vector::{distance::Metric, rerank_codec::RerankCodec},
     },
     supertable::{Supertable, SupertableOptions},
@@ -327,8 +326,7 @@ async fn reader_loop(
                     QUERY_FIELD,
                     QUERY_TERM,
                     TOP_K,
-                    BoolMode::Or,
-                    Bm25Stats::default(),
+                    infino::Bm25SearchOptions::new(),
                     None,
                 )
                 .expect("bm25_search"),

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -782,11 +782,17 @@ pub mod fts {
 
     impl FtsRead for SupertableReader {
         fn bm25_rows(&self, column: &str, query: &str, k: usize, mode: InfinoBoolMode) -> usize {
-            self.bm25_search(column, query, k, mode, infino::Bm25Stats::default(), None)
-                .expect("supertable bm25_search")
-                .iter()
-                .map(|b| b.num_rows())
-                .sum()
+            self.bm25_search(
+                column,
+                query,
+                k,
+                infino::Bm25SearchOptions::new().with_mode(mode),
+                None,
+            )
+            .expect("supertable bm25_search")
+            .iter()
+            .map(|b| b.num_rows())
+            .sum()
         }
 
         fn bm25_rows_fetched(
@@ -800,8 +806,7 @@ pub mod fts {
                 column,
                 query,
                 k,
-                mode,
-                infino::Bm25Stats::default(),
+                infino::Bm25SearchOptions::new().with_mode(mode),
                 Some(&["_id", column, "score"]),
             )
             .expect("supertable bm25_search fetched")
@@ -818,15 +823,20 @@ pub mod fts {
             mode: InfinoBoolMode,
         ) -> ((u64, u64), (u64, u64)) {
             let search = self
-                .bm25_search(column, query, k, mode, infino::Bm25Stats::default(), None)
+                .bm25_search(
+                    column,
+                    query,
+                    k,
+                    infino::Bm25SearchOptions::new().with_mode(mode),
+                    None,
+                )
                 .expect("supertable bm25_search payload");
             let fetched = self
                 .bm25_search(
                     column,
                     query,
                     k,
-                    mode,
-                    infino::Bm25Stats::default(),
+                    infino::Bm25SearchOptions::new().with_mode(mode),
                     Some(&["_id", column, "score"]),
                 )
                 .expect("supertable bm25_search fetched payload");

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 use arrow_array::{Array, RecordBatch};
+use infino::Bm25SearchOptions;
 
 use crate::{
     cpu,
@@ -786,7 +787,7 @@ pub mod fts {
                 column,
                 query,
                 k,
-                infino::Bm25SearchOptions::new().with_mode(mode),
+                Bm25SearchOptions::new().with_mode(mode),
                 None,
             )
             .expect("supertable bm25_search")
@@ -806,7 +807,7 @@ pub mod fts {
                 column,
                 query,
                 k,
-                infino::Bm25SearchOptions::new().with_mode(mode),
+                Bm25SearchOptions::new().with_mode(mode),
                 Some(&["_id", column, "score"]),
             )
             .expect("supertable bm25_search fetched")
@@ -827,7 +828,7 @@ pub mod fts {
                     column,
                     query,
                     k,
-                    infino::Bm25SearchOptions::new().with_mode(mode),
+                    Bm25SearchOptions::new().with_mode(mode),
                     None,
                 )
                 .expect("supertable bm25_search payload");
@@ -836,7 +837,7 @@ pub mod fts {
                     column,
                     query,
                     k,
-                    infino::Bm25SearchOptions::new().with_mode(mode),
+                    Bm25SearchOptions::new().with_mode(mode),
                     Some(&["_id", column, "score"]),
                 )
                 .expect("supertable bm25_search fetched payload");

--- a/benches/utils/fts_diag.rs
+++ b/benches/utils/fts_diag.rs
@@ -28,7 +28,7 @@
 
 use std::time::Instant;
 
-use infino::superfile::fts::reader::BoolMode;
+use infino::{Bm25SearchOptions, superfile::fts::reader::BoolMode};
 
 use crate::{diag_common, markdown::fmt_count};
 
@@ -98,7 +98,7 @@ pub fn run() {
                 COLUMN,
                 s.query,
                 K,
-                infino::Bm25SearchOptions::new().with_mode(s.mode),
+                Bm25SearchOptions::new().with_mode(s.mode),
                 None,
             )
             .expect("warm-up bm25_search");
@@ -129,7 +129,7 @@ pub fn run() {
                 COLUMN,
                 s.query,
                 K,
-                infino::Bm25SearchOptions::new().with_mode(s.mode),
+                Bm25SearchOptions::new().with_mode(s.mode),
             )
             .expect("bm25_hits")
             .len();
@@ -150,7 +150,7 @@ pub fn run() {
                     COLUMN,
                     s.query,
                     K,
-                    infino::Bm25SearchOptions::new().with_mode(s.mode),
+                    Bm25SearchOptions::new().with_mode(s.mode),
                 )
                 .expect("kernel bm25_hits");
             kernel.push(t.elapsed());
@@ -165,7 +165,7 @@ pub fn run() {
                     COLUMN,
                     s.query,
                     K,
-                    infino::Bm25SearchOptions::new().with_mode(s.mode),
+                    Bm25SearchOptions::new().with_mode(s.mode),
                     None,
                 )
                 .expect("full bm25_search");

--- a/benches/utils/fts_diag.rs
+++ b/benches/utils/fts_diag.rs
@@ -28,7 +28,7 @@
 
 use std::time::Instant;
 
-use infino::superfile::fts::reader::{Bm25Stats, BoolMode};
+use infino::superfile::fts::reader::BoolMode;
 
 use crate::{diag_common, markdown::fmt_count};
 
@@ -94,7 +94,13 @@ pub fn run() {
     // Warm both paths for every shape (cache-hot before timing).
     for s in SHAPES {
         let _ = reader
-            .bm25_search(COLUMN, s.query, K, s.mode, Bm25Stats::default(), None)
+            .bm25_search(
+                COLUMN,
+                s.query,
+                K,
+                infino::Bm25SearchOptions::new().with_mode(s.mode),
+                None,
+            )
             .expect("warm-up bm25_search");
     }
 
@@ -119,7 +125,12 @@ pub fn run() {
     );
     for s in SHAPES {
         let hits = reader
-            .bm25_hits(COLUMN, s.query, K, s.mode)
+            .bm25_hits(
+                COLUMN,
+                s.query,
+                K,
+                infino::Bm25SearchOptions::new().with_mode(s.mode),
+            )
             .expect("bm25_hits")
             .len();
 
@@ -135,7 +146,12 @@ pub fn run() {
         for _ in 0..cfg.iters {
             let t = Instant::now();
             let out = reader
-                .bm25_hits(COLUMN, s.query, K, s.mode)
+                .bm25_hits(
+                    COLUMN,
+                    s.query,
+                    K,
+                    infino::Bm25SearchOptions::new().with_mode(s.mode),
+                )
                 .expect("kernel bm25_hits");
             kernel.push(t.elapsed());
             std::hint::black_box(out);
@@ -145,7 +161,13 @@ pub fn run() {
         for _ in 0..cfg.iters {
             let t = Instant::now();
             let out = reader
-                .bm25_search(COLUMN, s.query, K, s.mode, Bm25Stats::default(), None)
+                .bm25_search(
+                    COLUMN,
+                    s.query,
+                    K,
+                    infino::Bm25SearchOptions::new().with_mode(s.mode),
+                    None,
+                )
                 .expect("full bm25_search");
             full.push(t.elapsed());
             std::hint::black_box(out);

--- a/benches/utils/fts_quality.rs
+++ b/benches/utils/fts_quality.rs
@@ -65,6 +65,7 @@ use std::{borrow::Cow, cmp::Ordering, collections::HashMap, time::Instant};
 
 use arrow_array::{Array, Float32Array, LargeStringArray, RecordBatch, StringArray};
 use infino::{
+    Bm25SearchOptions,
     superfile::fts::{
         bm25::stored_len,
         reader::{Bm25Stats, BoolMode},
@@ -651,9 +652,7 @@ fn engine_hits(
             column,
             q.query,
             k,
-            infino::Bm25SearchOptions::new()
-                .with_mode(q.mode)
-                .with_stats(stats),
+            Bm25SearchOptions::new().with_mode(q.mode).with_stats(stats),
             Some(&[column, "score"]),
         )
         .expect("quality bm25_search");

--- a/benches/utils/fts_quality.rs
+++ b/benches/utils/fts_quality.rs
@@ -647,7 +647,15 @@ fn engine_hits(
     stats: Bm25Stats,
 ) -> Vec<EngineHit> {
     let batches = reader
-        .bm25_search(column, q.query, k, q.mode, stats, Some(&[column, "score"]))
+        .bm25_search(
+            column,
+            q.query,
+            k,
+            infino::Bm25SearchOptions::new()
+                .with_mode(q.mode)
+                .with_stats(stats),
+            Some(&[column, "score"]),
+        )
         .expect("quality bm25_search");
     let mut hits = Vec::with_capacity(k);
     for batch in &batches {

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -1940,8 +1940,8 @@ pub mod fts {
                                 supertable::TEXT_COLUMN,
                                 &query,
                                 TOP_K,
-                                exec_fts::to_infino_mode(q.mode),
-                                infino::Bm25Stats::default(),
+                                infino::Bm25SearchOptions::new()
+                                    .with_mode(exec_fts::to_infino_mode(q.mode)),
                                 None,
                             )
                             .expect("serving working-set bm25_search");
@@ -2135,7 +2135,12 @@ pub mod fts {
             consumer_meter,
             &|| {
                 let hits = reader
-                    .bm25_hits(supertable::TEXT_COLUMN, &query, TOP_K, mode)
+                    .bm25_hits(
+                        supertable::TEXT_COLUMN,
+                        &query,
+                        TOP_K,
+                        infino::Bm25SearchOptions::new().with_mode(mode),
+                    )
                     .expect("routing-state bm25 hits");
                 let hidden_hits = hits
                     .iter()
@@ -2153,8 +2158,7 @@ pub mod fts {
                             supertable::TEXT_COLUMN,
                             &query,
                             TOP_K,
-                            mode,
-                            infino::Bm25Stats::default(),
+                            infino::Bm25SearchOptions::new().with_mode(mode),
                             None,
                         )
                         .expect("routing-state warm bm25 search"),
@@ -2205,8 +2209,7 @@ pub mod fts {
                     supertable::TEXT_COLUMN,
                     &query,
                     TOP_K,
-                    exec_fts::to_infino_mode(q.mode),
-                    infino::Bm25Stats::default(),
+                    infino::Bm25SearchOptions::new().with_mode(exec_fts::to_infino_mode(q.mode)),
                     None,
                 )
                 .expect("warm prewarm bm25_search");
@@ -2325,8 +2328,7 @@ pub mod fts {
                         supertable::TEXT_COLUMN,
                         &terms,
                         TOP_K,
-                        mode,
-                        infino::Bm25Stats::default(),
+                        infino::Bm25SearchOptions::new().with_mode(mode),
                         None,
                     )
                     .expect("metered cold bm25_search");
@@ -2342,8 +2344,7 @@ pub mod fts {
                         supertable::TEXT_COLUMN,
                         &terms,
                         TOP_K,
-                        mode,
-                        infino::Bm25Stats::default(),
+                        infino::Bm25SearchOptions::new().with_mode(mode),
                         None,
                     )
                     .expect("metered steady cold bm25_search");
@@ -2359,8 +2360,7 @@ pub mod fts {
                         supertable::TEXT_COLUMN,
                         &terms,
                         TOP_K,
-                        mode,
-                        infino::Bm25Stats::default(),
+                        infino::Bm25SearchOptions::new().with_mode(mode),
                         None,
                     )
                     .expect("metered repeat cold bm25_search");
@@ -2402,7 +2402,13 @@ pub mod fts {
             self.consumer
                 .reader()
                 .expect("reader")
-                .bm25_search(column, query, k, mode, infino::Bm25Stats::default(), None)
+                .bm25_search(
+                    column,
+                    query,
+                    k,
+                    infino::Bm25SearchOptions::new().with_mode(mode),
+                    None,
+                )
                 .expect("cold bm25_search")
                 .iter()
                 .map(|b| b.num_rows())
@@ -2423,8 +2429,7 @@ pub mod fts {
                     column,
                     query,
                     k,
-                    mode,
-                    infino::Bm25Stats::default(),
+                    infino::Bm25SearchOptions::new().with_mode(mode),
                     Some(&["_id", column, "score"]),
                 )
                 .expect("cold bm25_search fetched")

--- a/benches/utils/supertable.rs
+++ b/benches/utils/supertable.rs
@@ -37,9 +37,8 @@
 //! INFINO_BENCH_STORE=s3 INFINO_REAL_S3_BUCKET=my-bucket INFINO_BENCH_SUPERTABLE_DOCS=100000 cargo bench -- supertable
 //! ```
 
-#[allow(unused_imports)] // `Instant` is consumed by the child mods via `use super::*`
-use std::collections::HashSet;
 use std::{
+    collections::HashSet,
     env,
     process::{Command, Stdio},
     sync::{
@@ -49,6 +48,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[allow(unused_imports)] // `Instant` is consumed by the child mods via `use super::*`
+use infino::Bm25SearchOptions;
 use infino::{
     CompactionSettings, OptimizeOptions,
     supertable::{
@@ -1940,7 +1941,7 @@ pub mod fts {
                                 supertable::TEXT_COLUMN,
                                 &query,
                                 TOP_K,
-                                infino::Bm25SearchOptions::new()
+                                Bm25SearchOptions::new()
                                     .with_mode(exec_fts::to_infino_mode(q.mode)),
                                 None,
                             )
@@ -2139,7 +2140,7 @@ pub mod fts {
                         supertable::TEXT_COLUMN,
                         &query,
                         TOP_K,
-                        infino::Bm25SearchOptions::new().with_mode(mode),
+                        Bm25SearchOptions::new().with_mode(mode),
                     )
                     .expect("routing-state bm25 hits");
                 let hidden_hits = hits
@@ -2158,7 +2159,7 @@ pub mod fts {
                             supertable::TEXT_COLUMN,
                             &query,
                             TOP_K,
-                            infino::Bm25SearchOptions::new().with_mode(mode),
+                            Bm25SearchOptions::new().with_mode(mode),
                             None,
                         )
                         .expect("routing-state warm bm25 search"),
@@ -2209,7 +2210,7 @@ pub mod fts {
                     supertable::TEXT_COLUMN,
                     &query,
                     TOP_K,
-                    infino::Bm25SearchOptions::new().with_mode(exec_fts::to_infino_mode(q.mode)),
+                    Bm25SearchOptions::new().with_mode(exec_fts::to_infino_mode(q.mode)),
                     None,
                 )
                 .expect("warm prewarm bm25_search");
@@ -2328,7 +2329,7 @@ pub mod fts {
                         supertable::TEXT_COLUMN,
                         &terms,
                         TOP_K,
-                        infino::Bm25SearchOptions::new().with_mode(mode),
+                        Bm25SearchOptions::new().with_mode(mode),
                         None,
                     )
                     .expect("metered cold bm25_search");
@@ -2344,7 +2345,7 @@ pub mod fts {
                         supertable::TEXT_COLUMN,
                         &terms,
                         TOP_K,
-                        infino::Bm25SearchOptions::new().with_mode(mode),
+                        Bm25SearchOptions::new().with_mode(mode),
                         None,
                     )
                     .expect("metered steady cold bm25_search");
@@ -2360,7 +2361,7 @@ pub mod fts {
                         supertable::TEXT_COLUMN,
                         &terms,
                         TOP_K,
-                        infino::Bm25SearchOptions::new().with_mode(mode),
+                        Bm25SearchOptions::new().with_mode(mode),
                         None,
                     )
                     .expect("metered repeat cold bm25_search");
@@ -2406,7 +2407,7 @@ pub mod fts {
                     column,
                     query,
                     k,
-                    infino::Bm25SearchOptions::new().with_mode(mode),
+                    Bm25SearchOptions::new().with_mode(mode),
                     None,
                 )
                 .expect("cold bm25_search")
@@ -2429,7 +2430,7 @@ pub mod fts {
                     column,
                     query,
                     k,
-                    infino::Bm25SearchOptions::new().with_mode(mode),
+                    Bm25SearchOptions::new().with_mode(mode),
                     Some(&["_id", column, "score"]),
                 )
                 .expect("cold bm25_search fetched")

--- a/benches/utils/tombstone_overhead.rs
+++ b/benches/utils/tombstone_overhead.rs
@@ -46,6 +46,7 @@ use std::{
 use arrow_array::RecordBatch;
 use chrono::Utc;
 use infino::{
+    Bm25SearchOptions,
     storage::{LocalFsStorageProvider, StorageProvider},
     supertable::{
         Supertable,
@@ -244,13 +245,7 @@ fn measure_fts(st: &Supertable) -> Duration {
     let warm = st
         .reader()
         .expect("reader")
-        .bm25_search(
-            "title",
-            QUERY_TERM,
-            TOP_K,
-            infino::Bm25SearchOptions::new(),
-            None,
-        )
+        .bm25_search("title", QUERY_TERM, TOP_K, Bm25SearchOptions::new(), None)
         .expect("fts");
     black_box(warm);
     let mut samples = Vec::with_capacity(ITERS);
@@ -263,7 +258,7 @@ fn measure_fts(st: &Supertable) -> Duration {
                 black_box("title"),
                 black_box(QUERY_TERM),
                 black_box(TOP_K),
-                infino::Bm25SearchOptions::new(),
+                Bm25SearchOptions::new(),
                 None,
             )
             .expect("fts");

--- a/benches/utils/tombstone_overhead.rs
+++ b/benches/utils/tombstone_overhead.rs
@@ -47,7 +47,6 @@ use arrow_array::RecordBatch;
 use chrono::Utc;
 use infino::{
     storage::{LocalFsStorageProvider, StorageProvider},
-    superfile::fts::reader::{Bm25Stats, BoolMode},
     supertable::{
         Supertable,
         wal::{
@@ -249,8 +248,7 @@ fn measure_fts(st: &Supertable) -> Duration {
             "title",
             QUERY_TERM,
             TOP_K,
-            BoolMode::Or,
-            Bm25Stats::default(),
+            infino::Bm25SearchOptions::new(),
             None,
         )
         .expect("fts");
@@ -265,8 +263,7 @@ fn measure_fts(st: &Supertable) -> Duration {
                 black_box("title"),
                 black_box(QUERY_TERM),
                 black_box(TOP_K),
-                BoolMode::Or,
-                Bm25Stats::default(),
+                infino::Bm25SearchOptions::new(),
                 None,
             )
             .expect("fts");

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -1755,7 +1755,7 @@ pub(crate) mod diag {
             let bm25_t0 = Instant::now();
             let bm25_hits = consumer
                 .reader().expect("reader")
-                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, BoolMode::Or)
+                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, infino::Bm25SearchOptions::new().with_mode(BoolMode::Or))
                 .expect("cold BM25 over real S3 supertable");
             let cold_bm25 = bm25_t0.elapsed();
             eprintln!(
@@ -1782,7 +1782,7 @@ pub(crate) mod diag {
             let warm_bm25_t0 = Instant::now();
             let warm_bm25_hits = consumer
                 .reader().expect("reader")
-                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, BoolMode::Or)
+                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, infino::Bm25SearchOptions::new().with_mode(BoolMode::Or))
                 .expect("warm BM25 over real S3 supertable");
             let warm_bm25 = warm_bm25_t0.elapsed();
             let cache_stats = consumer
@@ -2180,7 +2180,12 @@ pub(crate) mod diag {
         let _ = consumer
             .reader()
             .expect("reader")
-            .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, BoolMode::Or)
+            .bm25_hits(
+                FTS_COLUMN,
+                FTS_QUERY_TERM,
+                TOP_K,
+                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("warm-up bm25");
         let _ = consumer
             .reader()
@@ -2235,7 +2240,12 @@ pub(crate) mod diag {
             let _ = consumer
                 .reader()
                 .expect("reader")
-                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, BoolMode::Or)
+                .bm25_hits(
+                    FTS_COLUMN,
+                    FTS_QUERY_TERM,
+                    TOP_K,
+                    infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+                )
                 .expect("kernel bm25");
             kernel_bm25.push(t.elapsed());
         }

--- a/benches/utils/unified_object_store.rs
+++ b/benches/utils/unified_object_store.rs
@@ -96,6 +96,7 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use infino::{
+    Bm25SearchOptions,
     config::{
         CompactionSettings, Config, StorageBackend, StorageColdFetchMode, StorageSettings,
         SupertableSettings,
@@ -1755,7 +1756,7 @@ pub(crate) mod diag {
             let bm25_t0 = Instant::now();
             let bm25_hits = consumer
                 .reader().expect("reader")
-                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, infino::Bm25SearchOptions::new().with_mode(BoolMode::Or))
+                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, Bm25SearchOptions::new().with_mode(BoolMode::Or))
                 .expect("cold BM25 over real S3 supertable");
             let cold_bm25 = bm25_t0.elapsed();
             eprintln!(
@@ -1782,7 +1783,7 @@ pub(crate) mod diag {
             let warm_bm25_t0 = Instant::now();
             let warm_bm25_hits = consumer
                 .reader().expect("reader")
-                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, infino::Bm25SearchOptions::new().with_mode(BoolMode::Or))
+                .bm25_hits(FTS_COLUMN, FTS_QUERY_TERM, TOP_K, Bm25SearchOptions::new().with_mode(BoolMode::Or))
                 .expect("warm BM25 over real S3 supertable");
             let warm_bm25 = warm_bm25_t0.elapsed();
             let cache_stats = consumer
@@ -2184,7 +2185,7 @@ pub(crate) mod diag {
                 FTS_COLUMN,
                 FTS_QUERY_TERM,
                 TOP_K,
-                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
             )
             .expect("warm-up bm25");
         let _ = consumer
@@ -2244,7 +2245,7 @@ pub(crate) mod diag {
                     FTS_COLUMN,
                     FTS_QUERY_TERM,
                     TOP_K,
-                    infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+                    Bm25SearchOptions::new().with_mode(BoolMode::Or),
                 )
                 .expect("kernel bm25");
             kernel_bm25.push(t.elapsed());

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -198,7 +198,12 @@ fn demo_supertable() {
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "fox", SEARCH_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "fox",
+            SEARCH_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("bm25 fan-out");
     println!("  bm25 \"fox\" across superfiles -> {} hit(s)", hits.len());
     for h in &hits {

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -520,7 +520,7 @@ pub struct VectorFilter {
 #[derive(Clone, Default)]
 pub struct IndexSpec {
     /// `(column, analyzer, stored)`; `analyzer` `None` means the default.
-    fts: Vec<(String, Option<String>, bool)>,
+    fts: Vec<(String, Option<String>, bool, Option<f64>, Option<f64>)>,
     /// `(column, dim, metric)`.
     vectors: Vec<(String, u32, String)>,
 }
@@ -539,6 +539,14 @@ pub struct FtsOptions {
     /// it cannot be selected, projected, or filtered on (append/update
     /// batches still carry it).
     pub stored: Option<bool>,
+    /// BM25 term-frequency saturation, `> 0`; defaults to 1.2. Recorded
+    /// with the table, and the stored score bounds are built with it,
+    /// so a search that does not override it pays nothing. Pass with
+    /// `b` or not at all.
+    pub k1: Option<f64>,
+    /// BM25 length normalization, in `[0, 1]`; defaults to 0.75. Pass
+    /// with `k1` or not at all.
+    pub b: Option<f64>,
 }
 
 #[napi]
@@ -549,13 +557,18 @@ impl IndexSpec {
     }
 
     /// Mark `column` (a UTF-8 string column) as full-text indexed,
-    /// with optional per-column `options` (analyzer, stored).
+    /// with optional per-column `options` (analyzer, stored, k1/b).
     #[napi]
     pub fn fts(&self, column: String, options: Option<FtsOptions>) -> Self {
         let mut next = self.clone();
         let opts = options.unwrap_or_default();
-        next.fts
-            .push((column, opts.analyzer, opts.stored.unwrap_or(true)));
+        next.fts.push((
+            column,
+            opts.analyzer,
+            opts.stored.unwrap_or(true),
+            opts.k1,
+            opts.b,
+        ));
         next
     }
 
@@ -574,10 +587,21 @@ impl IndexSpec {
     /// Lower to the core `IndexSpec` builder.
     fn to_rust(&self) -> Result<infino::IndexSpec> {
         let mut spec = infino::IndexSpec::new();
-        for (column, analyzer, stored) in &self.fts {
+        for (column, analyzer, stored, k1, b) in &self.fts {
             let mut field = infino::FtsField::new(column.clone()).stored(*stored);
             if let Some(a) = analyzer {
                 field = field.analyzer(a.clone());
+            }
+            // Both or neither: the two parameters interact through the
+            // length norm, so half-overriding is a footgun.
+            match (k1, b) {
+                (Some(k1), Some(b)) => field = field.bm25(*k1 as f32, *b as f32),
+                (None, None) => {}
+                _ => {
+                    return Err(napi::Error::from_reason(
+                        "IndexSpec.fts: pass k1 and b together, or neither",
+                    ));
+                }
             }
             spec = spec.fts(field);
         }
@@ -730,7 +754,16 @@ impl Table {
     /// `["_id", "score"]` for just id + score, or omit for full rows.
     /// `score` is a similarity (higher is better) — opposite direction
     /// from `vectorSearch`'s distance. Fuse with `hybridSearch`.
+    ///
+    /// `k1` / `b` override the columns' declared BM25 similarity
+    /// parameters for this search only — pass both or neither. The
+    /// stored score bounds belong to the declared pair, so the reader
+    /// corrects them for the difference: results stay exact and only
+    /// pruning power is traded, and nothing is rebuilt. A pair you mean
+    /// to keep belongs on the column (`IndexSpec.fts`), where the
+    /// bounds are built with it and the correction disappears.
     #[napi]
+    #[allow(clippy::too_many_arguments)]
     pub fn bm25_search(
         &self,
         column: String,
@@ -739,10 +772,21 @@ impl Table {
         mode: Option<String>,
         stats: Option<String>,
         projection: Option<Vec<String>>,
+        k1: Option<f64>,
+        b: Option<f64>,
     ) -> Result<Buffer> {
-        let opts = Bm25SearchOptions::new()
+        let mut opts = Bm25SearchOptions::new()
             .with_mode(parse_mode(mode.as_deref())?)
             .with_stats(parse_stats(stats.as_deref())?);
+        opts = match (k1, b) {
+            (Some(k1), Some(b)) => opts.with_bm25(k1 as f32, b as f32),
+            (None, None) => opts,
+            _ => {
+                return Err(napi::Error::from_reason(
+                    "bm25Search: pass k1 and b together, or neither",
+                ));
+            }
+        };
         let proj: Option<Vec<&str>> = projection
             .as_ref()
             .map(|v| v.iter().map(String::as_str).collect());

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -85,14 +85,24 @@ class IndexSpec:
     def __init__(self) -> None: ...
     # `stored=False` declares an index-only column: searchable, but the raw
     # text is never kept, so it cannot be selected, projected, or filtered on.
+    # `k1` / `b` are the column's BM25 similarity parameters (defaults 1.2 and
+    # 0.75); pass both or neither. The stored score bounds are built with them.
     def fts(
-        self, column: str, analyzer: str | None = None, stored: bool = True
+        self,
+        column: str,
+        analyzer: str | None = None,
+        stored: bool = True,
+        k1: float | None = None,
+        b: float | None = None,
     ) -> IndexSpec: ...
     # `dim` must be in [16, 4096]; out-of-range raises at `create_table`.
     def vector(self, column: str, dim: int, metric: Metric) -> IndexSpec: ...
 
 class Table:
     def append(self, data: RowData) -> None: ...
+    # `k1` / `b` override the columns' declared parameters for this search
+    # only; pass both or neither. Results stay exact — only pruning power is
+    # traded — and nothing is rebuilt.
     def bm25_search(
         self,
         column: str,
@@ -101,6 +111,8 @@ class Table:
         mode: BoolMode | None = ...,
         projection: Sequence[str] | None = ...,
         stats: Bm25Stats | None = ...,
+        k1: float | None = ...,
+        b: float | None = ...,
     ) -> ArrowTable: ...
     def vector_search(
         self,

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -214,14 +214,18 @@ fn connect(
     Ok(Connection { inner })
 }
 
+/// One declared FTS column: `(column, analyzer, stored, k1, b)`.
+/// `analyzer` `None` means the default; `k1` / `b` `None` means the
+/// column takes the standard BM25 pair.
+type FtsDecl = (String, Option<String>, bool, Option<f32>, Option<f32>);
+
 /// Declares which columns are full-text (BM25) and which are vector
 /// (IVF kNN) indexed. Built fluently:
 /// `IndexSpec().fts("body").vector("emb", 384, "cosine")`.
 #[pyclass(name = "IndexSpec", skip_from_py_object)]
 #[derive(Clone, Default)]
 struct IndexSpec {
-    /// `(column, analyzer, stored)`; `analyzer` `None` means the default.
-    fts: Vec<(String, Option<String>, bool, Option<f32>, Option<f32>)>,
+    fts: Vec<FtsDecl>,
     /// `(column, dim, metric)`.
     vectors: Vec<(String, usize, String)>,
 }

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -221,7 +221,7 @@ fn connect(
 #[derive(Clone, Default)]
 struct IndexSpec {
     /// `(column, analyzer, stored)`; `analyzer` `None` means the default.
-    fts: Vec<(String, Option<String>, bool)>,
+    fts: Vec<(String, Option<String>, bool, Option<f32>, Option<f32>)>,
     /// `(column, dim, metric)`.
     vectors: Vec<(String, usize, String)>,
 }
@@ -241,10 +241,26 @@ impl IndexSpec {
     /// `stored=False` makes the column index-only: searchable, but the
     /// raw text is never kept in the table, so it cannot be selected,
     /// projected, or filtered on (append/update batches still carry it).
-    #[pyo3(signature = (column, analyzer = None, stored = true))]
-    fn fts(&self, column: String, analyzer: Option<String>, stored: bool) -> Self {
+    ///
+    /// `k1` and `b` are the column's BM25 similarity parameters —
+    /// term-frequency saturation (`> 0`) and length normalization (in
+    /// `[0, 1]`), defaulting to `1.2` and `0.75`. They are recorded
+    /// with the table and the stored score bounds are built with them,
+    /// so a search that does not override them pays nothing. A search
+    /// may still score with a different pair (see `bm25_search`), which
+    /// is the shape to reach for while tuning; declare the pair here
+    /// once it is settled.
+    #[pyo3(signature = (column, analyzer = None, stored = true, k1 = None, b = None))]
+    fn fts(
+        &self,
+        column: String,
+        analyzer: Option<String>,
+        stored: bool,
+        k1: Option<f32>,
+        b: Option<f32>,
+    ) -> Self {
         let mut next = self.clone();
-        next.fts.push((column, analyzer, stored));
+        next.fts.push((column, analyzer, stored, k1, b));
         next
     }
 
@@ -262,10 +278,22 @@ impl IndexSpec {
     /// Lower to the core `IndexSpec` builder.
     fn to_rust(&self) -> PyResult<infino::IndexSpec> {
         let mut spec = infino::IndexSpec::new();
-        for (column, analyzer, stored) in &self.fts {
+        for (column, analyzer, stored, k1, b) in &self.fts {
             let mut field = infino::FtsField::new(column.clone()).stored(*stored);
             if let Some(a) = analyzer {
                 field = field.analyzer(a.clone());
+            }
+            // Both or neither, as at the search surface: the two
+            // parameters interact through the length norm, so
+            // half-overriding is a footgun rather than a shorthand.
+            match (k1, b) {
+                (Some(k1), Some(b)) => field = field.bm25(*k1, *b),
+                (None, None) => {}
+                _ => {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "IndexSpec.fts: pass k1 and b together, or neither",
+                    ));
+                }
             }
             spec = spec.fts(field);
         }
@@ -478,6 +506,15 @@ impl Table {
     /// `score` is a similarity (higher is better) — opposite direction
     /// from `vector_search`'s distance. Fuse with `hybrid_search`.
     ///
+    /// `k1` and `b` override the columns' declared BM25 similarity
+    /// parameters for this search only — pass both or neither. The
+    /// stored score bounds belong to the declared pair, so the reader
+    /// corrects them for the difference: results stay exact and only
+    /// pruning power is traded. Nothing is rebuilt, which is what makes
+    /// this the shape for relevance experimentation; a pair you mean to
+    /// keep belongs on the column (`IndexSpec.fts`), where the bounds
+    /// are built with it and the correction disappears.
+    ///
     /// `stats` selects the BM25 corpus statistics: `"global"` (default)
     /// scores against table-wide statistics gathered across all segments,
     /// so a fragmented table ranks like a single unified corpus, at the
@@ -486,7 +523,7 @@ impl Table {
     /// document count and term frequencies — fastest, and it skips that
     /// gather, but a term's idf depends on which segment a document
     /// landed in, so ranking drifts as the table fragments.
-    #[pyo3(signature = (column, query, k, mode=None, projection=None, stats=None))]
+    #[pyo3(signature = (column, query, k, mode=None, projection=None, stats=None, k1=None, b=None))]
     #[allow(clippy::too_many_arguments)]
     fn bm25_search<'py>(
         &self,
@@ -497,10 +534,24 @@ impl Table {
         mode: Option<&str>,
         projection: Option<Vec<String>>,
         stats: Option<&str>,
+        k1: Option<f32>,
+        b: Option<f32>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let opts = Bm25SearchOptions::new()
+        let mut opts = Bm25SearchOptions::new()
             .with_mode(parse_mode(mode)?)
             .with_stats(parse_stats(stats)?);
+        // Both or neither: overriding one parameter and silently
+        // keeping the engine default for the other is a footgun, since
+        // the two interact through the length norm.
+        opts = match (k1, b) {
+            (Some(k1), Some(b)) => opts.with_bm25(k1, b),
+            (None, None) => opts,
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "bm25_search: pass k1 and b together, or neither",
+                ));
+            }
+        };
         let batches = py
             .detach(|| {
                 let names = projection_refs(&projection);

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -110,6 +110,65 @@ def test_bm25_stats_kwarg():
     assert global_hits.num_rows == 2
 
 
+def test_bm25_params_declared_and_overridden():
+    # `k1` / `b` declared on the column, and the same pair reached by
+    # overriding a default table at query time, must rank identically —
+    # the engine corrects the stored score bounds for the difference.
+    # Correctness of the correction is covered by the Rust oracle; here
+    # we exercise the binding, including that a declared table and an
+    # overridden one agree through it.
+    db = infino.connect("memory://")
+    titles = ["the quick brown fox", "a lazy dog", "quick thinking about foxes"]
+
+    declared = db.create_table(
+        "declared", _title_schema(), infino.IndexSpec().fts("title", k1=1.6, b=0.4)
+    )
+    plain = db.create_table("plain", _title_schema(), infino.IndexSpec().fts("title"))
+    for title in titles:
+        declared.append(_title_batch([title]))
+        plain.append(_title_batch([title]))
+
+    from_declared = declared.bm25_search("title", "quick", 10, projection=["title", "score"])
+    from_override = plain.bm25_search(
+        "title", "quick", 10, projection=["title", "score"], k1=1.6, b=0.4
+    )
+
+    assert from_declared.num_rows == 2
+    assert from_declared.column("title").to_pylist() == from_override.column("title").to_pylist()
+    for a, b in zip(
+        from_declared.column("score").to_pylist(), from_override.column("score").to_pylist()
+    ):
+        assert abs(a - b) < 1e-4
+
+
+def test_bm25_params_must_be_passed_together():
+    # Overriding one parameter and inheriting the engine default for the
+    # other would score with a combination the caller never chose, since
+    # the two interact through the length norm. Both surfaces refuse it.
+    db = infino.connect("memory://")
+    t = db.create_table("docs", _title_schema(), infino.IndexSpec().fts("title"))
+    t.append(_title_batch(["the quick brown fox"]))
+
+    with pytest.raises(ValueError):
+        t.bm25_search("title", "fox", 10, k1=1.6)
+    with pytest.raises(ValueError):
+        t.bm25_search("title", "fox", 10, b=0.4)
+    with pytest.raises(ValueError):
+        db.create_table("half", _title_schema(), infino.IndexSpec().fts("title", k1=1.6))
+
+
+def test_bm25_params_out_of_range_is_rejected():
+    # Same bounds as the Rust surface: k1 > 0, b in [0, 1].
+    db = infino.connect("memory://")
+    for k1, b in [(0.0, 0.5), (-1.0, 0.5), (1.2, 1.5), (1.2, -0.1)]:
+        with pytest.raises(Exception):
+            db.create_table(
+                f"bad_{k1}_{b}",
+                _title_schema(),
+                infino.IndexSpec().fts("title", k1=k1, b=b),
+            )
+
+
 def test_bm25_unknown_stats_is_rejected():
     # An unknown stats mode is a configuration error, surfaced as ValueError.
     db = infino.connect("memory://")

--- a/infino-python/tests/typing/quickstart.py
+++ b/infino-python/tests/typing/quickstart.py
@@ -35,6 +35,15 @@ def quickstart() -> None:
     hits = docs.bm25_search("title", "fox", k=10, mode="and")
     names: list[str] = hits.column_names
 
+    # The BM25 pair: declared per column, and overridable per search.
+    tuned = db.create_table(
+        "tuned",
+        schema,
+        infino.IndexSpec().fts("title", k1=1.4, b=0.6),
+    )
+    retuned = tuned.bm25_search("title", "fox", k=10, k1=1.2, b=0.75)
+    _ = retuned.column_names
+
     counts = db.query_sql("SELECT COUNT(*) AS n FROM docs")
     tables: list[str] = db.list_tables()
     _ = (names, counts, tables)

--- a/public-api.txt
+++ b/public-api.txt
@@ -182,16 +182,40 @@ impl core::marker::Unpin for infino::OptimizeError
 impl core::marker::UnsafeUnpin for infino::OptimizeError
 impl !core::panic::unwind_safe::RefUnwindSafe for infino::OptimizeError
 impl !core::panic::unwind_safe::UnwindSafe for infino::OptimizeError
-pub struct infino::Bm25SearchOptions
+#[non_exhaustive] pub struct infino::Bm25Params
+pub infino::Bm25Params::b: f32
+pub infino::Bm25Params::k1: f32
+impl infino::Bm25Params
+pub const infino::Bm25Params::STANDARD: Self
+pub const fn infino::Bm25Params::new(f32, f32) -> Self
+impl core::clone::Clone for infino::Bm25Params
+pub fn infino::Bm25Params::clone(&self) -> infino::Bm25Params
+impl core::cmp::PartialEq for infino::Bm25Params
+pub fn infino::Bm25Params::eq(&self, &infino::Bm25Params) -> bool
+impl core::default::Default for infino::Bm25Params
+pub fn infino::Bm25Params::default() -> Self
+impl core::fmt::Debug for infino::Bm25Params
+pub fn infino::Bm25Params::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for infino::Bm25Params
+impl core::marker::StructuralPartialEq for infino::Bm25Params
+impl core::marker::Freeze for infino::Bm25Params
+impl core::marker::Send for infino::Bm25Params
+impl core::marker::Sync for infino::Bm25Params
+impl core::marker::Unpin for infino::Bm25Params
+impl core::marker::UnsafeUnpin for infino::Bm25Params
+impl core::panic::unwind_safe::RefUnwindSafe for infino::Bm25Params
+impl core::panic::unwind_safe::UnwindSafe for infino::Bm25Params
+#[non_exhaustive] pub struct infino::Bm25SearchOptions
+pub infino::Bm25SearchOptions::bm25: core::option::Option<infino::Bm25Params>
 pub infino::Bm25SearchOptions::mode: infino::BoolMode
 pub infino::Bm25SearchOptions::stats: infino::Bm25Stats
 impl infino::Bm25SearchOptions
 pub fn infino::Bm25SearchOptions::new() -> Self
+pub fn infino::Bm25SearchOptions::with_bm25(self, f32, f32) -> Self
 pub fn infino::Bm25SearchOptions::with_mode(self, infino::BoolMode) -> Self
 pub fn infino::Bm25SearchOptions::with_stats(self, infino::Bm25Stats) -> Self
 impl core::clone::Clone for infino::Bm25SearchOptions
 pub fn infino::Bm25SearchOptions::clone(&self) -> infino::Bm25SearchOptions
-impl core::cmp::Eq for infino::Bm25SearchOptions
 impl core::cmp::PartialEq for infino::Bm25SearchOptions
 pub fn infino::Bm25SearchOptions::eq(&self, &infino::Bm25SearchOptions) -> bool
 impl core::default::Default for infino::Bm25SearchOptions
@@ -279,6 +303,7 @@ impl !core::panic::unwind_safe::UnwindSafe for infino::Connection
 pub struct infino::FtsField
 impl infino::FtsField
 pub fn infino::FtsField::analyzer(self, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn infino::FtsField::bm25(self, f32, f32) -> Self
 pub fn infino::FtsField::new(impl core::convert::Into<alloc::string::String>) -> Self
 pub fn infino::FtsField::stored(self, bool) -> Self
 impl core::clone::Clone for infino::FtsField

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -8,7 +8,7 @@
 
 use crate::superfile::{
     builder::FtsConfig,
-    fts::tokenize::STANDARD_TOKENIZER,
+    fts::{bm25::Bm25Params, tokenize::STANDARD_TOKENIZER},
     vector::{builder::VectorConfig, distance::Metric},
 };
 
@@ -42,6 +42,7 @@ pub struct FtsField {
     column: String,
     analyzer: String,
     stored: bool,
+    bm25: Bm25Params,
 }
 
 impl FtsField {
@@ -54,6 +55,7 @@ impl FtsField {
             column: column.into(),
             analyzer: STANDARD_TOKENIZER.to_string(),
             stored: true,
+            bm25: Bm25Params::STANDARD,
         }
     }
 
@@ -78,6 +80,23 @@ impl FtsField {
     /// searched skips the stored copy entirely.
     pub fn stored(mut self, stored: bool) -> Self {
         self.stored = stored;
+        self
+    }
+
+    /// Set this column's BM25 similarity parameters — `k1` (term
+    /// frequency saturation, `> 0`) and `b` (length normalization, in
+    /// `[0, 1]`). Defaults to `1.2` / `0.75`, the standard pair.
+    ///
+    /// Per column, and recorded in the index: the stored block-max
+    /// bounds are built with the pair declared here, and the pair
+    /// itself is written alongside them, so a reader always scores with
+    /// the parameters its bounds belong to. A search may score with a
+    /// different pair — the bounds are corrected for the difference —
+    /// so this is the column's default rather than a commitment.
+    ///
+    /// Validated at `create_table`, with the column named in the error.
+    pub fn bm25(mut self, k1: f32, b: f32) -> Self {
+        self.bm25 = Bm25Params::new(k1, b);
         self
     }
 }
@@ -165,6 +184,12 @@ impl IndexSpec {
         self.fts.iter().map(|f| f.stored).collect()
     }
 
+    /// FTS BM25 parameters, in declaration order (parallel to
+    /// [`fts_columns`](Self::fts_columns)).
+    pub(crate) fn fts_bm25(&self) -> Vec<Bm25Params> {
+        self.fts.iter().map(|f| f.bm25).collect()
+    }
+
     /// Vector index declarations as `(column, dim, metric)`, in declaration
     /// order. Used by the remote transport to serialize the spec.
     #[cfg(feature = "remote")]
@@ -185,6 +210,7 @@ impl IndexSpec {
                 FtsConfig::new(f.column.clone())
                     .analyzer(f.analyzer.clone())
                     .stored(f.stored)
+                    .bm25(f.bm25.k1, f.bm25.b)
             })
             .collect();
         let vectors = self

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -68,6 +68,18 @@ pub(crate) struct TableEntry {
     /// defaults to stored on reopen.
     #[serde(default)]
     pub(crate) fts_stored: Vec<bool>,
+    /// FTS BM25 `k1` values, parallel to `fts`. Absent in catalogs
+    /// written before the parameters were declarable; a missing or
+    /// short entry defaults to the standard `1.2` on reopen — the only
+    /// value such a table can have been built with. Frozen, like the
+    /// superfile-side default: it must not follow a later change to
+    /// what the API recommends.
+    #[serde(default)]
+    pub(crate) fts_k1: Vec<f32>,
+    /// FTS BM25 `b` values, parallel to `fts`; same provenance and same
+    /// frozen default (`0.75`) as `fts_k1`.
+    #[serde(default)]
+    pub(crate) fts_b: Vec<f32>,
     /// Vector-indexed columns.
     pub(crate) vectors: Vec<VectorEntry>,
     /// Creation time, seconds since the Unix epoch.
@@ -184,6 +196,8 @@ mod tests {
             fts: vec!["title".into()],
             fts_analyzers: vec!["ascii_lower".into()],
             fts_stored: vec![true],
+            fts_k1: vec![1.2],
+            fts_b: vec![0.75],
             vectors: vec![VectorEntry {
                 column: "emb".into(),
                 dim: 8,

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -85,6 +85,7 @@ use crate::{
     },
     superfile::{
         builder::FtsConfig,
+        fts::bm25,
         vector::{builder::VectorConfig, distance::Metric},
     },
     supertable::{
@@ -435,6 +436,8 @@ impl Connection {
                     fts: indexes.fts_columns(),
                     fts_analyzers: indexes.fts_analyzers(),
                     fts_stored: indexes.fts_stored(),
+                    fts_k1: indexes.fts_bm25().iter().map(|p| p.k1).collect(),
+                    fts_b: indexes.fts_bm25().iter().map(|p| p.b).collect(),
                     vectors,
                     created_at_unix: now_unix(),
                 };
@@ -580,10 +583,17 @@ impl Connection {
                     // written before index-only columns existed can only
                     // mean the text is stored.
                     let stored = entry.fts_stored.get(i).copied().unwrap_or(true);
+                    // And again for the BM25 pair: a catalog written before
+                    // it was declarable can only describe a table built with
+                    // the standard values, so the fallback is frozen there
+                    // rather than tracking the crate default.
+                    let k1 = entry.fts_k1.get(i).copied().unwrap_or(bm25::K1);
+                    let b = entry.fts_b.get(i).copied().unwrap_or(bm25::B);
                     spec = spec.fts(
                         FtsField::new(column.clone())
                             .analyzer(analyzer)
-                            .stored(stored),
+                            .stored(stored)
+                            .bm25(k1, b),
                     );
                 }
                 for v in &entry.vectors {

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -46,10 +46,26 @@ pub(crate) fn metric_str(metric: Metric) -> &'static str {
 /// `{fts: [entry, …], vector: [{column, dim, metric}, …]}`. Absent index kinds
 /// are omitted (the server treats a missing key as "none").
 ///
-/// Each FTS entry is a `{column, analyzer}` object — plus `stored: false`
-/// for an index-only column. The analyzer is always named rather than left
-/// to the server's own idea of a default, so a table is created with the
-/// analyzer this client resolved and the two can never drift apart.
+/// Each FTS entry is a `{column, analyzer, k1, b}` object — plus
+/// `stored: false` for an index-only column. The analyzer and the BM25
+/// pair are always named rather than left to the server's own idea of a
+/// default, so a table is created with what this client resolved and the
+/// two can never drift apart. That matters most for the pair: it is the
+/// provenance of the stored score bounds, and a server that filled in
+/// its own default would build bounds the client never asked for.
+/// One BM25 parameter widened for JSON without picking up the noise of a
+/// naive `f32 as f64`: that cast is exact, so `1.2_f32` widens to
+/// `1.2000000476837158` and crosses the wire as those seventeen digits.
+/// Round-tripping through the `f32`'s shortest `Debug` form instead
+/// yields the `f64` a reader would write by hand, so the request body
+/// says `1.2` and a server comparing against its own `1.2` matches.
+/// Same reasoning as the superfile writer's parameter serializer.
+fn param_as_f64(v: f32) -> f64 {
+    format!("{v:?}")
+        .parse()
+        .expect("an f32's Debug form is always a valid f64 literal")
+}
+
 pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
     let mut indexes = serde_json::Map::new();
     let columns = spec.fts_columns();
@@ -58,10 +74,13 @@ pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
             .iter()
             .zip(spec.fts_analyzers())
             .zip(spec.fts_stored())
-            .map(|((column, analyzer), stored)| {
+            .zip(spec.fts_bm25())
+            .map(|(((column, analyzer), stored), bm25)| {
                 let mut entry = serde_json::Map::new();
                 entry.insert("column".to_string(), json!(column));
                 entry.insert("analyzer".to_string(), json!(analyzer));
+                entry.insert("k1".to_string(), json!(param_as_f64(bm25.k1)));
+                entry.insert("b".to_string(), json!(param_as_f64(bm25.b)));
                 if !stored {
                     entry.insert("stored".to_string(), json!(false));
                 }
@@ -178,7 +197,7 @@ mod tests {
         let json = index_spec_to_json(&spec);
         assert_eq!(
             json["fts"],
-            json!([{"column": "body", "analyzer": "standard"}])
+            json!([{"column": "body", "analyzer": "standard", "k1": 1.2, "b": 0.75}])
         );
         assert_eq!(
             json["vector"][0],
@@ -200,8 +219,8 @@ mod tests {
         assert_eq!(
             json["fts"],
             json!([
-                {"column": "title", "analyzer": "ascii_lower"},
-                {"column": "body", "analyzer": "standard"}
+                {"column": "title", "analyzer": "ascii_lower", "k1": 1.2, "b": 0.75},
+                {"column": "body", "analyzer": "standard", "k1": 1.2, "b": 0.75}
             ])
         );
 
@@ -211,7 +230,7 @@ mod tests {
         let defaulted = index_spec_to_json(&IndexSpec::new().fts("title"));
         assert_eq!(
             defaulted["fts"],
-            json!([{"column": "title", "analyzer": "standard"}])
+            json!([{"column": "title", "analyzer": "standard", "k1": 1.2, "b": 0.75}])
         );
     }
 
@@ -222,7 +241,30 @@ mod tests {
         let spec = IndexSpec::new().fts(FtsField::new("body").stored(false));
         assert_eq!(
             index_spec_to_json(&spec)["fts"],
-            json!([{"column": "body", "analyzer": "standard", "stored": false}])
+            json!([
+                {"column": "body", "analyzer": "standard", "k1": 1.2, "b": 0.75, "stored": false}
+            ])
+        );
+    }
+
+    #[test]
+    fn index_spec_json_carries_the_declared_bm25_pair() {
+        // The pair crosses on every column, defaults included, for the
+        // same reason the analyzer does: it is the provenance of the
+        // stored score bounds, so a server filling in its own default
+        // would build bounds the client never asked for. A declared pair
+        // that failed to cross would be worse than an error — the table
+        // would come back scoring something else, silently.
+        let spec = IndexSpec::new()
+            .fts(FtsField::new("title").bm25(1.6, 0.4))
+            .fts("body");
+        assert_eq!(
+            index_spec_to_json(&spec)["fts"],
+            json!([
+                {"column": "title", "analyzer": "standard", "k1": 1.6, "b": 0.4},
+                {"column": "body", "analyzer": "standard", "k1": 1.2, "b": 0.75}
+            ]),
+            "the declared pair crosses per column, and a default column names the standard pair"
         );
     }
 

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -111,7 +111,7 @@ impl Table for SupertableHandle {
         opts: Bm25SearchOptions,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
-        SupertableHandle::bm25_search(self, column, query, k, opts.mode, opts.stats, projection)
+        SupertableHandle::bm25_search(self, column, query, k, opts, projection)
     }
     fn token_match(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,10 @@ pub use error::InfinoError;
 pub use superfile::VectorSearchOptions;
 /// Value types named by the public method signatures.
 pub use superfile::{
-    fts::reader::{Bm25SearchOptions, Bm25Stats, BoolMode},
+    fts::{
+        bm25::Bm25Params,
+        reader::{Bm25SearchOptions, Bm25Stats, BoolMode},
+    },
     vector::distance::Metric,
 };
 pub use supertable::{

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -96,6 +96,7 @@ use crate::superfile::{
         kv,
     },
     fts::{
+        bm25,
         builder::FtsBuilder,
         reader::ColumnMeta,
         tokenize::{AsciiLowerTokenizer, STANDARD_TOKENIZER, tokenizer_for_name},
@@ -154,6 +155,16 @@ pub struct FtsConfig {
     /// existing superfile the column is legitimately absent from the
     /// stored schema and its postings are carried across instead.
     pub stored: bool,
+    /// BM25 similarity parameters for this column. The build bakes the
+    /// stored per-block score bounds at this pair and records it in the
+    /// column's `inf.fts.columns` entry, so a reader never infers which
+    /// parameters a bound belongs to. A query may score at a different
+    /// pair; the reader corrects the bounds for the difference.
+    ///
+    /// Defaults to the standard pair (`k1 = 1.2`, `b = 0.75`), which
+    /// keeps the built bytes identical to a file written before the
+    /// parameters were declarable.
+    pub bm25: bm25::Bm25Params,
 }
 
 impl FtsConfig {
@@ -165,6 +176,7 @@ impl FtsConfig {
             analyzer: STANDARD_TOKENIZER.to_string(),
             positions: false,
             stored: true,
+            bm25: bm25::Bm25Params::STANDARD,
         }
     }
 
@@ -183,6 +195,14 @@ impl FtsConfig {
     /// Keep the raw text in the Parquet body (see the field docs).
     pub fn stored(mut self, stored: bool) -> Self {
         self.stored = stored;
+        self
+    }
+
+    /// Set the BM25 similarity parameters (see the field docs).
+    /// Validated at `SupertableOptions::new`, which names the column
+    /// in the error.
+    pub fn bm25(mut self, k1: f32, b: f32) -> Self {
+        self.bm25 = bm25::Bm25Params::new(k1, b);
         self
     }
 }
@@ -382,6 +402,13 @@ impl BuilderOptions {
         // rebuild carries the analyzer the postings were built with. This
         // is why an existing table keeps its recorded analyzer through
         // compaction and optimize no matter what the engine's default is.
+        //
+        // The BM25 pair rides along for the same reason and with a sharper
+        // consequence: dropping it here would rebake the merged file's
+        // block-max bounds at the standard pair while the source files
+        // kept theirs, so one column would score two ways depending on
+        // which superfile a document landed in — and a compaction, not
+        // any user action, would be what changed the ranking.
         let fts_columns: Vec<FtsConfig> = if let Some(fts) = &reader.fts() {
             fts.fts_columns_config()
                 .map(|c| {
@@ -389,6 +416,7 @@ impl BuilderOptions {
                         .analyzer(c.tokenizer.name())
                         .positions(c.positions)
                         .stored(c.stored)
+                        .bm25(c.params.k1, c.params.b)
                 })
                 .collect()
         } else {
@@ -706,7 +734,7 @@ impl SuperfileBuilder {
                         analyzer: fc.analyzer.clone(),
                     }
                 })?;
-                fb.register_column_with_tokenizer(fc.column.clone(), fc.positions, tok)?;
+                fb.register_column_with_tokenizer(fc.column.clone(), fc.positions, tok, fc.bm25)?;
             }
             Some(fb)
         };
@@ -2286,11 +2314,32 @@ fn check_user_column_name(name: &str) -> Result<(), BuildError> {
 /// JSON per column.
 ///
 /// Output shape per column:
-/// `{"name":"<escaped>","tokenizer":"<name>"}`.
+/// `{"name":"<escaped>","tokenizer":"<name>","k1":<f>,"b":<f>}`.
 /// `tokenizer` is that column's analyzer name (`"ascii_lower"` or
 /// `"standard"`), straight from `FtsConfig.analyzer` — the reader
 /// reconstructs the matching tokenizer from it for query-time
 /// tokenization.
+///
+/// `k1` / `b` are written **unconditionally, defaults included**,
+/// unlike `positions` and `stored`. Those two are booleans whose
+/// absence has exactly one possible meaning, so omitting them keeps a
+/// default column's JSON byte-identical to older files. A scoring
+/// parameter is different: it is the provenance of the stored
+/// block-max bounds, and a reader that has to infer it is a reader
+/// that will infer wrong the day the recommended default moves. The
+/// same lesson is recorded on `rerank_codec` in
+/// `supertable::manifest::options_hash` — a data-determined value
+/// belongs on disk, read back rather than re-derived.
+/// One BM25 parameter as JSON. `{:?}` on an `f32` is the shortest
+/// decimal that round-trips back to the same bits, and always carries a
+/// `.`, so the value the reader deserializes is bit-for-bit the value
+/// the bounds were baked with — which is what makes the
+/// `params == query` comparison in the reader exact rather than
+/// approximate.
+fn fts_param_json(v: f32) -> String {
+    format!("{v:?}")
+}
+
 fn fts_columns_json(cols: &[FtsConfig]) -> String {
     let mut s = String::from("[");
     for (i, c) in cols.iter().enumerate() {
@@ -2302,6 +2351,11 @@ fn fts_columns_json(cols: &[FtsConfig]) -> String {
         s.push_str(r#"","tokenizer":""#);
         s.push_str(&escape_json(&c.analyzer));
         s.push('"');
+        // Always emitted — see the function docs.
+        s.push_str(r#","k1":"#);
+        s.push_str(&fts_param_json(c.bm25.k1));
+        s.push_str(r#","b":"#);
+        s.push_str(&fts_param_json(c.bm25.b));
         // Emitted only when set: a positionless column's JSON stays
         // byte-identical to files written before positions existed
         // (the reader defaults a missing field to false).
@@ -2716,11 +2770,13 @@ mod tests {
         ];
         let s = fts_columns_json(&cols);
         assert!(
-            s.contains(r#"{"name":"title","tokenizer":"standard","positions":true}"#),
+            s.contains(
+                r#"{"name":"title","tokenizer":"standard","k1":1.2,"b":0.75,"positions":true}"#
+            ),
             "positional column carries the flag: {s}"
         );
         assert!(
-            s.contains(r#"{"name":"body","tokenizer":"standard"}"#),
+            s.contains(r#"{"name":"body","tokenizer":"standard","k1":1.2,"b":0.75}"#),
             "positionless column carries no positions key at all: {s}"
         );
     }
@@ -2736,11 +2792,11 @@ mod tests {
         ];
         let s = fts_columns_json(&cols);
         assert!(
-            s.contains(r#"{"name":"title","tokenizer":"standard"}"#),
+            s.contains(r#"{"name":"title","tokenizer":"standard","k1":1.2,"b":0.75}"#),
             "title uses the standard analyzer: {s}"
         );
         assert!(
-            s.contains(r#"{"name":"body","tokenizer":"ascii_lower"}"#),
+            s.contains(r#"{"name":"body","tokenizer":"ascii_lower","k1":1.2,"b":0.75}"#),
             "body uses ascii_lower: {s}"
         );
     }
@@ -2755,11 +2811,13 @@ mod tests {
         ];
         let s = fts_columns_json(&cols);
         assert!(
-            s.contains(r#"{"name":"title","tokenizer":"standard"}"#),
+            s.contains(r#"{"name":"title","tokenizer":"standard","k1":1.2,"b":0.75}"#),
             "stored column carries no stored key at all: {s}"
         );
         assert!(
-            s.contains(r#"{"name":"body","tokenizer":"standard","stored":false}"#),
+            s.contains(
+                r#"{"name":"body","tokenizer":"standard","k1":1.2,"b":0.75,"stored":false}"#
+            ),
             "index-only column carries the flag: {s}"
         );
     }
@@ -4838,6 +4896,53 @@ mod tests {
             .await
             .expect("bm25 on carried stored column");
         assert_eq!(hits.iter().map(|(d, _)| *d).collect::<Vec<_>>(), vec![1, 3]);
+    }
+
+    #[tokio::test]
+    async fn build_from_readers_bm25_params_preserved_by_new_from_reader() {
+        // Same failure shape as the codec case below: dropping the pair in
+        // `new_from_reader` would rebake the merged file's block-max bounds
+        // at the standard values while the source kept its own, so one
+        // column would score two ways depending on which superfile a
+        // document landed in — and a compaction, not any user action,
+        // would be what changed the ranking.
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig::new("title").bm25(1.4, 0.6)],
+            vec![],
+        );
+        let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        let schema = b.opts.schema.clone();
+        b.add_batch(&batch_two_rows(&schema), &[])
+            .expect("add_batch");
+        let source_bytes = b.finish().expect("finish builder");
+
+        let reader = SuperfileReader::open(Bytes::from(source_bytes)).expect("open reader");
+        let source_pair = reader
+            .fts()
+            .expect("fts index")
+            .fts_columns_config()
+            .next()
+            .expect("has column")
+            .params;
+        assert_eq!(source_pair, bm25::Bm25Params::new(1.4, 0.6));
+
+        let (merged_bytes, _stats) =
+            SuperfileBuilder::build_from_readers(&[(Arc::new(reader), empty_bitmap())])
+                .expect("build_from_readers");
+        let merged = SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged");
+        let merged_pair = merged
+            .fts()
+            .expect("fts index")
+            .fts_columns_config()
+            .next()
+            .expect("has column")
+            .params;
+        assert_eq!(
+            merged_pair, source_pair,
+            "the declared pair must survive a rebuild, or compaction silently rescores the column"
+        );
     }
 
     #[tokio::test]

--- a/src/superfile/fts/bm25.rs
+++ b/src/superfile/fts/bm25.rs
@@ -68,14 +68,6 @@ impl Bm25Params {
         Self { k1, b }
     }
 
-    /// Whether this is the standard pair, bit-for-bit. Drives the
-    /// "only when non-default" decisions — chiefly whether a query
-    /// needs a bound-correction factor at all.
-    #[inline]
-    pub(crate) fn is_standard(&self) -> bool {
-        self.k1 == K1 && self.b == B
-    }
-
     /// `k1 · (1 − b + b·dl/avgdl)` — the per-doc length normalizer the
     /// scorer divides by, precomputed per length bucket in the reader's
     /// norm table. `avgdl <= 0` (an empty column) yields `k1`, the

--- a/src/superfile/fts/bm25.rs
+++ b/src/superfile/fts/bm25.rs
@@ -32,7 +32,7 @@ pub const B: f32 = 0.75;
 
 /// A column's BM25 similarity parameters.
 ///
-/// [`Default`] is the standard pair ([`K1`], [`B`]) — the values every
+/// [`Default`] is the standard pair (`k1 = 1.2`, `b = 0.75`) — the values every
 /// superfile written before the parameters were recordable was built
 /// with, and the values a column that declares nothing still uses. That
 /// meaning is frozen: a file whose column entry carries no parameters
@@ -68,12 +68,11 @@ impl Bm25Params {
         Self { k1, b }
     }
 
-    /// Whether this is the standard pair, bit-for-bit. Drives every
-    /// "only when non-default" decision: whether a file's FTS section
-    /// takes the parameter-carrying version, and whether a query needs
-    /// a bound-correction factor at all.
+    /// Whether this is the standard pair, bit-for-bit. Drives the
+    /// "only when non-default" decisions — chiefly whether a query
+    /// needs a bound-correction factor at all.
     #[inline]
-    pub fn is_standard(&self) -> bool {
+    pub(crate) fn is_standard(&self) -> bool {
         self.k1 == K1 && self.b == B
     }
 
@@ -82,7 +81,7 @@ impl Bm25Params {
     /// norm table. `avgdl <= 0` (an empty column) yields `k1`, the
     /// unit-norm value; such a column is never scored.
     #[inline]
-    pub fn dl_norm_k1(&self, dl: u32, avgdl: f32) -> f32 {
+    pub(crate) fn dl_norm_k1(&self, dl: u32, avgdl: f32) -> f32 {
         let norm = if avgdl > 0.0 {
             1.0 - self.b + self.b * (dl as f32) / avgdl
         } else {
@@ -93,7 +92,7 @@ impl Bm25Params {
 
     /// `idf · (k1 + 1)` — the per-term factor the scorer multiplies by.
     #[inline]
-    pub fn idf_x_k1p1(&self, idf: f32) -> f32 {
+    pub(crate) fn idf_x_k1p1(&self, idf: f32) -> f32 {
         idf * (self.k1 + 1.0)
     }
 }

--- a/src/superfile/fts/bm25.rs
+++ b/src/superfile/fts/bm25.rs
@@ -30,6 +30,74 @@ pub const K1: f32 = 1.2;
 /// Standard BM25 default `b` — length-normalization parameter.
 pub const B: f32 = 0.75;
 
+/// A column's BM25 similarity parameters.
+///
+/// [`Default`] is the standard pair ([`K1`], [`B`]) — the values every
+/// superfile written before the parameters were recordable was built
+/// with, and the values a column that declares nothing still uses. That
+/// meaning is frozen: a file whose column entry carries no parameters
+/// can only have been built with this pair, so the default here must
+/// never track a change to what the *API* recommends.
+///
+/// `#[non_exhaustive]`: build with [`Bm25Params::new`] so a further
+/// similarity parameter can be added without breaking callers.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub struct Bm25Params {
+    /// Term-frequency saturation. Must be `> 0` and finite.
+    pub k1: f32,
+    /// Length normalization, in `[0, 1]`. `0` disables it entirely.
+    pub b: f32,
+}
+
+impl Default for Bm25Params {
+    fn default() -> Self {
+        Self { k1: K1, b: B }
+    }
+}
+
+impl Bm25Params {
+    /// The standard pair — `k1 = 1.2`, `b = 0.75`.
+    pub const STANDARD: Self = Self { k1: K1, b: B };
+
+    /// Unvalidated constructor. Callers that accept these from a user
+    /// validate first (`SupertableOptions::new` for a declared column,
+    /// the search options for an override) so the error names the
+    /// column or argument at fault.
+    pub const fn new(k1: f32, b: f32) -> Self {
+        Self { k1, b }
+    }
+
+    /// Whether this is the standard pair, bit-for-bit. Drives every
+    /// "only when non-default" decision: whether a file's FTS section
+    /// takes the parameter-carrying version, and whether a query needs
+    /// a bound-correction factor at all.
+    #[inline]
+    pub fn is_standard(&self) -> bool {
+        self.k1 == K1 && self.b == B
+    }
+
+    /// `k1 · (1 − b + b·dl/avgdl)` — the per-doc length normalizer the
+    /// scorer divides by, precomputed per length bucket in the reader's
+    /// norm table. `avgdl <= 0` (an empty column) yields `k1`, the
+    /// unit-norm value; such a column is never scored.
+    #[inline]
+    pub fn dl_norm_k1(&self, dl: u32, avgdl: f32) -> f32 {
+        let norm = if avgdl > 0.0 {
+            1.0 - self.b + self.b * (dl as f32) / avgdl
+        } else {
+            1.0
+        };
+        self.k1 * norm
+    }
+
+    /// `idf · (k1 + 1)` — the per-term factor the scorer multiplies by.
+    #[inline]
+    pub fn idf_x_k1p1(&self, idf: f32) -> f32 {
+        idf * (self.k1 + 1.0)
+    }
+}
+
 /// Plus-half IDF smoothing term. Added to both the numerator and
 /// denominator of the IDF log argument so it stays ≥ 1 (hence
 /// `idf >= 0`) for every valid `(N, df)` — the "BM25+1" form.
@@ -118,28 +186,24 @@ pub fn idf(n_docs: u64, df: u64) -> f32 {
 
 /// Per-doc BM25 contribution for a single (column, term, doc).
 ///
-/// `tf`    — term frequency in this document, this column.
-/// `dl`    — this document's length in this column (in tokens).
-/// `avgdl` — average document length across the superfile, this column.
+/// `tf`     — term frequency in this document, this column.
+/// `dl`     — this document's length in this column (in tokens).
+/// `avgdl`  — average document length across the superfile, this column.
+/// `params` — the column's similarity parameters.
 #[inline(always)]
-pub fn score(idf_t: f32, tf: u32, dl: u32, avgdl: f32) -> f32 {
+pub fn score(idf_t: f32, tf: u32, dl: u32, avgdl: f32, params: Bm25Params) -> f32 {
     let tf = tf as f32;
     // avgdl is precomputed at build time and stored in the doc-lengths
     // directory; if a superfile has zero docs we wouldn't be calling this
     // function, but guard anyway against a divide-by-zero on degenerate
     // input.
-    let norm = if avgdl > 0.0 {
-        1.0 - B + B * (dl as f32) / avgdl
-    } else {
-        1.0
-    };
-    let denom = tf + K1 * norm;
+    let denom = tf + params.dl_norm_k1(dl, avgdl);
     if denom == 0.0 {
         // tf=0 should never reach this function (callers gate on
         // posting list membership), but stay defensive.
         return 0.0;
     }
-    idf_t * tf * (K1 + 1.0) / denom
+    params.idf_x_k1p1(idf_t) * tf / denom
 }
 
 /// BM25 score using a precomputed `dl_norm_k1 = K1 * (1 - B + B * dl/avgdl)`
@@ -276,10 +340,10 @@ mod tests {
         for tf in [1, 2, 5, 10, 100] {
             for dl in [1, 10, 100, 1_000, 10_000] {
                 for avgdl in [10.0, 100.0, 1_000.0] {
-                    let s = score(i, tf, dl, avgdl);
+                    let s = score(i, tf, dl, avgdl, Bm25Params::STANDARD);
                     assert!(
                         s >= 0.0,
-                        "score(i={i}, tf={tf}, dl={dl}, avgdl={avgdl}) = {s}"
+                        "score(i={i}, tf={tf}, dl={dl}, avgdl={avgdl}, Bm25Params::STANDARD) = {s}"
                     );
                     assert!(s.is_finite());
                 }
@@ -292,9 +356,9 @@ mod tests {
         // Holding everything else fixed, more occurrences of the query
         // term in this doc should increase the score.
         let i = idf(1_000_000, 100);
-        let s1 = score(i, 1, 200, 200.0);
-        let s2 = score(i, 5, 200, 200.0);
-        let s3 = score(i, 100, 200, 200.0);
+        let s1 = score(i, 1, 200, 200.0, Bm25Params::STANDARD);
+        let s2 = score(i, 5, 200, 200.0, Bm25Params::STANDARD);
+        let s3 = score(i, 100, 200, 200.0, Bm25Params::STANDARD);
         assert!(s1 < s2 && s2 < s3);
     }
 
@@ -303,9 +367,9 @@ mod tests {
         // BM25's whole point: tf saturation. score(tf=1000) is not
         // ~1000× score(tf=1); the gap shrinks as tf grows.
         let i = idf(1_000_000, 100);
-        let s_low = score(i, 1, 200, 200.0);
-        let s_mid = score(i, 10, 200, 200.0);
-        let s_high = score(i, 1_000, 200, 200.0);
+        let s_low = score(i, 1, 200, 200.0, Bm25Params::STANDARD);
+        let s_mid = score(i, 10, 200, 200.0, Bm25Params::STANDARD);
+        let s_high = score(i, 1_000, 200, 200.0, Bm25Params::STANDARD);
 
         // Linear scaling would predict s_high ≈ 100 × s_mid.
         // Saturating scaling predicts s_high < 2 × s_mid (rough bound).
@@ -320,8 +384,8 @@ mod tests {
     fn score_decreases_with_doc_length() {
         // Longer docs should score lower for the same (term, tf).
         let i = idf(1_000_000, 100);
-        let s_short = score(i, 3, 50, 200.0);
-        let s_long = score(i, 3, 800, 200.0);
+        let s_short = score(i, 3, 50, 200.0, Bm25Params::STANDARD);
+        let s_long = score(i, 3, 800, 200.0, Bm25Params::STANDARD);
         assert!(s_short > s_long);
     }
 
@@ -334,7 +398,7 @@ mod tests {
         let avgdl = 200.0;
         let dl = 200;
         let expected = i * (tf as f32) * (K1 + 1.0) / ((tf as f32) + K1);
-        let actual = score(i, tf, dl, avgdl);
+        let actual = score(i, tf, dl, avgdl, Bm25Params::STANDARD);
         assert!(
             approx(actual, expected, 1e-5),
             "expected {expected}, got {actual}"
@@ -344,7 +408,7 @@ mod tests {
     #[test]
     fn score_handles_degenerate_avgdl_zero() {
         // Defensive: avgdl=0 must not panic or NaN.
-        let s = score(1.0, 1, 100, 0.0);
+        let s = score(1.0, 1, 100, 0.0, Bm25Params::STANDARD);
         assert!(s.is_finite());
         assert!(s >= 0.0);
     }
@@ -359,8 +423,8 @@ mod tests {
         // This test instead verifies that a small dl drives norm < 1
         // and therefore score *up* relative to dl=avgdl.
         let i = 2.0_f32;
-        let s_at_avgdl = score(i, 5, 200, 200.0);
-        let s_short = score(i, 5, 1, 200.0);
+        let s_at_avgdl = score(i, 5, 200, 200.0, Bm25Params::STANDARD);
+        let s_short = score(i, 5, 1, 200.0, Bm25Params::STANDARD);
         assert!(s_short > s_at_avgdl);
     }
 
@@ -370,8 +434,8 @@ mod tests {
         // (with default b=0.75). Score should be max for the (idf, tf)
         // shape — strictly larger than any positive-length variant.
         let i = 2.0_f32;
-        let s_zero_dl = score(i, 5, 0, 200.0);
-        let s_one_dl = score(i, 5, 1, 200.0);
+        let s_zero_dl = score(i, 5, 0, 200.0, Bm25Params::STANDARD);
+        let s_one_dl = score(i, 5, 1, 200.0, Bm25Params::STANDARD);
         assert!(s_zero_dl > s_one_dl);
     }
 
@@ -398,7 +462,7 @@ mod tests {
         let triples: [(f32, u32); 4] = [(1.5, 1), (1.7, 2), (2.0, 1), (1.2, 3)];
         let scalar: f32 = triples
             .iter()
-            .map(|(idf, tf)| score(*idf, *tf, dl, avgdl))
+            .map(|(idf, tf)| score(*idf, *tf, dl, avgdl, Bm25Params::STANDARD))
             .sum();
         let idfs_x_k1p1 = [
             triples[0].0 * (K1 + 1.0),

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -315,6 +315,11 @@ struct ColumnState {
     /// positional capture path in `add_doc` and the extended
     /// per-term layout at emit.
     positions: bool,
+    /// BM25 parameters for this column, from `FtsConfig::bm25`. The
+    /// per-block score bounds in the skip table are the block's true
+    /// max under this pair, and the pair itself is recorded in the
+    /// column's KV entry so the reader knows what the bounds mean.
+    params: bm25::Bm25Params,
 }
 
 /// Per-column posting accumulator. Starts in `InRam` mode; transitions
@@ -1386,9 +1391,12 @@ impl FtsBuilder {
     /// Register an FTS column up-front, tokenized with the builder's
     /// default tokenizer. Returns its `column_id` (its index in
     /// declaration order).
+    /// Scores with the standard BM25 pair; use
+    /// [`FtsBuilder::register_column_with_tokenizer`] to declare
+    /// another.
     pub fn register_column(&mut self, name: String, positions: bool) -> Result<u32, BuildError> {
         let tokenizer = Arc::clone(&self.default_tokenizer);
-        self.register_column_with_tokenizer(name, positions, tokenizer)
+        self.register_column_with_tokenizer(name, positions, tokenizer, bm25::Bm25Params::STANDARD)
     }
 
     /// Register an FTS column tokenized with an explicit `tokenizer`,
@@ -1399,6 +1407,7 @@ impl FtsBuilder {
         name: String,
         positions: bool,
         tokenizer: Arc<dyn Tokenizer>,
+        params: bm25::Bm25Params,
     ) -> Result<u32, BuildError> {
         if name.as_bytes().contains(&FST_SEPARATOR) {
             return Err(BuildError::ReservedSeparatorInColumnName(name));
@@ -1415,6 +1424,7 @@ impl FtsBuilder {
             doc_lengths: Vec::new(),
             total_tokens: 0,
             positions,
+            params,
         });
         self.postings.push(ColumnPostings::new());
         self.column_tokenizers.push(tokenizer);
@@ -2549,6 +2559,7 @@ impl FtsBuilder {
                 doc_lengths: col_doc_lengths_owned,
                 total_tokens: _,
                 positions: col_positions,
+                params,
             } = col_state;
             let col_name_bytes = col_name.as_bytes();
             let avgdl = avgdl_per_col[orig_col_idx];
@@ -2597,6 +2608,7 @@ impl FtsBuilder {
                     col_name_bytes,
                     col_doc_lengths,
                     avgdl,
+                    params,
                     n_docs,
                     &mut key_buf,
                     &mut postings_writer,
@@ -2759,6 +2771,7 @@ impl FtsBuilder {
                 doc_lengths: col_doc_lengths_owned,
                 total_tokens: _,
                 positions: col_positions,
+                params,
             } = col_state;
             let col_name_bytes = col_name.as_bytes();
             let avgdl = avgdl_per_col[orig_col_idx];
@@ -2802,6 +2815,7 @@ impl FtsBuilder {
                             col_name_bytes,
                             col_doc_lengths,
                             avgdl,
+                            params,
                             n_docs,
                             &mut key_buf,
                             &mut postings_writer,
@@ -2949,6 +2963,7 @@ impl FtsBuilder {
                             col_name_bytes,
                             col_doc_lengths,
                             avgdl,
+                            params,
                             n_docs,
                             &mut key_buf,
                             &mut postings_writer,
@@ -2986,6 +3001,7 @@ impl FtsBuilder {
                                 col_name_bytes,
                                 col_doc_lengths,
                                 avgdl,
+                                params,
                                 n_docs,
                                 &mut key_buf,
                                 &mut postings_writer,
@@ -3378,6 +3394,10 @@ fn assemble_and_write_blob<W: Write>(
     // The legacy ladder (V2/V3/V4) is written only when the coarse table is
     // suppressed (test-only), so the backwards-compat tests can produce a
     // genuine pre-086 blob.
+    // A column's BM25 parameters do not move the version: they are
+    // recorded in its `inf.fts.columns` entry and read back from there,
+    // so the stored per-block bound is interpreted against the pair that
+    // entry names. Nothing about the layout differs either way.
     let fts_version = if write_coarse {
         format::fts::VERSION_V5
     } else if finish_profile.saw_bitset_block {
@@ -3515,6 +3535,7 @@ fn merge_sorted_spill<const N: usize, W: Write>(
     col_name_bytes: &[u8],
     col_doc_lengths: &[u32],
     avgdl: f32,
+    params: bm25::Bm25Params,
     n_docs: u32,
     key_buf: &mut Vec<u8>,
     postings_writer: &mut W,
@@ -3626,6 +3647,7 @@ fn merge_sorted_spill<const N: usize, W: Write>(
             col_name_bytes,
             col_doc_lengths,
             avgdl,
+            params,
             n_docs,
             key_buf,
             postings_writer,
@@ -3667,6 +3689,7 @@ fn encode_and_emit_term<W: Write>(
     col_name_bytes: &[u8],
     col_doc_lengths: &[u32],
     avgdl: f32,
+    params: bm25::Bm25Params,
     n_docs: u32,
     key_buf: &mut Vec<u8>,
     postings_writer: &mut W,
@@ -3773,7 +3796,7 @@ fn encode_and_emit_term<W: Write>(
                 .map(|(&d, &t)| {
                     let reader_dl =
                         bm25::dequantize_len(bm25::quantize_len(col_doc_lengths[d as usize]));
-                    bm25::score(idf_t, t, reader_dl, avgdl)
+                    bm25::score(idf_t, t, reader_dl, avgdl, params)
                 })
                 .fold(0.0f32, f32::max);
             block_ub_per_block.push(block_ub);

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -502,7 +502,7 @@ impl FtsReader {
     /// Cheap enough to do per query: the clone is a `Bytes`/`Arc` bump
     /// for the blob, one `String` and one 1 KiB table per re-derived
     /// column, and no pass over any per-doc array.
-    pub fn with_bm25_override(&self, params: bm25::Bm25Params) -> Self {
+    pub(crate) fn with_bm25_override(&self, params: bm25::Bm25Params) -> Self {
         let mut view = self.clone();
         for col in &mut view.columns {
             if col.params == params {

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -45,6 +45,7 @@ use crate::superfile::{
         },
     },
     fts::{
+        bm25,
         builder::{DOC_LENGTHS_ENTRY_SIZE, TERM_META_SIZE},
         dict::{DictReader, make_key},
         fst_value::FstValue,
@@ -453,7 +454,7 @@ pub(super) fn two_term_has_rare_anchor(cursors: &[TermCursor]) -> bool {
 
 /// FTS blob reader. Self-contained — owns its `Bytes` (which the storage
 /// layer assembled from mmap / range-fetch / full-read).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FtsReader {
     pub(super) source: Source,
     pub(super) n_docs: u32,
@@ -483,6 +484,38 @@ pub struct FtsReader {
 }
 
 impl FtsReader {
+    /// A view of this reader that scores every column with `params`
+    /// instead of the pair that column declared.
+    ///
+    /// Two things change per column, and nothing else: the norm decode
+    /// table is re-derived at `params` (the per-doc length buckets are
+    /// shared, not copied — they carry no parameters), and
+    /// [`ColumnMeta::bound_scale`] picks up the factor that keeps the
+    /// *stored* bounds — which belong to the declared pair — upper
+    /// bounds under the new one. Results stay exact; only pruning power
+    /// is traded.
+    ///
+    /// A column whose declared pair already equals `params` is left
+    /// untouched, so a query that "overrides" with what the column
+    /// already uses costs nothing.
+    ///
+    /// Cheap enough to do per query: the clone is a `Bytes`/`Arc` bump
+    /// for the blob, one `String` and one 1 KiB table per re-derived
+    /// column, and no pass over any per-doc array.
+    pub fn with_bm25_override(&self, params: bm25::Bm25Params) -> Self {
+        let mut view = self.clone();
+        for col in &mut view.columns {
+            if col.params == params {
+                continue;
+            }
+            let rescored = col.dl_norm_k1.rescored(col.avgdl, params);
+            col.bound_scale = col.dl_norm_k1.bound_scale(&rescored, col.params, params);
+            col.dl_norm_k1 = rescored;
+            col.params = params;
+        }
+        view
+    }
+
     /// Open with default options (CRC verification on).
     pub fn open(blob: Bytes, columns_json: &str) -> Result<Self, FtsError> {
         Self::open_with(blob, columns_json, OpenOptions::default())
@@ -882,10 +915,15 @@ impl FtsReader {
             // For avgdl == 0 (empty column) this is an empty table; it'll
             // never be indexed since `search` short-circuits.
             let n = n_docs as usize;
+            // The column's declared parameters — recorded in the KV
+            // entry by every writer since they became recordable, and
+            // the standard pair for any file older than that.
+            let params = col_cfg.params();
             let dl_norm_k1 = NormTable::new(
                 (0..n).map(|d| read_u32_le(&array_region[d * 4..d * 4 + 4])),
                 n,
                 avgdl,
+                params,
             );
             let tokenizer = tokenizer_for_name(&col_cfg.tokenizer).ok_or_else(|| {
                 FtsError::Read(ReadError::MalformedVersion(format!(
@@ -898,6 +936,10 @@ impl FtsReader {
                 doc_lengths_range: doc_lengths_offset..array_end,
                 avgdl,
                 dl_norm_k1,
+                params,
+                // Scoring with the pair the bounds were baked at, so no
+                // correction. `with_bm25_override` is what changes this.
+                bound_scale: 1.0,
                 positions: col_cfg.positions,
                 tokenizer,
                 stored: col_cfg.stored,
@@ -1219,7 +1261,10 @@ impl FtsReader {
                 .collect();
             let positions = self.fetch_term_positions(&pos_ranges).await?;
             out.push(Some(AnyCursor::Phrase(PhraseCursor::new(
-                cursors, positions, positional,
+                cursors,
+                positions,
+                positional,
+                col_meta.params,
             )?)));
         }
         Ok((out, dict_ranges))
@@ -1350,6 +1395,12 @@ impl FtsReader {
                         false,
                         false,
                         self.has_coarse_block_max,
+                        // Carry-only: no scores, so the pair is irrelevant.
+                        bm25::Bm25Params::STANDARD,
+                        // This walk carries postings across into a merge; it
+                        // reads doc ids, tfs and positions and never consults
+                        // a score bound, so no correction applies.
+                        1.0,
                     )?;
                     while !cursor.is_exhausted() {
                         while cursor.pos < cursor.block_n {
@@ -1813,7 +1864,7 @@ mod tests {
     use super::{super::test_util::*, *};
     use crate::superfile::{
         BytesLazyByteSource,
-        fts::{builder::FtsBuilder, reader::BoolMode, tokenize::AsciiLowerTokenizer},
+        fts::{bm25, builder::FtsBuilder, reader::BoolMode, tokenize::AsciiLowerTokenizer},
     };
 
     #[test]
@@ -2025,6 +2076,270 @@ mod tests {
         let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
         let r = FtsReader::open(Bytes::from(b.finish().expect("finish")), json).expect("open");
         assert_eq!(r.read_doc_lengths(0).expect("doc lengths"), vec![3, 4]);
+    }
+
+    #[test]
+    fn declared_bm25_params_round_trip_through_the_column_entry() {
+        // A column whose entry records a non-standard pair: the reader
+        // must score with what the file says, never with the crate
+        // default, because the stored bounds were baked at that pair.
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column_with_tokenizer(
+            "body".into(),
+            false,
+            Arc::new(AsciiLowerTokenizer),
+            bm25::Bm25Params::new(1.4, 0.6),
+        )
+        .expect("register");
+        b.add_doc(0, 0, "a b a").expect("doc 0");
+        b.add_doc(0, 1, "b a c d").expect("doc 1");
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower","k1":1.4,"b":0.6}]"#;
+        let r = FtsReader::open(Bytes::from(b.finish().expect("finish")), json).expect("open");
+        assert_eq!(r.columns[0].params, bm25::Bm25Params::new(1.4, 0.6));
+        assert!(!r.columns[0].params.is_standard());
+    }
+
+    #[test]
+    fn a_column_entry_without_params_reads_as_the_standard_pair() {
+        // The frozen legacy default: a file written before the pair was
+        // recordable can only have been built with the standard values,
+        // so absence has exactly one meaning and must not track a later
+        // change to what the API recommends.
+        let tok = Arc::new(AsciiLowerTokenizer);
+        let mut b = FtsBuilder::new(tok);
+        b.register_column("body".into(), false).expect("register");
+        b.add_doc(0, 0, "a b a").expect("doc 0");
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(Bytes::from(b.finish().expect("finish")), json).expect("open");
+        assert_eq!(r.columns[0].params, bm25::Bm25Params::STANDARD);
+        assert_eq!(r.columns[0].params.k1, bm25::K1);
+        assert_eq!(r.columns[0].params.b, bm25::B);
+    }
+
+    #[test]
+    fn norm_table_is_built_from_the_declared_pair() {
+        // The per-doc buckets are lengths (parameter-free); the 256-entry
+        // decode table is where the parameters live. Two readers over the
+        // same corpus at different pairs must therefore disagree on the
+        // norm and agree on nothing else being different.
+        let build = |params: bm25::Bm25Params| {
+            let mut b = FtsBuilder::new(Arc::new(AsciiLowerTokenizer));
+            b.register_column_with_tokenizer(
+                "body".into(),
+                false,
+                Arc::new(AsciiLowerTokenizer),
+                params,
+            )
+            .expect("register");
+            b.add_doc(0, 0, "a b a").expect("doc 0");
+            b.add_doc(0, 1, "b a c d e f g h").expect("doc 1");
+            b.finish().expect("finish")
+        };
+
+        let std_json = r#"[{"name":"body","tokenizer":"ascii_lower","k1":1.2,"b":0.75}]"#;
+        let alt_json = r#"[{"name":"body","tokenizer":"ascii_lower","k1":1.4,"b":0.6}]"#;
+        let std_reader = FtsReader::open(Bytes::from(build(bm25::Bm25Params::STANDARD)), std_json)
+            .expect("open standard");
+        let alt_reader = FtsReader::open(
+            Bytes::from(build(bm25::Bm25Params::new(1.4, 0.6))),
+            alt_json,
+        )
+        .expect("open alt");
+
+        let std_norm = std_reader.columns[0].dl_norm_k1.get(1);
+        let alt_norm = alt_reader.columns[0].dl_norm_k1.get(1);
+        assert_ne!(
+            std_norm, alt_norm,
+            "the decode table must reflect the declared pair"
+        );
+        // And each matches the closed form for its own pair, against the
+        // quantized length the scorer actually sees.
+        let dl = bm25::stored_len(8);
+        let avgdl = std_reader.columns[0].avgdl;
+        assert!((std_norm - bm25::Bm25Params::STANDARD.dl_norm_k1(dl, avgdl)).abs() < 1e-6);
+        assert!((alt_norm - bm25::Bm25Params::new(1.4, 0.6).dl_norm_k1(dl, avgdl)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bound_scale_is_one_for_the_same_pair_and_above_one_otherwise() {
+        let mut b = FtsBuilder::new(Arc::new(AsciiLowerTokenizer));
+        b.register_column("body".into(), false).expect("register");
+        for d in 0..64u32 {
+            let words = (d % 30) + 1;
+            let text: String = (0..words).map(|w| format!("t{w} ")).collect();
+            b.add_doc(0, d, text.trim()).expect("add doc");
+        }
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(Bytes::from(b.finish().expect("finish")), json).expect("open");
+        let col = &r.columns[0];
+        let baked = col.params;
+
+        assert_eq!(
+            col.dl_norm_k1.bound_scale(&col.dl_norm_k1, baked, baked),
+            1.0,
+            "no correction when the query scores at the baked pair"
+        );
+
+        for (k1, b_param) in [(1.4_f32, 0.75_f32), (0.9, 0.75), (1.2, 0.4), (1.2, 0.0)] {
+            let query = bm25::Bm25Params::new(k1, b_param);
+            let other = col.dl_norm_k1.rescored(col.avgdl, query);
+            let r_factor = col.dl_norm_k1.bound_scale(&other, baked, query);
+            assert!(
+                r_factor >= 1.0,
+                "the factor must never shrink a bound: {k1}/{b_param} gave {r_factor}"
+            );
+        }
+    }
+
+    #[test]
+    fn bound_scale_keeps_the_bound_above_every_rescored_score() {
+        // The property the whole correction rests on: for any (tf, dl) in
+        // the column, R * score_at(baked) >= score_at(query). Checked
+        // against the closed form over the corpus's own length range
+        // rather than a hand-picked case.
+        let mut b = FtsBuilder::new(Arc::new(AsciiLowerTokenizer));
+        b.register_column("body".into(), false).expect("register");
+        for d in 0..128u32 {
+            let words = (d % 50) + 1;
+            let text: String = (0..words).map(|w| format!("t{w} ")).collect();
+            b.add_doc(0, d, text.trim()).expect("add doc");
+        }
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(Bytes::from(b.finish().expect("finish")), json).expect("open");
+        let col = &r.columns[0];
+        let baked = col.params;
+        let avgdl = col.avgdl;
+
+        for (k1, b_param) in [
+            (1.4_f32, 0.75_f32),
+            (0.5, 0.75),
+            (2.0, 0.75),
+            (1.2, 0.0),
+            (1.2, 1.0),
+            (0.5, 0.2),
+            (2.0, 1.0),
+        ] {
+            let query = bm25::Bm25Params::new(k1, b_param);
+            let other = col.dl_norm_k1.rescored(avgdl, query);
+            let r_factor = col.dl_norm_k1.bound_scale(&other, baked, query);
+            for dl in 1..=50u32 {
+                for tf in [1u32, 2, 3, 7, 20, 100] {
+                    let idf = 1.0_f32;
+                    let at_baked = bm25::score(idf, tf, bm25::stored_len(dl), avgdl, baked);
+                    let at_query = bm25::score(idf, tf, bm25::stored_len(dl), avgdl, query);
+                    assert!(
+                        r_factor * at_baked >= at_query - 1e-6,
+                        "R={r_factor} too small for k1={k1} b={b_param} tf={tf} dl={dl}: \
+                         {} vs {}",
+                        r_factor * at_baked,
+                        at_query
+                    );
+                }
+            }
+        }
+    }
+
+    /// The end-to-end guarantee behind the correction factor: scoring
+    /// with an override must produce exactly what a file *built* at
+    /// those parameters produces. Scores never depend on which pair the
+    /// bounds were baked at — only pruning does — so any divergence
+    /// means a bound was left too small and a qualifying document was
+    /// skipped.
+    #[tokio::test]
+    async fn an_override_scores_identically_to_a_file_baked_at_that_pair() {
+        let corpus: Vec<String> = (0..400u32)
+            .map(|d| {
+                let words = (d % 37) + 1;
+                let mut text: String = (0..words).map(|w| format!("t{} ", w % 11)).collect();
+                if d % 3 == 0 {
+                    text.push_str("common ");
+                }
+                if d % 29 == 0 {
+                    text.push_str("rare ");
+                }
+                text.trim().to_string()
+            })
+            .collect();
+
+        let build = |params: bm25::Bm25Params| {
+            let mut b = FtsBuilder::new(Arc::new(AsciiLowerTokenizer));
+            b.register_column_with_tokenizer(
+                "body".into(),
+                false,
+                Arc::new(AsciiLowerTokenizer),
+                params,
+            )
+            .expect("register");
+            for (i, t) in corpus.iter().enumerate() {
+                b.add_doc(0, i as u32, t).expect("add doc");
+            }
+            Bytes::from(b.finish().expect("finish"))
+        };
+
+        for (k1, b_param) in [(1.4_f32, 0.6_f32), (0.5, 0.9), (2.0, 0.2), (1.2, 0.0)] {
+            let params = bm25::Bm25Params::new(k1, b_param);
+            let json_std = r#"[{"name":"body","tokenizer":"ascii_lower","k1":1.2,"b":0.75}]"#;
+            let json_alt = format!(
+                r#"[{{"name":"body","tokenizer":"ascii_lower","k1":{k1:?},"b":{b_param:?}}}]"#
+            );
+
+            let baked_standard =
+                FtsReader::open(build(bm25::Bm25Params::STANDARD), json_std).expect("open std");
+            let baked_at_params = FtsReader::open(build(params), &json_alt).expect("open alt");
+            // Same query parameters, reached two ways: an override on a
+            // file baked at the standard pair, and a file baked at the
+            // pair itself.
+            let overridden = baked_standard.with_bm25_override(params);
+
+            for terms in [
+                &["common"][..],
+                &["rare"][..],
+                &["common", "rare"][..],
+                &["t0", "t1", "common"][..],
+            ] {
+                for k in [1usize, 10, 100] {
+                    let a = overridden
+                        .search("body", terms, k, BoolMode::Or)
+                        .await
+                        .expect("override search");
+                    let b = baked_at_params
+                        .search("body", terms, k, BoolMode::Or)
+                        .await
+                        .expect("baked search");
+                    assert_eq!(
+                        a.len(),
+                        b.len(),
+                        "hit count diverged for {terms:?} k={k} at k1={k1} b={b_param}"
+                    );
+                    for ((da, sa), (db, sb)) in a.iter().zip(b.iter()) {
+                        assert_eq!(
+                            da, db,
+                            "doc order diverged for {terms:?} k={k} at k1={k1} b={b_param}"
+                        );
+                        assert!(
+                            (sa - sb).abs() < 1e-4,
+                            "score diverged for doc {da} on {terms:?} at k1={k1} b={b_param}: \
+                             {sa} vs {sb}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// An override equal to what the column already declares is a no-op:
+    /// no rescaled table, no correction factor.
+    #[test]
+    fn an_override_matching_the_declared_pair_changes_nothing() {
+        let mut b = FtsBuilder::new(Arc::new(AsciiLowerTokenizer));
+        b.register_column("body".into(), false).expect("register");
+        b.add_doc(0, 0, "a b a").expect("doc 0");
+        let json = r#"[{"name":"body","tokenizer":"ascii_lower"}]"#;
+        let r = FtsReader::open(Bytes::from(b.finish().expect("finish")), json).expect("open");
+        let same = r.with_bm25_override(bm25::Bm25Params::STANDARD);
+        assert_eq!(same.columns[0].bound_scale, 1.0);
+        assert_eq!(same.columns[0].params, r.columns[0].params);
     }
 
     #[test]

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -2097,7 +2097,7 @@ mod tests {
         let json = r#"[{"name":"body","tokenizer":"ascii_lower","k1":1.4,"b":0.6}]"#;
         let r = FtsReader::open(Bytes::from(b.finish().expect("finish")), json).expect("open");
         assert_eq!(r.columns[0].params, bm25::Bm25Params::new(1.4, 0.6));
-        assert!(!r.columns[0].params.is_standard());
+        assert_ne!(r.columns[0].params, bm25::Bm25Params::STANDARD);
     }
 
     #[test]

--- a/src/superfile/fts/reader/cursor.rs
+++ b/src/superfile/fts/reader/cursor.rs
@@ -338,13 +338,17 @@ pub(super) struct BlockMeta {
 /// iteration.
 #[derive(Clone)]
 pub(crate) struct TermCursor {
-    /// Precomputed `idf * (K1 + 1)` — the score numerator's
-    /// per-cursor constant. Computed once at cursor build so the
-    /// hot inner loop fits one multiply + add + divide per call.
-    /// (The bare `idf` value isn't kept on the cursor — every hot
-    /// scoring path uses `score_with_dl_norm_k1` which takes
-    /// `idf_x_k1p1` directly.)
+    /// Precomputed `idf * (k1 + 1)` — the score numerator's
+    /// per-cursor constant, built from the parameters this query is
+    /// scoring with. Computed once at cursor build so the hot inner
+    /// loop fits one multiply + add + divide per call.
     pub(super) idf_x_k1p1: f32,
+    /// The bare effective idf (global override and repeated-term
+    /// `weight` already folded in). Kept alongside `idf_x_k1p1` because
+    /// a phrase cursor composes its members' idfs, and recovering one
+    /// by dividing by `(k1 + 1)` would silently use the wrong `k1` the
+    /// moment a column declares a non-standard pair.
+    pub(super) idf: f32,
     /// Maximum block-max-BM25 across all blocks. Used by the WAND
     /// pivot test (term-level upper bound).
     pub(super) term_max_bm25: f32,
@@ -431,6 +435,8 @@ impl TermCursor {
         header_probed: bool,
         count_only: bool,
         has_coarse: bool,
+        params: bm25::Bm25Params,
+        bound_scale: f32,
     ) -> Result<Self, FtsError> {
         let postings: &[u8] = term_bytes.as_ref();
         let metadata_offset = 0usize;
@@ -452,10 +458,25 @@ impl TermCursor {
         // from `idf_x_k1p1` below. When `idf == local_idf` (the default
         // per-superfile path with weight 1) the ratio is 1 and the block loop does
         // no extra work, matching the per-superfile scorer exactly.
-        let idf_rescale = if local_idf > 0.0 && idf != local_idf {
-            Some(idf / local_idf)
-        } else {
-            None
+        // Two independent reasons a stored bound needs scaling, and both
+        // are linear multipliers on it, so they compose into one:
+        //
+        //   idf / local_idf — the bounds bake in this superfile's own
+        //     idf; a global-statistics override or a repeated-term
+        //     `weight` scales the score away from it. Exact, since the
+        //     score is linear in idf.
+        //   bound_scale — the bounds were baked at the column's declared
+        //     BM25 pair; a query scoring at another needs them inflated
+        //     by the supremum of the ratio between the two. Loosening
+        //     rather than exact, because k1/b do not enter linearly.
+        //
+        // Both are 1.0 on the default path (per-superfile stats, weight
+        // 1, no parameter override), and the block loop then does no
+        // extra work at all.
+        let idf_ratio = (local_idf > 0.0 && idf != local_idf).then(|| idf / local_idf);
+        let idf_rescale = match (idf_ratio, bound_scale != 1.0) {
+            (None, false) => None,
+            (ratio, _) => Some(ratio.unwrap_or(1.0) * bound_scale),
         };
 
         // Collect straight into the `Arc` allocation: `0..num_blocks` is
@@ -485,7 +506,8 @@ impl TermCursor {
             .collect();
 
         let mut cursor = Self {
-            idf_x_k1p1: idf * (bm25::K1 + 1.0),
+            idf_x_k1p1: params.idf_x_k1p1(idf),
+            idf,
             term_max_bm25,
             df: term_meta.df,
             blocks,
@@ -521,11 +543,12 @@ impl TermCursor {
         dl_norm_k1: f32,
         global_idf: Option<f32>,
         weight: u32,
+        params: bm25::Bm25Params,
     ) -> Self {
         // Fold the qtf `weight` into the effective idf so the single-doc block-max
         // (computed below from `idf_x_k1p1`) scales together with the score.
         let idf = global_idf.unwrap_or_else(|| bm25::idf(n_docs, 1)) * weight as f32;
-        let idf_x_k1p1 = idf * (bm25::K1 + 1.0);
+        let idf_x_k1p1 = params.idf_x_k1p1(idf);
         let block_max_bm25 = bm25::score_with_dl_norm_k1(idf_x_k1p1, tf, dl_norm_k1);
 
         let blocks: Arc<[BlockMeta]> = Arc::from([BlockMeta {
@@ -545,6 +568,7 @@ impl TermCursor {
 
         Self {
             idf_x_k1p1,
+            idf,
             term_max_bm25: block_max_bm25,
             df: 1,
             blocks,

--- a/src/superfile/fts/reader/metadata.rs
+++ b/src/superfile/fts/reader/metadata.rs
@@ -26,36 +26,105 @@ use crate::superfile::fts::{bm25, tokenize::Tokenizer};
 #[derive(Debug, Clone)]
 pub struct NormTable {
     /// Per-doc quantized length bucket. Empty for a column with no docs.
-    bytes: Vec<u8>,
-    /// Bucket → `K1·(1 - B + B·dequantize_len(bucket)/avgdl)`. A fixed
+    /// Parameter-free — the buckets are lengths, not norms — and shared
+    /// rather than copied so [`NormTable::rescored`] costs one `Arc`
+    /// bump plus a 1 KiB table instead of a pass over every doc.
+    bytes: Arc<[u8]>,
+    /// Bucket → `k1·(1 - b + b·dequantize_len(bucket)/avgdl)`. A fixed
     /// 256-entry table, boxed so `ColumnMeta` stays pointer-sized (it is
     /// scanned by non-scoring paths — column lookup, listing) while the
     /// `u8` bucket index into a fixed-length array lets the compiler drop
-    /// the bounds check in `get`.
-    lut: Box<[f32; 256]>,
+    /// the bounds check in `get`. This is the only parameter-dependent
+    /// part of the table.
+    lut: Arc<[f32; 256]>,
+    /// Lowest and highest bucket any doc in this column actually
+    /// occupies, tracked at build so [`NormTable::bound_scale`] takes
+    /// its supremum over lengths that occur rather than over all 256
+    /// representable ones. `(0, 0)` for an empty column.
+    occupied: (u8, u8),
 }
 
 impl NormTable {
     /// Build from a column's per-doc lengths and average length. An
     /// `avgdl` of `0.0` (empty column) yields an empty table; it is
     /// never indexed because `search` short-circuits on empty columns.
-    pub(super) fn new(doc_lengths: impl Iterator<Item = u32>, n_docs: usize, avgdl: f32) -> Self {
+    pub(super) fn new(
+        doc_lengths: impl Iterator<Item = u32>,
+        n_docs: usize,
+        avgdl: f32,
+        params: bm25::Bm25Params,
+    ) -> Self {
         if avgdl <= 0.0 {
             return Self::empty();
         }
-        let inv_avgdl = 1.0_f32 / avgdl;
-        // Fill the boxed table in place so the 256 f32s land on the heap
-        // directly rather than being built on the stack and moved.
-        let mut lut = Box::new([0.0_f32; 256]);
-        for (b, slot) in lut.iter_mut().enumerate() {
-            let dl = bm25::dequantize_len(b as u8) as f32;
-            *slot = bm25::K1 * (1.0 - bm25::B + bm25::B * dl * inv_avgdl);
-        }
         let mut bytes = Vec::with_capacity(n_docs);
+        let mut lo = u8::MAX;
+        let mut hi = u8::MIN;
         for dl in doc_lengths {
-            bytes.push(bm25::quantize_len(dl));
+            let bucket = bm25::quantize_len(dl);
+            lo = lo.min(bucket);
+            hi = hi.max(bucket);
+            bytes.push(bucket);
         }
-        Self { bytes, lut }
+        let occupied = if bytes.is_empty() { (0, 0) } else { (lo, hi) };
+        Self {
+            bytes: Arc::from(bytes),
+            lut: build_lut(avgdl, params),
+            occupied,
+        }
+    }
+
+    /// The same per-doc buckets decoded at different parameters — for a
+    /// query that overrides what its column declared. Shares `bytes`,
+    /// so the cost is one 256-entry table.
+    pub(super) fn rescored(&self, avgdl: f32, params: bm25::Bm25Params) -> Self {
+        if self.bytes.is_empty() {
+            return Self::empty();
+        }
+        Self {
+            bytes: Arc::clone(&self.bytes),
+            lut: build_lut(avgdl, params),
+            occupied: self.occupied,
+        }
+    }
+
+    /// The factor `R >= 1` by which every bound built at `baked` must be
+    /// inflated to stay an upper bound under `query`'s parameters, where
+    /// `self` is the norm table at `baked` and `other` the one at
+    /// `query`.
+    ///
+    /// The stored per-block bound is the block's true max of
+    /// `idf·tf·(k1+1) / (tf + dl_norm_k1)`. Between two parameter sets
+    /// the per-doc ratio is
+    ///
+    /// ```text
+    ///   (k1'+1)/(k1+1) · (tf + A) / (tf + B),
+    ///       A = lut_baked[bucket],  B = lut_query[bucket]
+    /// ```
+    ///
+    /// with `idf` cancelling — it carries no parameters. For a fixed
+    /// bucket that is monotone in `tf` and tends to 1, so its supremum
+    /// over `tf >= 1` is `max(1, (1+A)/(1+B))`; taking the max over the
+    /// buckets docs actually occupy gives the supremum over the column.
+    /// Loosening, never under-bounding, and exactly `1.0` when the two
+    /// parameter sets agree.
+    pub(super) fn bound_scale(
+        &self,
+        other: &NormTable,
+        baked: bm25::Bm25Params,
+        query: bm25::Bm25Params,
+    ) -> f32 {
+        if baked == query || self.bytes.is_empty() {
+            return 1.0;
+        }
+        let (lo, hi) = self.occupied;
+        let mut worst = 1.0_f32;
+        for bucket in lo..=hi {
+            let a = self.lut[bucket as usize];
+            let b = other.lut[bucket as usize];
+            worst = worst.max((1.0 + a) / (1.0 + b));
+        }
+        worst * (query.k1 + 1.0) / (baked.k1 + 1.0)
     }
 
     /// `dl_norm_k1` for a doc (length quantized): one per-doc byte load
@@ -79,10 +148,23 @@ impl NormTable {
     /// read.
     pub(super) fn empty() -> Self {
         Self {
-            bytes: Vec::new(),
-            lut: Box::new([0.0; 256]),
+            bytes: Arc::from(Vec::new()),
+            lut: Arc::new([0.0; 256]),
+            occupied: (0, 0),
         }
     }
+}
+
+/// Decode table for one parameter set: bucket → `dl_norm_k1`. Filled in
+/// place on the heap so the 256 `f32`s are not built on the stack and
+/// moved.
+fn build_lut(avgdl: f32, params: bm25::Bm25Params) -> Arc<[f32; 256]> {
+    let mut lut = Box::new([0.0_f32; 256]);
+    for (bucket, slot) in lut.iter_mut().enumerate() {
+        let dl = bm25::dequantize_len(bucket as u8);
+        *slot = params.dl_norm_k1(dl, avgdl);
+    }
+    Arc::from(lut)
 }
 
 /// Per-column metadata, indexed by column_id (declaration order).
@@ -101,6 +183,19 @@ pub struct ColumnMeta {
     /// `dl_norm_k1.get(d)` and multiplies-out to `idf · tf · (K1+1) /
     /// (tf + dl_norm_k1.get(d))`.
     pub dl_norm_k1: NormTable,
+    /// The parameters this column is being *scored* with. Equal to the
+    /// pair recorded in the KV entry unless the query overrode it, in
+    /// which case `dl_norm_k1` has been re-decoded to match and
+    /// `bound_scale` carries the correction for the stored bounds.
+    pub params: bm25::Bm25Params,
+    /// Factor to apply to every bound read out of the skip table or the
+    /// coarse table before comparing it against a score. `1.0` unless
+    /// the query overrode this column's parameters, in which case it is
+    /// [`NormTable::bound_scale`] between the baked pair and the
+    /// query's — the stored bounds belong to the baked pair, and
+    /// inflating them by this keeps them upper bounds under the pair
+    /// actually being scored.
+    pub bound_scale: f32,
     /// Whether this column's index carries token positions (from
     /// `inf.fts.columns`); phrase queries require it.
     pub positions: bool,
@@ -138,10 +233,39 @@ pub struct FtsColumnConfig {
     /// `true` (the writer emits it only when `false`).
     #[serde(default = "default_stored")]
     pub stored: bool,
+    /// BM25 term-frequency saturation this column's stored block-max
+    /// bounds were built with. Files written before the parameters were
+    /// recordable lack the field, and can only have been built with the
+    /// standard value — so the default here is frozen at
+    /// [`bm25::K1`] and must not follow a change to what the API
+    /// recommends. The writer emits it unconditionally, defaults
+    /// included, so no reader of a current file has to fall back on
+    /// this.
+    #[serde(default = "default_k1")]
+    pub k1: f32,
+    /// BM25 length normalization, same provenance and same frozen
+    /// default ([`bm25::B`]) as [`FtsColumnConfig::k1`].
+    #[serde(default = "default_b")]
+    pub b: f32,
+}
+
+impl FtsColumnConfig {
+    /// The parameters this column's bounds were baked at.
+    pub fn params(&self) -> bm25::Bm25Params {
+        bm25::Bm25Params::new(self.k1, self.b)
+    }
 }
 
 pub(super) fn default_stored() -> bool {
     true
+}
+
+pub(super) fn default_k1() -> f32 {
+    bm25::K1
+}
+
+pub(super) fn default_b() -> f32 {
+    bm25::B
 }
 
 /// Per-open knobs for [`FtsReader::open_with`]. Mirrors the
@@ -259,7 +383,7 @@ mod tests {
         let r = FtsReader::open(Bytes::from(bytes), json).expect("open");
         let nt = &r.columns[0].dl_norm_k1;
 
-        let per_doc = nt.bytes.capacity(); // 1 byte/doc
+        let per_doc = nt.bytes.len(); // 1 byte/doc
         let lut = std::mem::size_of_val(&*nt.lut); // 256 * 4 = 1 KiB
         let m2_bytes = per_doc + lut;
         let f32_baseline = N as usize * std::mem::size_of::<f32>();

--- a/src/superfile/fts/reader/options.rs
+++ b/src/superfile/fts/reader/options.rs
@@ -5,6 +5,8 @@
 //! the [`Bm25Stats`] idf-source selector, and the [`Bm25SearchOptions`]
 //! builder. Part of the `fts::reader::*` public surface.
 
+use crate::superfile::fts::bm25::Bm25Params;
+
 /// Default operator for a query's bare (sigil-less) terms. Terms
 /// carrying an explicit clause sigil keep their polarity regardless
 /// of mode: `+term` is a must (every hit contains it), `-term` a
@@ -67,12 +69,33 @@ impl From<&str> for Bm25Stats {
 /// // AND mode, per-superfile (segment-local) stats:
 /// Bm25SearchOptions::new().with_mode(BoolMode::And).with_stats(Bm25Stats::PerSuperfile)
 /// ```
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+/// `#[non_exhaustive]`: construct with [`Bm25SearchOptions::new`] and
+/// the `with_*` setters. The attribute is what lets a further search
+/// option be added without breaking callers — adding a field to a
+/// struct that can be built with a literal is a breaking change no
+/// matter what the field defaults to, because Rust literals must name
+/// every field.
+///
+/// `Eq` is deliberately absent: [`Bm25SearchOptions::bm25`] holds
+/// `f32`s, which have no total equality. `PartialEq` is derived.
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[non_exhaustive]
 pub struct Bm25SearchOptions {
     /// Boolean mode for the query's bare terms (`Or` = should, `And` = must).
     pub mode: BoolMode,
     /// Which BM25 corpus statistics to score with.
     pub stats: Bm25Stats,
+    /// Similarity parameters to score with, overriding whatever each
+    /// column declared. `None` — the default — scores every column with
+    /// its own declared pair, which is also the pair its stored bounds
+    /// were baked at, so the query pays nothing for pruning.
+    ///
+    /// An override is corrected for: the reader inflates each column's
+    /// stored bounds by the supremum of the ratio between the two
+    /// parameter sets, so results stay exact and only pruning power is
+    /// traded. A column whose declared pair already equals the override
+    /// pays nothing either.
+    pub bm25: Option<Bm25Params>,
 }
 
 impl Bm25SearchOptions {
@@ -90,6 +113,21 @@ impl Bm25SearchOptions {
     /// Set which BM25 corpus statistics to score with.
     pub fn with_stats(mut self, stats: Bm25Stats) -> Self {
         self.stats = stats;
+        self
+    }
+
+    /// Score with these similarity parameters instead of each column's
+    /// declared pair — `k1` (term frequency saturation, `> 0`) and `b`
+    /// (length normalization, in `[0, 1]`). Invalid values are rejected
+    /// when the search runs.
+    ///
+    /// Intended for relevance experimentation, which is what a
+    /// query-time knob is good for: it needs no rebuild, and the cost
+    /// is bound looseness rather than wrong results. A pair you mean to
+    /// keep belongs on the column (`FtsField::bm25`), where the bounds
+    /// are built with it and the correction disappears.
+    pub fn with_bm25(mut self, k1: f32, b: f32) -> Self {
+        self.bm25 = Some(Bm25Params::new(k1, b));
         self
     }
 }

--- a/src/superfile/fts/reader/phrase.rs
+++ b/src/superfile/fts/reader/phrase.rs
@@ -184,8 +184,13 @@ pub(super) struct PhraseCursor {
     /// Positional verification still runs in query order (`members`
     /// order), which the phrase adjacency check requires.
     pub(super) align_order: Vec<usize>,
-    /// Σ member idf × (K1 + 1) — the phrase's scoring constant.
+    /// Σ member idf × (k1 + 1) — the phrase's scoring constant, built
+    /// with the parameters this query scores with.
     pub(super) idf_x_k1p1: f32,
+    /// Σ member idf, kept so a bound in the "scaled" form can be
+    /// recovered without dividing `idf_x_k1p1` by a `(k1 + 1)` the
+    /// cursor would have to guess.
+    pub(super) idf_sum: f32,
     /// Phrase-scaled term-level upper bound (see type docs).
     pub(super) term_max_bm25: f32,
     /// Aligned-and-verified doc, or `u32::MAX` when exhausted.
@@ -207,6 +212,7 @@ impl PhraseCursor {
         cursors: Vec<TermCursor>,
         positions: Vec<Bytes>,
         positional: Vec<(Option<TermMeta>, Option<u32>)>,
+        params: bm25::Bm25Params,
     ) -> Result<Self, FtsError> {
         debug_assert!(cursors.len() >= 2, "single-token phrases degrade to terms");
         debug_assert_eq!(cursors.len(), positions.len());
@@ -218,7 +224,11 @@ impl PhraseCursor {
             .zip(positions)
             .zip(positional)
             .map(|((cursor, positions), (term_meta, inline_position))| {
-                let idf = cursor.idf_x_k1p1 / (bm25::K1 + 1.0);
+                // The member's own idf, not `idf_x_k1p1 / (K1 + 1)`:
+                // dividing by the crate constant would recover the wrong
+                // value for a column scoring at a declared or overridden
+                // pair.
+                let idf = cursor.idf;
                 min_scaled_bound = min_scaled_bound.min(cursor.term_max_bm25 / idf);
                 idf_sum += idf;
                 PhraseMember {
@@ -240,7 +250,8 @@ impl PhraseCursor {
         let mut align_order: Vec<usize> = (0..members.len()).collect();
         align_order.sort_by_key(|&i| members[i].cursor.block_count());
         let mut cursor = Self {
-            idf_x_k1p1: idf_sum * (bm25::K1 + 1.0),
+            idf_x_k1p1: params.idf_x_k1p1(idf_sum),
+            idf_sum,
             term_max_bm25: idf_sum * min_scaled_bound,
             members,
             align_order,
@@ -532,7 +543,7 @@ impl PhraseCursor {
             let b = m.cursor.block_max_in_range(range_start, range_end);
             min_scaled = min_scaled.min(b / m.idf);
         }
-        let idf_sum = self.idf_x_k1p1 / (bm25::K1 + 1.0);
+        let idf_sum = self.idf_sum;
         idf_sum * min_scaled
     }
 }

--- a/src/superfile/fts/reader/search.rs
+++ b/src/superfile/fts/reader/search.rs
@@ -1031,7 +1031,7 @@ impl FtsReader {
                     false => tf,
                 };
                 let idf_t = global_idf.unwrap_or_else(|| bm25::idf(self.n_docs as u64, 1));
-                let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);
+                let idf_x_k1p1 = col_meta.params.idf_x_k1p1(idf_t);
                 // Drop the lone match if a negated term excludes it.
                 // The inline slot read no postings-region bytes; the
                 // work-stats byte count for this path is genuinely zero.
@@ -1070,17 +1070,25 @@ impl FtsReader {
 
         let local_idf = bm25::idf(self.n_docs as u64, term_meta.df);
         let idf_t = global_idf.unwrap_or(local_idf);
-        let idf_x_k1p1 = idf_t * (bm25::K1 + 1.0);
+        let idf_x_k1p1 = col_meta.params.idf_x_k1p1(idf_t);
         // Stored block-max and coarse entries bake in the LOCAL idf. Scores
         // below use the (possibly overridden) effective idf, and the score
         // is linear in idf, so rescaling every stored bound by the ratio
         // keeps bounds exactly as tight as the per-superfile path — the
         // same exact rescale `TermCursor::new` applies (see cursor.rs).
-        let bound_rescale = if local_idf > 0.0 && idf_t != local_idf {
-            idf_t / local_idf
-        } else {
-            1.0
-        };
+        let bound_rescale = match local_idf > 0.0 && idf_t != local_idf {
+            true => idf_t / local_idf,
+            false => 1.0,
+        }
+        // And the same again for a parameter override: the stored bounds
+        // were baked at the column's declared pair, so scoring at
+        // another needs them inflated by the supremum of the ratio
+        // between the two. Both factors are linear multipliers on a
+        // stored bound, so they compose; both are 1.0 on the default
+        // path. See `ColumnMeta::bound_scale` and `TermCursor::new`,
+        // which does the identical composition for the multi-term
+        // kernels.
+        * col_meta.bound_scale;
         let dl_norm_k1 = &col_meta.dl_norm_k1;
 
         // Top-k min-heap; see `TopKEntry` for the reversed ordering
@@ -1536,6 +1544,7 @@ impl FtsReader {
                         dl_norm_k1,
                         gidf,
                         weight,
+                        col_meta.params,
                     )));
                 }
                 Some(Resolved::Memo {
@@ -1556,6 +1565,8 @@ impl FtsReader {
                         header_probed,
                         count_only,
                         self.has_coarse_block_max,
+                        col_meta.params,
+                        col_meta.bound_scale,
                     )?;
                     cursors.push(Some(cursor));
                 }
@@ -1578,6 +1589,7 @@ impl FtsReader {
                         dl_norm_k1,
                         gidf,
                         weight,
+                        col_meta.params,
                     );
                     cursors.push(Some(cursor));
                 }
@@ -1595,6 +1607,8 @@ impl FtsReader {
                         header_probed,
                         count_only,
                         self.has_coarse_block_max,
+                        col_meta.params,
+                        col_meta.bound_scale,
                     )?;
                     cursors.push(Some(cursor));
                 }

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -52,6 +52,7 @@ use crate::{
         BytesLazyByteSource, LazyByteSource, LazySubSource, ReadError,
         format::{self, footer, kv},
         fts::{
+            bm25::Bm25Params,
             reader::{
                 self as fts_reader, BoolMode, ClauseLists, FtsReader, MatchWork, OrCursorSet,
                 PreparedClauses, TermPattern,
@@ -1414,20 +1415,46 @@ impl SuperfileReader {
         lists: ClauseLists<'_>,
         k: usize,
         floor: f32,
+        bm25: Option<Bm25Params>,
     ) -> Result<PreparedClauses, ReadError> {
-        let fts = self
-            .fts()
-            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        let fts = self.fts_scored(bm25)?;
         Ok(fts.prepare_clauses(column, lists, k, floor).await?)
     }
 
     /// CPU half paired with [`Self::prepare_clauses`] — scores the
     /// cursors it fetched.
-    pub(crate) fn run_prepared(&self, prep: PreparedClauses) -> Result<Vec<(u32, f32)>, ReadError> {
+    ///
+    /// `bm25` must be the same override the paired `prepare_clauses`
+    /// was given: the cursors carry `idf · (k1 + 1)` from the pair they
+    /// were built with, and scoring divides by a norm table derived
+    /// from the same pair. `with_bm25_override` is deterministic, so
+    /// two separately-derived views of one pair agree bit for bit.
+    pub(crate) fn run_prepared(
+        &self,
+        prep: PreparedClauses,
+        bm25: Option<Bm25Params>,
+    ) -> Result<Vec<(u32, f32)>, ReadError> {
+        let fts = self.fts_scored(bm25)?;
+        Ok(fts.run_prepared(prep)?)
+    }
+
+    /// The FTS reader a scored query should read through: this
+    /// superfile's own, or a view of it that scores with `bm25`
+    /// instead of what each column declared.
+    ///
+    /// Borrowed when there is no override, which is the default path
+    /// and costs nothing. An override clones the reader — an `Arc` bump
+    /// for the blob plus one 1 KiB decode table per column whose pair
+    /// actually differs — and records the factor that keeps each
+    /// column's stored bounds upper bounds under the new pair.
+    fn fts_scored(&self, bm25: Option<Bm25Params>) -> Result<Cow<'_, FtsReader>, ReadError> {
         let fts = self
             .fts()
             .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
-        Ok(fts.run_prepared(prep)?)
+        Ok(match bm25 {
+            Some(params) => Cow::Owned(fts.with_bm25_override(params)),
+            None => Cow::Borrowed(fts),
+        })
     }
 
     /// Prefix-expanded BM25 search.
@@ -1598,10 +1625,9 @@ impl SuperfileReader {
         doc_id_start: u32,
         doc_id_end: u32,
         floor: f32,
+        bm25: Option<Bm25Params>,
     ) -> Result<Vec<(u32, f32)>, ReadError> {
-        let fts = self
-            .fts()
-            .ok_or_else(|| ReadError::MissingKv(kv::FTS_OFFSET))?;
+        let fts = self.fts_scored(bm25)?;
         Ok(fts.search_or_range_prebuilt(set, k, doc_id_start, doc_id_end, floor)?)
     }
 
@@ -1626,7 +1652,16 @@ impl SuperfileReader {
             return Ok(Vec::new());
         }
         let set = self.bm25_prefix_cursor_set(column, prefix, pool).await?;
-        self.bm25_search_or_range_prebuilt(&set, k, doc_id_start, doc_id_end, f32::NEG_INFINITY)
+        // Prefix search has no search-options surface, so columns score
+        // with the pair they declared.
+        self.bm25_search_or_range_prebuilt(
+            &set,
+            k,
+            doc_id_start,
+            doc_id_end,
+            f32::NEG_INFINITY,
+            None,
+        )
     }
 
     /// Multi-column BM25 search with per-column weights ("most

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -2901,14 +2901,30 @@ mod tests {
         measured_iters: usize,
     ) -> u128 {
         for _ in 0..warmup_iters {
-            st.bm25_search("title", query, 10, BoolMode::Or, Bm25Stats::Global, None)
-                .expect("bm25_search warmup");
+            st.bm25_search(
+                "title",
+                query,
+                10,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
+            .expect("bm25_search warmup");
         }
         let mut samples = Vec::with_capacity(measured_iters);
         for _ in 0..measured_iters {
             let start = Instant::now();
-            st.bm25_search("title", query, 10, BoolMode::Or, Bm25Stats::Global, None)
-                .expect("bm25_search measured");
+            st.bm25_search(
+                "title",
+                query,
+                10,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
+            .expect("bm25_search measured");
             samples.push(start.elapsed().as_micros());
         }
         samples.sort_unstable();

--- a/src/supertable/compaction/mod.rs
+++ b/src/supertable/compaction/mod.rs
@@ -969,7 +969,7 @@ mod tests {
         Bm25Stats, BoolMode, VectorSearchOptions,
         config::DEFAULT_STALE_SEAL_TIMEOUT_MS,
         memory::ConnectionMemoryBudget,
-        superfile::builder::FtsConfig,
+        superfile::{builder::FtsConfig, fts::reader::Bm25SearchOptions},
         supertable::{
             Supertable, SupertableOptions,
             error::CompactionError,
@@ -2905,7 +2905,7 @@ mod tests {
                 "title",
                 query,
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 None,
@@ -2919,7 +2919,7 @@ mod tests {
                 "title",
                 query,
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 None,

--- a/src/supertable/error.rs
+++ b/src/supertable/error.rs
@@ -48,6 +48,17 @@ pub enum BuildError {
     #[error("FTS column {column:?} must be LargeUtf8; found {actual}")]
     FtsColumnMustBeLargeUtf8 { column: String, actual: String },
 
+    /// A column declared BM25 parameters outside their valid ranges.
+    /// Caught before anything is written: the build bakes the
+    /// block-max bounds with these, so a nonsense pair would otherwise
+    /// surface much later as strange scores rather than as a rejected
+    /// table.
+    #[error(
+        "FTS column {column:?}: BM25 k1 must be finite and > 0, b must be finite and in [0, 1]; \
+         got k1={k1}, b={b}"
+    )]
+    FtsBm25ParamsOutOfRange { column: String, k1: f32, b: f32 },
+
     #[error("vector column {column:?} not found in schema")]
     VectorColumnMissing { column: String },
 

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -2343,6 +2343,7 @@ mod tests {
         storage::{LocalFsStorageProvider, ObjectMeta, StorageError, StorageProvider},
         superfile::{
             builder::{FtsConfig, VectorConfig},
+            fts::reader::Bm25SearchOptions,
             vector::{distance::Metric, layout::VectorLayout, rerank_codec::RerankCodec},
         },
         supertable::{
@@ -4430,7 +4431,7 @@ mod tests {
                 "title",
                 "doc",
                 5,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 None,
@@ -4447,7 +4448,7 @@ mod tests {
                 "title",
                 "doc",
                 5,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 None,
@@ -8450,7 +8451,7 @@ mod tests {
                 "title",
                 query,
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 None,

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -4426,7 +4426,15 @@ mod tests {
         // pre-compact warm/cold queries against a disk-cache consumer).
         use crate::superfile::fts::reader::{Bm25Stats, BoolMode};
         let hits = consumer
-            .bm25_search("title", "doc", 5, BoolMode::Or, Bm25Stats::Global, None)
+            .bm25_search(
+                "title",
+                "doc",
+                5,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
             .expect("bm25 pre-optimize");
         assert!(!hits.is_empty(), "pre-optimize FTS should return hits");
 
@@ -4435,7 +4443,15 @@ mod tests {
             .expect("sql-shaped optimize after lazy reads");
 
         let hits_after = consumer
-            .bm25_search("title", "doc", 5, BoolMode::Or, Bm25Stats::Global, None)
+            .bm25_search(
+                "title",
+                "doc",
+                5,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
             .expect("bm25 post-optimize");
         assert!(
             !hits_after.is_empty(),
@@ -8430,7 +8446,15 @@ mod tests {
     fn bm25_title_hits(table: &Supertable, query: &str) -> usize {
         use crate::superfile::fts::reader::{Bm25Stats, BoolMode};
         table
-            .bm25_search("title", query, 10, BoolMode::Or, Bm25Stats::Global, None)
+            .bm25_search(
+                "title",
+                query,
+                10,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
             .expect("bm25 search")
             .iter()
             .map(|b| b.num_rows())

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -1460,6 +1460,57 @@ mod tests {
         );
     }
 
+    /// A declared pair outside its valid ranges is refused before
+    /// anything is written. The build bakes the block-max bounds with
+    /// these values, so accepting a nonsense pair would surface much
+    /// later as strange scores rather than as a rejected table.
+    #[test]
+    fn fts_bm25_params_out_of_range_rejected() {
+        let s = Arc::new(Schema::new(vec![Field::new(
+            "body",
+            DataType::LargeUtf8,
+            false,
+        )]));
+        for (k1, b) in [
+            (0.0_f32, 0.75_f32),
+            (-1.0, 0.75),
+            (f32::NAN, 0.75),
+            (f32::INFINITY, 0.75),
+            (1.2, -0.01),
+            (1.2, 1.01),
+            (1.2, f32::NAN),
+        ] {
+            let err = SupertableOptions::new(Arc::clone(&s), vec![fc("body").bm25(k1, b)], vec![])
+                .expect_err("out-of-range pair must be refused");
+            assert!(
+                matches!(
+                    err,
+                    BuildError::FtsBm25ParamsOutOfRange { ref column, .. } if column == "body"
+                ),
+                "k1={k1} b={b} gave {err:?}"
+            );
+            // The message names both bounds, so a caller sees what is
+            // acceptable rather than only what was rejected.
+            let msg = err.to_string();
+            assert!(msg.contains("k1") && msg.contains("b"), "{msg}");
+        }
+    }
+
+    /// The boundary values are accepted: `b` is inclusive at both ends
+    /// and a large `k1` is legal.
+    #[test]
+    fn fts_bm25_params_boundaries_accepted() {
+        let s = Arc::new(Schema::new(vec![Field::new(
+            "body",
+            DataType::LargeUtf8,
+            false,
+        )]));
+        for (k1, b) in [(1.2_f32, 0.0_f32), (1.2, 1.0), (0.001, 0.5), (100.0, 0.5)] {
+            SupertableOptions::new(Arc::clone(&s), vec![fc("body").bm25(k1, b)], vec![])
+                .unwrap_or_else(|e| panic!("k1={k1} b={b} should be accepted: {e}"));
+        }
+    }
+
     #[test]
     fn vector_column_missing_from_schema_rejected() {
         let s = Arc::new(Schema::new(vec![Field::new(

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -657,6 +657,18 @@ impl SupertableOptions {
                     actual: format!("{:?}", f.data_type()),
                 });
             }
+            // BM25 parameters, validated here rather than at scoring
+            // time: the build bakes the block-max bounds with them, so a
+            // nonsense pair would otherwise be discovered as strange
+            // scores long after the bytes were written.
+            let (k1, b) = (fc.bm25.k1, fc.bm25.b);
+            if !k1.is_finite() || k1 <= 0.0 || !b.is_finite() || !(0.0..=1.0).contains(&b) {
+                return Err(BuildError::FtsBm25ParamsOutOfRange {
+                    column: fc.column.clone(),
+                    k1,
+                    b,
+                });
+            }
         }
 
         // 3. Each vector column must exist in schema as

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -916,7 +916,7 @@ mod tests {
         storage::{LocalFsStorageProvider, StorageProvider},
         superfile::{
             builder::{BuilderOptions, FtsConfig, SuperfileBuilder, VectorConfig},
-            fts::reader::{Bm25Stats, BoolMode},
+            fts::reader::{Bm25SearchOptions, Bm25Stats, BoolMode},
             vector::{distance::Metric, layout::VectorLayout, rerank_codec::RerankCodec},
         },
         supertable::{
@@ -1072,7 +1072,7 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 Some(&["_id"]),
@@ -1095,7 +1095,7 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 None,
@@ -1119,7 +1119,7 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 Some(&["_id", "title", "score"]),
@@ -1144,7 +1144,7 @@ mod tests {
             "title",
             "rust",
             10,
-            crate::superfile::fts::reader::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             Some(&["nope"]),
@@ -1162,7 +1162,7 @@ mod tests {
                 "title",
                 "nonexistentterm",
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 Some(&["_id"]),
@@ -1681,7 +1681,7 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 Some(&["title", "score"]),
@@ -1722,7 +1722,7 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 Some(&["_id", "title", "score"]),
@@ -1750,7 +1750,7 @@ mod tests {
                 "title",
                 "nonexistentterm",
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 Some(&["title", "score"]),

--- a/src/supertable/query/exec/common.rs
+++ b/src/supertable/query/exec/common.rs
@@ -1072,8 +1072,9 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["_id"]),
             )
             .expect("bm25_search _id");
@@ -1090,7 +1091,15 @@ mod tests {
         let batches = st
             .reader()
             .expect("reader")
-            .bm25_search("title", "rust", 10, BoolMode::Or, Bm25Stats::Global, None)
+            .bm25_search(
+                "title",
+                "rust",
+                10,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
             .expect("bm25_search default");
         let b = &batches[0];
         assert_eq!(b.num_columns(), 2);
@@ -1110,8 +1119,9 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["_id", "title", "score"]),
             )
             .expect("bm25_search title");
@@ -1134,8 +1144,9 @@ mod tests {
             "title",
             "rust",
             10,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            crate::superfile::fts::reader::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             Some(&["nope"]),
         );
         assert!(res.is_err(), "unknown projected column must error");
@@ -1151,8 +1162,9 @@ mod tests {
                 "title",
                 "nonexistentterm",
                 10,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["_id"]),
             )
             .expect("bm25_search empty");
@@ -1669,8 +1681,9 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["title", "score"]),
             )
             .expect("cold bm25 with scalar projection");
@@ -1709,8 +1722,9 @@ mod tests {
                 "title",
                 "rust",
                 10,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["_id", "title", "score"]),
             )
             .expect("cold bm25 with id and scalar projection");
@@ -1736,8 +1750,9 @@ mod tests {
                 "title",
                 "nonexistentterm",
                 10,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["title", "score"]),
             )
             .expect("cold bm25 with no matches");

--- a/src/supertable/query/exec/fts_exec.rs
+++ b/src/supertable/query/exec/fts_exec.rs
@@ -45,7 +45,7 @@ use datafusion::{
 };
 
 use crate::{
-    superfile::fts::reader::{Bm25Stats, BoolMode},
+    superfile::fts::reader::{Bm25SearchOptions, BoolMode},
     supertable::{
         handle::{SupertableReader, WeakReader},
         query::exec::common::{
@@ -377,7 +377,12 @@ impl ExecutionPlan for Bm25Exec {
             let hits = match &query {
                 Bm25Query::Terms { query, mode } => {
                     reader
-                        .bm25_search_async(&column, query, k, *mode, Bm25Stats::default())
+                        .bm25_search_async(
+                            &column,
+                            query,
+                            k,
+                            Bm25SearchOptions::new().with_mode(*mode),
+                        )
                         .await
                 }
                 Bm25Query::Prefix { prefix } => {

--- a/src/supertable/query/exec/hybrid_exec.rs
+++ b/src/supertable/query/exec/hybrid_exec.rs
@@ -70,7 +70,7 @@ use crate::{
     InfinoError,
     runtime_metrics::op_stats,
     superfile::{
-        fts::reader::{Bm25Stats, BoolMode},
+        fts::reader::{Bm25SearchOptions, BoolMode},
         reader::VectorSearchOptions,
     },
     supertable::{
@@ -152,7 +152,12 @@ impl SupertableReader {
         // Both retrievers run concurrently on the query runtime; each
         // inherits its own manifest skip and returns hits best-first.
         let (bm25_res, vector_res) = future::join(
-            self.bm25_search_async(text_col, q_text, k, mode, Bm25Stats::default()),
+            self.bm25_search_async(
+                text_col,
+                q_text,
+                k,
+                Bm25SearchOptions::new().with_mode(mode),
+            ),
             self.vector_search_user_table_async(vec_col, &q_vec, k, options),
         )
         .await;

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -2250,7 +2250,10 @@ mod tests {
         superfile::{
             SuperfileReader,
             builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
-            fts::reader::{Bm25SearchOptions, top_k_initial_capacity},
+            fts::{
+                posting::BLOCK_LEN,
+                reader::{Bm25SearchOptions, top_k_initial_capacity},
+            },
             vector::layout::VectorLayout,
         },
         supertable::{
@@ -3655,12 +3658,116 @@ mod tests {
         }
     }
 
+    /// Docs in the block-skip fixture. `BLOCK_LEN` is 128, so a term
+    /// carried by every document spans several whole blocks and the
+    /// block-max skip has something to skip *over*. Three documents fit
+    /// in one partial block, where the skip path is unreachable.
+    const BLOCK_SKIP_DOCS: usize = 5 * BLOCK_LEN;
+
+    /// Longest document, in repetitions of the padding token. Lengths
+    /// sweep from 1 to this, so the length norm — the half of the score
+    /// `b` controls — varies widely across blocks. A uniform-length
+    /// corpus would make the correction factor's length term
+    /// degenerate and hide an under-tight bound.
+    const BLOCK_SKIP_MAX_PAD: usize = 24;
+
+    /// A corpus large enough that the block-max skip actually runs.
+    ///
+    /// Every document carries `quick`, so its posting list covers all
+    /// `BLOCK_SKIP_DOCS` and is split into whole blocks with a stored
+    /// per-block maximum. `brown` is planted on a sparse, irregular
+    /// subset, and both the term frequency and the document length
+    /// vary per document, so per-block maxima differ and a small `k`
+    /// prunes rather than walking everything.
+    fn seeded_block_skip_supertable() -> Supertable {
+        let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
+        let mut w = st.writer().expect("writer");
+        let titles: Vec<String> = (0..BLOCK_SKIP_DOCS)
+            .map(|i| {
+                let mut t = String::from("quick");
+                // Term frequency varies: a repeated term saturates
+                // differently as k1 moves, so the tf half of the score
+                // is exercised too.
+                for _ in 0..(i % 3) {
+                    t.push_str(" quick");
+                }
+                if i % 7 == 0 {
+                    t.push_str(" brown");
+                }
+                // Length varies 1..=BLOCK_SKIP_MAX_PAD padding tokens.
+                for j in 0..(i % BLOCK_SKIP_MAX_PAD + 1) {
+                    t.push_str(&format!(" pad{j}"));
+                }
+                t
+            })
+            .collect();
+        let refs: Vec<&str> = titles.iter().map(String::as_str).collect();
+        w.append(&build_batch(0, &refs)).expect("append");
+        w.commit().expect("commit");
+        st
+    }
+
     /// A small `k` fills the top-k heap and engages the block-max skips;
     /// a `k` covering the whole match set does not. Under an override
     /// every stored bound is inflated by the correction factor, so a
     /// factor that came out too small would skip a block holding a
     /// qualifying document — visible only as the small-`k` result
     /// disagreeing with the head of the unpruned one.
+    ///
+    /// The corpus spans several whole blocks on purpose. The skip
+    /// compares a *stored per-block maximum* against the current
+    /// kth-best score, so a corpus that fits in one partial block never
+    /// reaches that comparison and cannot observe the correction at
+    /// all — the assertion would hold no matter how wrong the factor
+    /// was.
+    #[test]
+    fn an_override_prunes_without_dropping_hits_across_blocks() {
+        let st = seeded_block_skip_supertable();
+        let r = st.reader().expect("reader");
+        const K_ALL: usize = 4 * BLOCK_SKIP_DOCS;
+
+        for (k1, b) in [(1.6_f32, 0.4_f32), (0.5, 0.9), (1.2, 0.0), (2.0, 1.0)] {
+            let opts = || {
+                Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_bm25(k1, b)
+            };
+            let unpruned = r
+                .bm25_hits("title", "quick brown", K_ALL, opts())
+                .expect("unpruned");
+            assert!(
+                unpruned.len() > BLOCK_LEN,
+                "fixture must span more than one block; got {}",
+                unpruned.len()
+            );
+            // Small k relative to the match set: the heap fills early
+            // and the kth-best score climbs above whole blocks' maxima.
+            for k in [1usize, 2, 10, 50] {
+                let pruned = r
+                    .bm25_hits("title", "quick brown", k, opts())
+                    .expect("pruned");
+                assert_eq!(
+                    pruned.len(),
+                    k.min(unpruned.len()),
+                    "k={k} at k1={k1} b={b}"
+                );
+                for (i, hit) in pruned.iter().enumerate() {
+                    assert_eq!(
+                        hit.local_doc_id, unpruned[i].local_doc_id,
+                        "k={k} at k1={k1} b={b}: pruning changed the top-{k} head"
+                    );
+                    assert!(
+                        (hit.score - unpruned[i].score).abs() < 1e-4,
+                        "k={k} at k1={k1} b={b}: pruning changed a score"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The same property on a corpus too small to form a full block.
+    /// Kept alongside the multi-block case because it covers the
+    /// partial-block tail, which has its own bound handling.
     #[test]
     fn an_override_prunes_without_dropping_hits() {
         let st = seeded_three_doc_supertable();

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -3502,6 +3502,196 @@ mod tests {
         st
     }
 
+    /// Phrase and must-clause queries route through kernels the
+    /// single-term and union tests never touch — the phrase cursor
+    /// composes its members' idfs and its own term-level bound, and a
+    /// `+must` clause runs the ranked-AND membership walk. Both read
+    /// stored bounds, so both have to see the correction; the check is
+    /// that a declared pair and the same pair reached by override agree
+    /// document-for-document and score-for-score.
+    #[test]
+    fn declared_and_overridden_pairs_agree_on_phrase_and_must_kernels() {
+        const K1: f32 = 1.6;
+        const B: f32 = 0.4;
+
+        // One table baked at the pair, one baked at the defaults and
+        // queried with the pair as an override.
+        let baked = {
+            let pool = Arc::new(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(1)
+                    .build()
+                    .expect("pool"),
+            );
+            let opts = SupertableOptions::new(
+                schema_id_title(),
+                vec![FtsConfig::new("title").positions(true).bm25(K1, B)],
+                vec![],
+            )
+            .expect("valid options")
+            .with_writer_pool(pool);
+            let st = Supertable::create(opts).expect("create");
+            let mut w = st.writer().expect("writer");
+            w.append(&build_batch(0, &["new york city", "the new york times"]))
+                .expect("append");
+            w.commit().expect("commit");
+            w.append(&build_batch(10, &["york loves new haven", "big new york"]))
+                .expect("append");
+            w.commit().expect("commit");
+            st
+        };
+        let standard = seeded_phrase_supertable();
+
+        let hits = |st: &Supertable, query: &str, opts: Bm25SearchOptions| {
+            st.reader()
+                .expect("reader")
+                .bm25_hits("title", query, 10, opts)
+                .expect("bm25 hits")
+        };
+
+        for query in [r#""new york""#, "+new +york", r#""new york" city"#] {
+            let from_declared = hits(
+                &baked,
+                query,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            );
+            let from_override = hits(
+                &standard,
+                query,
+                Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_bm25(K1, B),
+            );
+            assert!(
+                !from_declared.is_empty(),
+                "{query} must match something for the comparison to mean anything"
+            );
+            assert_eq!(
+                from_declared.len(),
+                from_override.len(),
+                "hit count diverged for {query}"
+            );
+            for (a, b) in from_declared.iter().zip(from_override.iter()) {
+                assert_eq!(
+                    a.local_doc_id, b.local_doc_id,
+                    "doc order diverged for {query}"
+                );
+                assert!(
+                    (a.score - b.score).abs() < 1e-4,
+                    "score diverged for {query}: {} vs {}",
+                    a.score,
+                    b.score
+                );
+            }
+        }
+    }
+
+    /// The correction factor composes with the idf rescale — the shipped
+    /// factor is `(idf / local_idf) · R`, and global statistics are the
+    /// default, so the composed form is the common path rather than an
+    /// edge case. Under either statistics scope, an override must agree
+    /// with a table baked at that pair.
+    #[test]
+    fn the_override_composes_with_either_statistics_scope() {
+        const K1: f32 = 0.7;
+        const B: f32 = 0.9;
+
+        let baked = {
+            let pool = Arc::new(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(1)
+                    .build()
+                    .expect("pool"),
+            );
+            let opts = SupertableOptions::new(
+                schema_id_title(),
+                vec![FtsConfig::new("title").bm25(K1, B)],
+                vec![],
+            )
+            .expect("valid options")
+            .with_writer_pool(pool);
+            let st = Supertable::create(opts).expect("create");
+            let mut w = st.writer().expect("writer");
+            w.append(&build_batch(
+                0,
+                &["the quick brown fox", "a lazy dog", "quick thinking"],
+            ))
+            .expect("append");
+            w.commit().expect("commit");
+            st
+        };
+        let standard = seeded_three_doc_supertable();
+
+        for stats in [Bm25Stats::Global, Bm25Stats::PerSuperfile] {
+            let declared = baked
+                .reader()
+                .expect("reader")
+                .bm25_hits(
+                    "title",
+                    "quick",
+                    10,
+                    Bm25SearchOptions::new().with_stats(stats),
+                )
+                .expect("declared");
+            let overridden = standard
+                .reader()
+                .expect("reader")
+                .bm25_hits(
+                    "title",
+                    "quick",
+                    10,
+                    Bm25SearchOptions::new().with_stats(stats).with_bm25(K1, B),
+                )
+                .expect("overridden");
+            assert_eq!(declared.len(), overridden.len(), "{stats:?}: hit count");
+            for (a, b) in declared.iter().zip(overridden.iter()) {
+                assert!(
+                    (a.score - b.score).abs() < 1e-4,
+                    "{stats:?}: score diverged {} vs {}",
+                    a.score,
+                    b.score
+                );
+            }
+        }
+    }
+
+    /// A small `k` fills the top-k heap and engages the block-max skips;
+    /// a `k` covering the whole match set does not. Under an override
+    /// every stored bound is inflated by the correction factor, so a
+    /// factor that came out too small would skip a block holding a
+    /// qualifying document — visible only as the small-`k` result
+    /// disagreeing with the head of the unpruned one.
+    #[test]
+    fn an_override_prunes_without_dropping_hits() {
+        let st = seeded_three_doc_supertable();
+        let r = st.reader().expect("reader");
+        const K_ALL: usize = 1000;
+
+        for (k1, b) in [(1.6_f32, 0.4_f32), (0.5, 0.9), (1.2, 0.0), (2.0, 1.0)] {
+            let opts = || {
+                Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_bm25(k1, b)
+            };
+            let unpruned = r
+                .bm25_hits("title", "quick brown", K_ALL, opts())
+                .expect("unpruned");
+            for k in [1usize, 2] {
+                let pruned = r
+                    .bm25_hits("title", "quick brown", k, opts())
+                    .expect("pruned");
+                let want = k.min(unpruned.len());
+                assert_eq!(pruned.len(), want, "k={k} at k1={k1} b={b}");
+                for (i, hit) in pruned.iter().enumerate() {
+                    assert_eq!(
+                        hit.local_doc_id, unpruned[i].local_doc_id,
+                        "k={k} at k1={k1} b={b}: pruning changed the top-{k} head"
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn phrase_query_end_to_end() {
         let st = seeded_phrase_supertable();

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -123,9 +123,10 @@ use crate::{
         error::{FtsError, ReadError},
         fts::{
             bm25,
+            bm25::Bm25Params,
             reader::{
-                Bm25Stats, ClauseLists, FetchedTermMemo, GlobalTermIdf, LiveFloor,
-                OR_WINDOW_MIN_TERMS, OrCursorSet, PreparedClauses,
+                Bm25SearchOptions, Bm25Stats, ClauseLists, FetchedTermMemo, GlobalTermIdf,
+                LiveFloor, OR_WINDOW_MIN_TERMS, OrCursorSet, PreparedClauses,
             },
         },
     },
@@ -414,16 +415,44 @@ impl SupertableReader {
         feature = "detailed-tracing",
         tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
+    /// Reject an out-of-range query-time override before the fan-out
+    /// starts. A declared pair is validated at `create_table`; this is
+    /// the same check for the per-search form, so a caller sees the
+    /// bounds rather than a silently strange ranking.
+    fn validate_bm25_override(p: Bm25Params) -> Result<(), QueryError> {
+        let (k1, b) = (p.k1, p.b);
+        match k1.is_finite() && k1 > 0.0 && b.is_finite() && (0.0..=1.0).contains(&b) {
+            true => Ok(()),
+            false => Err(QueryError::InvalidQuery(format!(
+                "bm25 k1 must be finite and > 0, b must be finite and in [0, 1]; \
+                 got k1={k1}, b={b}"
+            ))),
+        }
+    }
+
     pub(crate) async fn bm25_search_async(
         &self,
         column: &str,
         query: &str,
         k: usize,
-        mode: BoolMode,
-        stats: Bm25Stats,
+        opts: Bm25SearchOptions,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
         if k == 0 {
             return Ok(Vec::new());
+        }
+        // Destructured once here rather than threaded as three
+        // positionals: `mode` shapes the clause split, `stats` selects
+        // the idf source, and `bm25` — when set — overrides what each
+        // column declared, which every per-superfile reader below has
+        // to apply identically or two superfiles would score one query
+        // two ways.
+        let Bm25SearchOptions {
+            mode,
+            stats,
+            bm25: bm25_override,
+        } = opts;
+        if let Some(p) = bm25_override {
+            Self::validate_bm25_override(p)?;
         }
         let manifest = self.manifest();
         let pool_threads = manifest.options.reader_pool.current_num_threads();
@@ -721,6 +750,7 @@ impl SupertableReader {
                                             start,
                                             end,
                                             floor,
+                                            bm25_override,
                                         )
                                     })
                                 },
@@ -730,7 +760,14 @@ impl SupertableReader {
                             .map_err(fts_read_error)?
                         } else {
                             op_stats::timed_kernel(&op_stats, || {
-                                r.bm25_search_or_range_prebuilt(set, k, start, end, floor)
+                                r.bm25_search_or_range_prebuilt(
+                                    set,
+                                    k,
+                                    start,
+                                    end,
+                                    floor,
+                                    bm25_override,
+                                )
                             })
                             .map_err(fts_read_error)?
                         }
@@ -756,6 +793,7 @@ impl SupertableReader {
                                 },
                                 k,
                                 floor,
+                                bm25_override,
                             )
                             .await
                             .map_err(fts_read_error)?;
@@ -787,7 +825,7 @@ impl SupertableReader {
                                     "un-ranged fts kernel: reader pool dropped result",
                                     move || {
                                         op_stats::timed_kernel(&kernel_stats, || {
-                                            kernel_reader.run_prepared(prep)
+                                            kernel_reader.run_prepared(prep, bm25_override)
                                         })
                                     },
                                 )
@@ -795,8 +833,10 @@ impl SupertableReader {
                                 .map_err(|e| QueryError::Execute(e.to_string()))?
                                 .map_err(fts_read_error)?
                             }
-                            prep => op_stats::timed_kernel(&op_stats, || r.run_prepared(prep))
-                                .map_err(fts_read_error)?,
+                            prep => op_stats::timed_kernel(&op_stats, || {
+                                r.run_prepared(prep, bm25_override)
+                            })
+                            .map_err(fts_read_error)?,
                         }
                     }
                 };
@@ -1116,6 +1156,13 @@ impl SupertableReader {
                                             start,
                                             end,
                                             f32::NEG_INFINITY,
+                                            // Prefix search takes no
+                                            // search options yet, so
+                                            // there is no pair to
+                                            // override with; columns
+                                            // score with what they
+                                            // declared.
+                                            None,
                                         )
                                     })
                                 },
@@ -1131,6 +1178,7 @@ impl SupertableReader {
                                     start,
                                     end,
                                     f32::NEG_INFINITY,
+                                    None,
                                 )
                             })
                             .map_err(fts_read_error)
@@ -1721,15 +1769,12 @@ impl SupertableReader {
         column: &str,
         query: &str,
         k: usize,
-        mode: BoolMode,
-        stats: Bm25Stats,
+        opts: Bm25SearchOptions,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, QueryError> {
         let _foreground = ForegroundQueryGuard::enter();
         self.block_on(async {
-            let hits = self
-                .bm25_search_async(column, query, k, mode, stats)
-                .await?;
+            let hits = self.bm25_search_async(column, query, k, opts).await?;
             // `projection` selects columns by name (any of `_id`, the
             // visible scalar columns, or the trailing `score`); `None`
             // returns `_id` + `score` only. The shared resolver decodes
@@ -1756,30 +1801,20 @@ impl SupertableReader {
     /// `climate`, ranking those that also mention `policy` higher)
     /// and a plain union when none does. A query with only negated
     /// terms is an error.
+    ///
+    /// Takes the same [`Bm25SearchOptions`] as
+    /// [`bm25_search`](Self::bm25_search) — the statistics scope a
+    /// separate `bm25_hits_stats` used to exist for is one of its
+    /// fields, so the two collapsed into this.
     pub fn bm25_hits(
         &self,
         column: &str,
         query: &str,
         k: usize,
-        mode: BoolMode,
-    ) -> Result<Vec<SuperfileHit>, QueryError> {
-        self.bm25_hits_stats(column, query, k, mode, Bm25Stats::default())
-    }
-
-    /// [`bm25_hits`](Self::bm25_hits) with an explicit statistics
-    /// scope. Callers that pin mode-specific behavior (the
-    /// per-superfile fan shape, or local-idf scoring parity) select it
-    /// here instead of relying on the crate default.
-    pub fn bm25_hits_stats(
-        &self,
-        column: &str,
-        query: &str,
-        k: usize,
-        mode: BoolMode,
-        stats: Bm25Stats,
+        opts: Bm25SearchOptions,
     ) -> Result<Vec<SuperfileHit>, QueryError> {
         let _foreground = ForegroundQueryGuard::enter();
-        self.block_on(self.bm25_search_async(column, query, k, mode, stats))
+        self.block_on(self.bm25_search_async(column, query, k, opts))
     }
 
     /// Prefix-expanded BM25 search — see [`SupertableReader::bm25_search`]
@@ -2081,13 +2116,12 @@ impl Supertable {
         column: &str,
         query: &str,
         k: usize,
-        mode: BoolMode,
-        stats: Bm25Stats,
+        opts: Bm25SearchOptions,
         projection: Option<&[&str]>,
     ) -> Result<Vec<RecordBatch>, InfinoError> {
-        debug!(column, k, mode = ?mode, "bm25_search");
+        debug!(column, k, mode = ?opts.mode, "bm25_search");
         self.reader()?
-            .bm25_search(column, query, k, mode, stats, projection)
+            .bm25_search(column, query, k, opts, projection)
             .map_err(InfinoError::from)
             .map_err(|e| e.with_context("bm25_search", None))
     }
@@ -2216,7 +2250,7 @@ mod tests {
         superfile::{
             SuperfileReader,
             builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
-            fts::reader::top_k_initial_capacity,
+            fts::reader::{Bm25SearchOptions, top_k_initial_capacity},
             vector::layout::VectorLayout,
         },
         supertable::{
@@ -2317,8 +2351,9 @@ mod tests {
                 "title",
                 query,
                 k,
-                BoolMode::Or,
-                stats,
+                Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(stats),
                 Some(&["title", "score"]),
             )
             .expect("bm25_search");
@@ -2781,13 +2816,23 @@ mod tests {
 
         let r = st.reader().expect("reader");
         let hits = r
-            .bm25_hits("title", "alpha -beta", 10, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "alpha -beta",
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("negation search");
         assert_eq!(hits.len(), 2, "alpha minus beta: {hits:?}");
 
         // Positive-only stays untouched: all three alpha docs.
         let hits = r
-            .bm25_hits("title", "alpha", 10, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "alpha",
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("positive search");
         assert_eq!(hits.len(), 3);
     }
@@ -2810,7 +2855,12 @@ mod tests {
 
         let r = st.reader().expect("reader");
         let hits = r
-            .bm25_hits("title", "alpha -delta", 10, BoolMode::And)
+            .bm25_hits(
+                "title",
+                "alpha -delta",
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::And),
+            )
             .expect("negation search");
         assert_eq!(hits.len(), 2, "alpha minus delta: {hits:?}");
     }
@@ -2823,7 +2873,12 @@ mod tests {
         w.commit().expect("commit");
 
         let r = st.reader().expect("reader");
-        let res = r.bm25_hits("title", "-alpha", 10, BoolMode::Or);
+        let res = r.bm25_hits(
+            "title",
+            "-alpha",
+            10,
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        );
         assert!(res.is_err(), "negation-only must error; got {res:?}");
     }
 
@@ -2865,7 +2920,12 @@ mod tests {
         let st = Supertable::create(options_one_superfile_per_commit()).expect("create");
         let r = st.reader().expect("reader");
         let hits = r
-            .bm25_hits("title", "rust", 5, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "rust",
+                5,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("query");
         assert!(hits.is_empty());
     }
@@ -2883,8 +2943,9 @@ mod tests {
                 "title",
                 "rust",
                 5,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["title", "does_not_exist"]),
             )
             .expect_err("unknown projection column must error");
@@ -2922,7 +2983,12 @@ mod tests {
         w.commit().expect("commit");
         let r = st.reader().expect("reader");
         let hits = r
-            .bm25_hits("title", "rust", 0, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "rust",
+                0,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("query");
         assert!(hits.is_empty());
     }
@@ -2944,7 +3010,12 @@ mod tests {
         w.commit().expect("commit");
         let r = st.reader().expect("reader");
         let hits = r
-            .bm25_hits("title", "rust", 4, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "rust",
+                4,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("query");
         // Should return 3 hits (the python doc has no `rust`).
         assert_eq!(hits.len(), 3);
@@ -2966,7 +3037,12 @@ mod tests {
         let r = st.reader().expect("reader");
         assert_eq!(r.n_superfiles(), 2);
         let hits = r
-            .bm25_hits("title", "rust", 5, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "rust",
+                5,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("query");
         assert_eq!(hits.len(), 2);
         // Both superfile URIs should appear.
@@ -3029,7 +3105,12 @@ mod tests {
 
         let st_reader = st.reader().expect("reader");
         let st_hits = st_reader
-            .bm25_hits("title", "nimblefox", 5, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "nimblefox",
+                5,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("supertable query");
         assert_eq!(st_hits.len(), 3);
         // Resolve supertable hits to global doc-ids via superfile
@@ -3141,7 +3222,12 @@ mod tests {
 
         let r = st.reader().expect("reader");
         let err = r
-            .bm25_hits("missing_column", "rust", 5, BoolMode::Or)
+            .bm25_hits(
+                "missing_column",
+                "rust",
+                5,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect_err("expected error");
         assert!(matches!(err, QueryError::InvalidQuery(_)), "got {err:?}");
         let msg = err.to_string();
@@ -3168,7 +3254,12 @@ mod tests {
         }
         let r = st.reader().expect("reader");
         let hits = r
-            .bm25_hits("title", "rust", 2, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "rust",
+                2,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("query");
         assert_eq!(hits.len(), 2);
     }
@@ -3185,13 +3276,111 @@ mod tests {
         st
     }
 
+    /// The override has to survive the whole path — public options,
+    /// `bm25_search_async`, the per-superfile fan-out, both the prepare
+    /// and the score halves — and it is only observable through scores,
+    /// so this asserts on the numbers rather than on plumbing.
+    #[test]
+    fn supertable_bm25_search_honors_a_query_time_bm25_override() {
+        let st = seeded_three_doc_supertable();
+        let scores = |opts: Bm25SearchOptions| -> Vec<(String, f32)> {
+            use arrow_array::{Float32Array, LargeStringArray};
+            let batches = st
+                .reader()
+                .expect("reader")
+                .bm25_search("title", "quick", 10, opts, Some(&["title", "score"]))
+                .expect("bm25_search");
+            let mut out = Vec::new();
+            for b in &batches {
+                let titles = b
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<LargeStringArray>()
+                    .expect("title utf8");
+                let sc = b
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .expect("score f32");
+                for i in 0..b.num_rows() {
+                    out.push((titles.value(i).to_string(), sc.value(i)));
+                }
+            }
+            out
+        };
+
+        let base = scores(Bm25SearchOptions::new());
+        assert_eq!(base.len(), 2, "two docs contain `quick`");
+
+        // b = 0 disables length normalization entirely, so the two docs'
+        // scores must converge: they differ under the default only
+        // because one is longer.
+        let no_len_norm = scores(Bm25SearchOptions::new().with_bm25(1.2, 0.0));
+        assert_eq!(no_len_norm.len(), base.len(), "same match set");
+        let spread = |v: &[(String, f32)]| {
+            let mut s: Vec<f32> = v.iter().map(|(_, x)| *x).collect();
+            s.sort_by(|a, b| b.total_cmp(a));
+            s[0] - s[s.len() - 1]
+        };
+        assert!(
+            spread(&no_len_norm) < spread(&base),
+            "b=0 must compress the score spread: base {:?} vs override {:?}",
+            base,
+            no_len_norm
+        );
+        assert!(
+            spread(&no_len_norm) < 1e-6,
+            "with b=0 both docs share a length norm, so scores tie: {no_len_norm:?}"
+        );
+
+        // An override equal to what the columns declare changes nothing.
+        let same = scores(Bm25SearchOptions::new().with_bm25(1.2, 0.75));
+        for ((t1, s1), (t2, s2)) in base.iter().zip(same.iter()) {
+            assert_eq!(t1, t2);
+            assert!((s1 - s2).abs() < 1e-6, "{s1} vs {s2}");
+        }
+    }
+
+    /// An out-of-range override is rejected before the fan-out, naming
+    /// the bounds rather than ranking oddly.
+    #[test]
+    fn supertable_bm25_search_rejects_an_invalid_override() {
+        let st = seeded_three_doc_supertable();
+        for (k1, b) in [(0.0_f32, 0.5_f32), (-1.0, 0.5), (1.2, 1.5), (1.2, -0.1)] {
+            let err = st
+                .reader()
+                .expect("reader")
+                .bm25_search(
+                    "title",
+                    "quick",
+                    10,
+                    Bm25SearchOptions::new().with_bm25(k1, b),
+                    None,
+                )
+                .expect_err("out-of-range override must be refused");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("k1") && msg.contains("b"),
+                "the error should name both bounds: {msg}"
+            );
+        }
+    }
+
     #[test]
     fn supertable_bm25_search_rows_default_and_projected() {
         let st = seeded_three_doc_supertable();
 
         // Bare call → `_id` + `score` only (no scalar decode).
         let bare = st
-            .bm25_search("title", "fox", 10, BoolMode::Or, Bm25Stats::Global, None)
+            .bm25_search(
+                "title",
+                "fox",
+                10,
+                Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
             .expect("bm25 rows");
         assert_eq!(bare.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
         assert_eq!(bare[0].num_columns(), 2, "_id + score");
@@ -3202,8 +3391,9 @@ mod tests {
                 "title",
                 "fox",
                 10,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["_id", "title", "score"]),
             )
             .expect("bm25 projected rows");
@@ -3320,7 +3510,12 @@ mod tests {
         // Ranked: exactly the adjacent-in-order docs across both
         // superfiles.
         let hits = r
-            .bm25_hits("title", r#""new york""#, 10, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                r#""new york""#,
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("phrase hits");
         assert_eq!(hits.len(), 3, "three docs contain the phrase");
 
@@ -3337,7 +3532,12 @@ mod tests {
 
         // Phrase composed with clauses: must-phrase + must-term.
         let hits = r
-            .bm25_hits("title", r#"+"new york" +the"#, 10, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                r#"+"new york" +the"#,
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("phrase + term");
         assert_eq!(hits.len(), 1);
 
@@ -3353,7 +3553,12 @@ mod tests {
         let st = seeded_clause_supertable();
         let r = st.reader().expect("reader");
         let err = r
-            .bm25_hits("title", r#""climate change""#, 10, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                r#""climate change""#,
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect_err("typed error expected");
         // A phrase on a positionless column is a bad *request*, not a
         // read failure — it surfaces as InvalidQuery, and the message
@@ -3384,7 +3589,12 @@ mod tests {
         // 3 docs contain `climate`; `policy` is scoring-only and must
         // not pull in "policy analysis quarterly".
         let hits = r
-            .bm25_hits("title", "+climate policy", 10, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "+climate policy",
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("bm25 +climate policy");
         assert_eq!(hits.len(), 3, "match set is the must set");
 
@@ -3428,7 +3638,12 @@ mod tests {
         // Negation still excludes: drop the summit doc from the
         // climate must set.
         let hits = r
-            .bm25_hits("title", "+climate policy -summit", 10, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "+climate policy -summit",
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("bm25 with negation");
         assert_eq!(hits.len(), 2);
         let n = r
@@ -3444,7 +3659,12 @@ mod tests {
         // The must term exists nowhere: bloom-prune (or the empty
         // intersection) yields no hits despite the common should.
         let hits = r
-            .bm25_hits("title", "+zzzabsent policy", 10, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "+zzzabsent policy",
+                10,
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("bm25 absent must");
         assert!(hits.is_empty());
         let n = r

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -7532,6 +7532,7 @@ mod tests {
     use bytes::Bytes;
 
     use super::IndexOutcome;
+    use crate::superfile::fts::reader::Bm25SearchOptions;
 
     /// Cosine columns normalize the query; every other metric passes the
     /// caller's slice through untouched, by reference (no copy, no scale).
@@ -10684,7 +10685,7 @@ mod tests {
                 "title",
                 "5",
                 8,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::And)
                     .with_stats(Bm25Stats::Global),
                 None,

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -10680,7 +10680,15 @@ mod tests {
         let (_dir, st, _q, _k) = drained_three_direction_fixture();
         let reader = st.reader().expect("reader");
         let batches = reader
-            .bm25_search("title", "5", 8, BoolMode::And, Bm25Stats::Global, None)
+            .bm25_search(
+                "title",
+                "5",
+                8,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::And)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
             .expect("global-stats bm25");
         let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(

--- a/src/supertable/wal/recovery_sweep_tests.rs
+++ b/src/supertable/wal/recovery_sweep_tests.rs
@@ -130,7 +130,12 @@ async fn open_time_sweep_drives_pre_seeded_intent_walls_to_complete() {
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "alpha", 10, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "alpha",
+            10,
+            crate::superfile::fts::reader::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("fts");
     // The "alpha" row is local doc_id 0 — verify it's filtered.
     for hit in &hits {
@@ -274,7 +279,12 @@ async fn sweep_preempts_expired_lease_and_completes_wal() {
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "foo", 10, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "foo",
+            10,
+            crate::superfile::fts::reader::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("fts");
     for hit in &hits {
         assert_ne!(hit.local_doc_id, 0);

--- a/src/supertable/wal/recovery_sweep_tests.rs
+++ b/src/supertable/wal/recovery_sweep_tests.rs
@@ -15,7 +15,7 @@ use tempfile::TempDir;
 
 use crate::{
     storage::{LocalFsStorageProvider, StorageProvider},
-    superfile::fts::reader::BoolMode,
+    superfile::fts::reader::{Bm25SearchOptions, BoolMode},
     supertable::{
         Supertable,
         reader_cache::{ColdFetchMode, DiskCacheConfig, DiskCacheStore, LruPolicy},
@@ -134,7 +134,7 @@ async fn open_time_sweep_drives_pre_seeded_intent_walls_to_complete() {
             "title",
             "alpha",
             10,
-            crate::superfile::fts::reader::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("fts");
     // The "alpha" row is local doc_id 0 — verify it's filtered.
@@ -283,7 +283,7 @@ async fn sweep_preempts_expired_lease_and_completes_wal() {
             "title",
             "foo",
             10,
-            crate::superfile::fts::reader::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("fts");
     for hit in &hits {

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -10097,7 +10097,7 @@ mod tests {
         config::Config,
         superfile::{
             builder::{FtsConfig, VectorConfig},
-            fts::reader::{Bm25Stats, BoolMode},
+            fts::reader::{Bm25SearchOptions, Bm25Stats, BoolMode},
             vector::{distance::Metric, rerank_codec::RerankCodec},
         },
         supertable::{
@@ -10567,7 +10567,7 @@ mod tests {
                 "title",
                 "alpha",
                 10,
-                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 None,

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -10563,7 +10563,15 @@ mod tests {
         // Every doc's title contains "alpha" (see build_simple_batch); a match-all term must
         // surface hits from the one-piece index.
         let hits = st
-            .bm25_search("title", "alpha", 10, BoolMode::Or, Bm25Stats::Global, None)
+            .bm25_search(
+                "title",
+                "alpha",
+                10,
+                crate::superfile::fts::reader::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
+                None,
+            )
             .expect("bm25 over one-piece commit");
         let n: usize = hits.iter().map(|b| b.num_rows()).sum();
         assert!(n > 0, "single-shard FTS index must return hits");

--- a/src/test_helpers/brute_force_bm25.rs
+++ b/src/test_helpers/brute_force_bm25.rs
@@ -33,6 +33,25 @@ use crate::superfile::fts::tokenize::Tokenizer;
 const K1: f32 = 1.2;
 const B: f32 = 0.75;
 
+/// The similarity parameters the oracle scores with. Defaults to the
+/// standard pair, so every existing caller is unaffected; a fixture
+/// whose column declares another pair — or whose query overrides one —
+/// sets this to the same values, or the comparison grades the engine
+/// against a different formula than the one it is running.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OracleBm25Params {
+    /// Term-frequency saturation.
+    pub k1: f32,
+    /// Length normalization.
+    pub b: f32,
+}
+
+impl Default for OracleBm25Params {
+    fn default() -> Self {
+        Self { k1: K1, b: B }
+    }
+}
+
 /// Number of times `phrase` occurs contiguously (in order) in
 /// `tokens` — the brute-force phrase tf.
 fn phrase_tf(tokens: &[String], phrase: &[String]) -> u32 {
@@ -70,6 +89,7 @@ pub struct BruteForceBm25 {
     df: HashMap<String, u32>,
     avgdl: f32,
     n: u32,
+    params: OracleBm25Params,
 }
 
 impl BruteForceBm25 {
@@ -111,7 +131,21 @@ impl BruteForceBm25 {
             total_tokens as f32 / n as f32
         };
 
-        Self { docs, df, avgdl, n }
+        Self {
+            docs,
+            df,
+            avgdl,
+            n,
+            params: OracleBm25Params::default(),
+        }
+    }
+
+    /// Score with `params` instead of the standard pair. Chain onto
+    /// [`BruteForceBm25::index`] for a fixture that declares or
+    /// overrides its parameters.
+    pub fn with_params(mut self, params: OracleBm25Params) -> Self {
+        self.params = params;
+        self
     }
 
     /// Brute-force top-k for a multi-term OR-mode BM25 query.
@@ -145,7 +179,8 @@ impl BruteForceBm25 {
         for doc in &self.docs {
             let mut score: f32 = 0.0;
             let dl = doc.dl as f32;
-            let dl_norm = K1 * (1.0 - B + B * dl / avgdl.max(f32::MIN_POSITIVE));
+            let (k1, b) = (self.params.k1, self.params.b);
+            let dl_norm = k1 * (1.0 - b + b * dl / avgdl.max(f32::MIN_POSITIVE));
             for term in terms {
                 let Some(&tf) = doc.tf.get(term) else {
                     continue;
@@ -156,7 +191,7 @@ impl BruteForceBm25 {
                 }
                 let idf = (1.0 + (n - df + 0.5) / (df + 0.5)).ln();
                 let tf_f = tf as f32;
-                score += idf * tf_f * (K1 + 1.0) / (tf_f + dl_norm);
+                score += idf * tf_f * (k1 + 1.0) / (tf_f + dl_norm);
             }
             if score > 0.0 {
                 scored.push((doc.doc_id, score));
@@ -206,7 +241,8 @@ impl BruteForceBm25 {
                 }
             }
             let dl = doc.dl as f32;
-            let dl_norm = K1 * (1.0 - B + B * dl / avgdl.max(f32::MIN_POSITIVE));
+            let (k1, b) = (self.params.k1, self.params.b);
+            let dl_norm = k1 * (1.0 - b + b * dl / avgdl.max(f32::MIN_POSITIVE));
             let mut score: f32 = 0.0;
             let mut any_should = false;
             for term in musts.iter().chain(shoulds) {
@@ -220,7 +256,7 @@ impl BruteForceBm25 {
                 }
                 let idf = (1.0 + (n - df + 0.5) / (df + 0.5)).ln();
                 let tf_f = tf as f32;
-                score += idf * tf_f * (K1 + 1.0) / (tf_f + dl_norm);
+                score += idf * tf_f * (k1 + 1.0) / (tf_f + dl_norm);
             }
             // With musts, every surviving doc matches (score > 0 since
             // idf is always positive); with none, only docs hit by at
@@ -302,8 +338,9 @@ impl BruteForceBm25 {
             }
 
             let dl = doc.dl as f32;
-            let dl_norm = K1 * (1.0 - B + B * dl / avgdl.max(f32::MIN_POSITIVE));
-            let tf_factor = |tf: u32| -> f32 { tf as f32 * (K1 + 1.0) / (tf as f32 + dl_norm) };
+            let (k1, b) = (self.params.k1, self.params.b);
+            let dl_norm = k1 * (1.0 - b + b * dl / avgdl.max(f32::MIN_POSITIVE));
+            let tf_factor = |tf: u32| -> f32 { tf as f32 * (k1 + 1.0) / (tf as f32 + dl_norm) };
 
             let mut score: f32 = 0.0;
             let mut matched_any_should = false;
@@ -359,7 +396,8 @@ impl BruteForceBm25 {
         let mut scored: Vec<(u64, f32)> = Vec::with_capacity(self.docs.len());
         'docs: for doc in &self.docs {
             let dl = doc.dl as f32;
-            let dl_norm = K1 * (1.0 - B + B * dl / avgdl.max(f32::MIN_POSITIVE));
+            let (k1, b) = (self.params.k1, self.params.b);
+            let dl_norm = k1 * (1.0 - b + b * dl / avgdl.max(f32::MIN_POSITIVE));
             let mut score: f32 = 0.0;
             for term in terms {
                 let Some(&tf) = doc.tf.get(term) else {
@@ -371,7 +409,7 @@ impl BruteForceBm25 {
                 }
                 let idf = (1.0 + (n - df + 0.5) / (df + 0.5)).ln();
                 let tf_f = tf as f32;
-                score += idf * tf_f * (K1 + 1.0) / (tf_f + dl_norm);
+                score += idf * tf_f * (k1 + 1.0) / (tf_f + dl_norm);
             }
             scored.push((doc.doc_id, score));
         }

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -25,6 +25,7 @@
 use std::sync::Arc;
 
 use infino::{
+    Bm25SearchOptions,
     superfile::{
         builder::FtsConfig,
         fts::{reader::BoolMode, tokenize::Tokenizer},
@@ -146,7 +147,7 @@ fn strong_consistency_query_sees_another_writers_new_commit() {
             "title",
             "added",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("query under strong consistency");
     assert!(!hits.is_empty(), "strong query must see the v2 row");
@@ -196,7 +197,7 @@ fn strong_consistency_query_is_stable_when_pointer_unchanged() {
             "title",
             "only",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("query");
     assert_eq!(consumer.manifest_id(), 1);
@@ -224,7 +225,7 @@ fn strong_consistency_query_on_uncommitted_table_stays_at_zero() {
             "title",
             "anything",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("query on uncommitted table");
     assert!(hits.is_empty());

--- a/tests/supertable/commit/open_refresh.rs
+++ b/tests/supertable/commit/open_refresh.rs
@@ -142,7 +142,12 @@ fn strong_consistency_query_sees_another_writers_new_commit() {
     let hits = consumer
         .reader()
         .expect("reader")
-        .bm25_hits("title", "added", BM25_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "added",
+            BM25_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("query under strong consistency");
     assert!(!hits.is_empty(), "strong query must see the v2 row");
     assert_eq!(consumer.manifest_id(), 2);
@@ -187,7 +192,12 @@ fn strong_consistency_query_is_stable_when_pointer_unchanged() {
     let _ = consumer
         .reader()
         .expect("reader")
-        .bm25_hits("title", "only", BM25_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "only",
+            BM25_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("query");
     assert_eq!(consumer.manifest_id(), 1);
 }
@@ -210,7 +220,12 @@ fn strong_consistency_query_on_uncommitted_table_stays_at_zero() {
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "anything", BM25_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "anything",
+            BM25_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("query on uncommitted table");
     assert!(hits.is_empty());
     assert_eq!(st.manifest_id(), 0);

--- a/tests/supertable/commit/persistence.rs
+++ b/tests/supertable/commit/persistence.rs
@@ -33,6 +33,7 @@ const PUT_MULTIPART_THRESHOLD_BYTES: u64 = 1;
 /// BM25 top-k for the post-commit query.
 const BM25_TOP_K: usize = 5;
 use infino::{
+    Bm25SearchOptions,
     supertable::storage::{LocalFsStorageProvider, StorageProvider},
     test_helpers::{build_title_batch, default_supertable_options},
 };
@@ -263,8 +264,7 @@ fn committed_supertable_remains_in_memory_queryable_for_now() {
             "title",
             "nimblefox",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new()
-                .with_mode(infino::supertable::query::fts::BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(infino::supertable::query::fts::BoolMode::Or),
         )
         .expect("query");
     assert_eq!(hits.len(), 1, "commit must not break in-memory reads");

--- a/tests/supertable/commit/persistence.rs
+++ b/tests/supertable/commit/persistence.rs
@@ -263,7 +263,8 @@ fn committed_supertable_remains_in_memory_queryable_for_now() {
             "title",
             "nimblefox",
             BM25_TOP_K,
-            infino::supertable::query::fts::BoolMode::Or,
+            infino::Bm25SearchOptions::new()
+                .with_mode(infino::supertable::query::fts::BoolMode::Or),
         )
         .expect("query");
     assert_eq!(hits.len(), 1, "commit must not break in-memory reads");

--- a/tests/supertable/commit/same_handle_query.rs
+++ b/tests/supertable/commit/same_handle_query.rs
@@ -39,6 +39,7 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use infino::{
+    Bm25SearchOptions,
     superfile::fts::reader::BoolMode,
     supertable::{
         Supertable,
@@ -83,7 +84,7 @@ fn query_after_first_commit_on_same_handle_succeeds() {
             "title",
             "alpha",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("same-handle query after first commit must resolve parts");
     assert_eq!(hits.len(), 1, "expected the one matching row");
@@ -124,7 +125,7 @@ fn query_after_second_commit_on_same_handle_succeeds() {
             "title",
             "alpha",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("query for first-commit term");
     assert_eq!(
@@ -141,7 +142,7 @@ fn query_after_second_commit_on_same_handle_succeeds() {
             "title",
             "echo",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("query for second-commit term");
     assert_eq!(new_hits.len(), 1, "second-commit row must be queryable");
@@ -178,7 +179,7 @@ fn same_handle_query_after_commit_refetches_no_manifest_parts() {
             "title",
             "alpha",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("query");
     let after = counter.part_gets();
@@ -300,7 +301,7 @@ fn open_metadata_cost_is_fixed_and_reads_check_pointer_once_per_window() {
                 "title",
                 "alpha",
                 BM25_TOP_K,
-                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
             )
             .expect("query");
         assert_eq!(hits.len(), 1);

--- a/tests/supertable/commit/same_handle_query.rs
+++ b/tests/supertable/commit/same_handle_query.rs
@@ -79,7 +79,12 @@ fn query_after_first_commit_on_same_handle_succeeds() {
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "alpha",
+            BM25_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("same-handle query after first commit must resolve parts");
     assert_eq!(hits.len(), 1, "expected the one matching row");
 }
@@ -115,7 +120,12 @@ fn query_after_second_commit_on_same_handle_succeeds() {
     let old_hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "alpha",
+            BM25_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("query for first-commit term");
     assert_eq!(
         old_hits.len(),
@@ -127,7 +137,12 @@ fn query_after_second_commit_on_same_handle_succeeds() {
     let new_hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "echo", BM25_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "echo",
+            BM25_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("query for second-commit term");
     assert_eq!(new_hits.len(), 1, "second-commit row must be queryable");
 }
@@ -159,7 +174,12 @@ fn same_handle_query_after_commit_refetches_no_manifest_parts() {
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "alpha",
+            BM25_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("query");
     let after = counter.part_gets();
 
@@ -276,7 +296,12 @@ fn open_metadata_cost_is_fixed_and_reads_check_pointer_once_per_window() {
         let hits = st
             .reader()
             .expect("reader")
-            .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "alpha",
+                BM25_TOP_K,
+                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("query");
         assert_eq!(hits.len(), 1);
     }

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -23,7 +23,7 @@ use arrow_schema::{DataType, Field, Schema};
 use chrono::{Duration as ChronoDuration, Utc};
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
-    CompactionSettings, GcSettings, OptimizeOptions,
+    Bm25SearchOptions, CompactionSettings, GcSettings, OptimizeOptions,
     superfile::{builder::FtsConfig, fts::reader::BoolMode, vector::rerank_codec::RerankCodec},
     supertable::{
         Supertable, SupertableOptions,
@@ -136,7 +136,7 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
             "title",
             "alphatoken",
             TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+            Bm25SearchOptions::new().with_mode(BoolMode::Or)
         )
         .expect("query alpha")
         .len(),
@@ -147,7 +147,7 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
             "title",
             "kappatoken",
             TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+            Bm25SearchOptions::new().with_mode(BoolMode::Or)
         )
         .expect("query kappa")
         .len(),
@@ -201,7 +201,7 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
                 "title",
                 m,
                 TOP_K,
-                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+                Bm25SearchOptions::new().with_mode(BoolMode::Or)
             )
             .expect("query after gc")
             .len(),
@@ -280,7 +280,7 @@ fn gc_reaps_tombstone_sidecar_for_merged_away_superfile() {
             "title",
             "alphatoken",
             TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+            Bm25SearchOptions::new().with_mode(BoolMode::Or)
         )
         .expect("query alpha after gc")
         .len(),
@@ -293,7 +293,7 @@ fn gc_reaps_tombstone_sidecar_for_merged_away_superfile() {
                 "title",
                 m,
                 TOP_K,
-                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+                Bm25SearchOptions::new().with_mode(BoolMode::Or)
             )
             .expect("query after gc")
             .len(),
@@ -499,7 +499,7 @@ fn gc_drops_disk_cache_copies_of_deleted_superfiles() {
             "title",
             "alpha",
             TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
             None,
         )
         .expect("bm25 after gc");

--- a/tests/supertable/compact_gc.rs
+++ b/tests/supertable/compact_gc.rs
@@ -132,15 +132,25 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
 
     // Spot-check three markers are queryable.
     assert_eq!(
-        r.bm25_hits("title", "alphatoken", TOP_K, BoolMode::Or)
-            .expect("query alpha")
-            .len(),
+        r.bm25_hits(
+            "title",
+            "alphatoken",
+            TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+        )
+        .expect("query alpha")
+        .len(),
         1
     );
     assert_eq!(
-        r.bm25_hits("title", "kappatoken", TOP_K, BoolMode::Or)
-            .expect("query kappa")
-            .len(),
+        r.bm25_hits(
+            "title",
+            "kappatoken",
+            TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+        )
+        .expect("query kappa")
+        .len(),
         1
     );
 
@@ -187,9 +197,14 @@ fn compact_then_gc_removes_stale_files_and_preserves_queries() {
     let r = st.reader().expect("reader");
     for m in &markers {
         assert_eq!(
-            r.bm25_hits("title", m, TOP_K, BoolMode::Or)
-                .expect("query after gc")
-                .len(),
+            r.bm25_hits(
+                "title",
+                m,
+                TOP_K,
+                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+            )
+            .expect("query after gc")
+            .len(),
             1,
             "marker {m} not found after GC"
         );
@@ -261,17 +276,27 @@ fn gc_reaps_tombstone_sidecar_for_merged_away_superfile() {
 
     let r = st.reader().expect("reader");
     assert_eq!(
-        r.bm25_hits("title", "alphatoken", TOP_K, BoolMode::Or)
-            .expect("query alpha after gc")
-            .len(),
+        r.bm25_hits(
+            "title",
+            "alphatoken",
+            TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+        )
+        .expect("query alpha after gc")
+        .len(),
         0,
         "deleted row stays gone"
     );
     for m in &markers[1..] {
         assert_eq!(
-            r.bm25_hits("title", m, TOP_K, BoolMode::Or)
-                .expect("query after gc")
-                .len(),
+            r.bm25_hits(
+                "title",
+                m,
+                TOP_K,
+                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or)
+            )
+            .expect("query after gc")
+            .len(),
             1,
             "marker {m} not found after GC"
         );
@@ -474,8 +499,7 @@ fn gc_drops_disk_cache_copies_of_deleted_superfiles() {
             "title",
             "alpha",
             TOP_K,
-            BoolMode::Or,
-            Default::default(),
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
             None,
         )
         .expect("bm25 after gc");

--- a/tests/supertable/disk_cache/cold_projection.rs
+++ b/tests/supertable/disk_cache/cold_projection.rs
@@ -180,8 +180,9 @@ async fn cold_bm25_projection_pairs_each_hit_with_its_own_row() {
             "title",
             "fox",
             TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "rating", "score"]),
         )
         .expect("cold bm25");
@@ -205,8 +206,9 @@ async fn cold_bm25_projection_pairs_each_hit_with_its_own_row() {
             "title",
             "async wolf",
             TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "rating", "score"]),
         )
         .expect("cold bm25 or");

--- a/tests/supertable/disk_cache/cold_projection.rs
+++ b/tests/supertable/disk_cache/cold_projection.rs
@@ -22,7 +22,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
-    VectorSearchOptions,
+    Bm25SearchOptions, VectorSearchOptions,
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
         builder::FtsConfig,
@@ -180,7 +180,7 @@ async fn cold_bm25_projection_pairs_each_hit_with_its_own_row() {
             "title",
             "fox",
             TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "rating", "score"]),
@@ -206,7 +206,7 @@ async fn cold_bm25_projection_pairs_each_hit_with_its_own_row() {
             "title",
             "async wolf",
             TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "rating", "score"]),

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -44,7 +44,10 @@ use infino::{
         },
     },
     supertable::{Supertable, SupertableOptions, query::SuperfileHit},
-    test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer, schema_id_title},
+    test_helpers::{
+        brute_force_bm25::{BruteForceBm25, OracleBm25Params},
+        default_tokenizer, schema_id_title,
+    },
 };
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -171,6 +174,42 @@ fn build_supertable(corpus: &[(u64, String)], n_superfiles: usize) -> Supertable
     st
 }
 
+/// Same fixture, but every FTS column declares `params` — so the build
+/// bakes its block-max bounds at that pair and the reader scores with
+/// it.
+fn build_supertable_with_params(
+    corpus: &[(u64, String)],
+    n_superfiles: usize,
+    params: OracleBm25Params,
+) -> Supertable {
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(RAYON_POOL_THREADS)
+            .build()
+            .expect("pool"),
+    );
+    let opts = SupertableOptions::new(
+        schema_id_title(),
+        vec![FtsConfig::new("title").bm25(params.k1, params.b)],
+        vec![],
+    )
+    .expect("opts")
+    .with_writer_pool(pool);
+
+    let st = Supertable::create(opts).expect("create");
+    let mut w = st.writer().expect("writer");
+    let chunk_size = corpus.len().div_ceil(n_superfiles);
+    for chunk in corpus.chunks(chunk_size) {
+        let titles =
+            LargeStringArray::from(chunk.iter().map(|(_, t)| t.as_str()).collect::<Vec<_>>());
+        let batch = RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)]).expect("batch");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+    }
+    drop(w);
+    st
+}
+
 /// Convert supertable hits to global doc_ids using the superfile-
 /// append order (superfile_index * chunk_size + local_doc_id).
 fn supertable_to_global_ids(
@@ -260,6 +299,19 @@ fn supertable_prefix_global(
 /// Build a per-superfile BruteForceBm25 oracle list. Index i scores
 /// superfile i with that superfile's own IDF/avgdl, mirroring the
 /// supertable's per-superfile scoring shape.
+/// Per-superfile oracles that score with `params` rather than the
+/// standard pair — the reference side of a declared-parameter fixture.
+fn build_oracles_with_params(
+    corpus: &[(u64, String)],
+    n_superfiles: usize,
+    params: OracleBm25Params,
+) -> Vec<BruteForceBm25> {
+    build_oracles(corpus, n_superfiles)
+        .into_iter()
+        .map(|o| o.with_params(params))
+        .collect()
+}
+
 fn build_oracles(corpus: &[(u64, String)], n_superfiles: usize) -> Vec<BruteForceBm25> {
     let tok = default_tokenizer();
     let chunk_size = corpus.len().div_ceil(n_superfiles);
@@ -350,6 +402,90 @@ static STANDARD_FIXTURE: LazyLock<StandardFixture> = LazyLock::new(|| {
     let oracles = build_oracles(&corp, SUPERFILES);
     StandardFixture { infino, oracles }
 });
+
+/// The same corpus with a declared, non-standard BM25 pair on both
+/// sides. The engine bakes its block-max bounds at this pair and scores
+/// with it; the oracle uses the identical formula, so a divergence is a
+/// real disagreement rather than two different similarity functions.
+const DECLARED_PARAMS: OracleBm25Params = OracleBm25Params { k1: 1.6, b: 0.4 };
+
+static DECLARED_PARAM_FIXTURE: LazyLock<StandardFixture> = LazyLock::new(|| {
+    let corp = corpus_with_prefix_terms();
+    let infino = build_supertable_with_params(&corp, SUPERFILES, DECLARED_PARAMS);
+    let oracles = build_oracles_with_params(&corp, SUPERFILES, DECLARED_PARAMS);
+    StandardFixture { infino, oracles }
+});
+
+// ---- Tests: declared BM25 parameters ---------------------------------
+
+/// A column that declares a non-standard pair must rank exactly as the
+/// reference implementation does at the same pair — across the query
+/// shapes that exercise different kernels (single rare, single common,
+/// multi-term union).
+#[test]
+fn oracle_declared_bm25_params_match_across_query_shapes() {
+    let f = &*DECLARED_PARAM_FIXTURE;
+    for (label, query, k, head) in [
+        (
+            "declared_single_rare",
+            "rare-token-zzz",
+            ORACLE_TOP_K_SMALL,
+            1,
+        ),
+        ("declared_single_common", "rust", ORACLE_TOP_K, 3),
+        ("declared_two_term_or", "rust async", ORACLE_TOP_K, 2),
+    ] {
+        let inf_hits = supertable_search_global(&f.infino, query, k, CHUNK_SIZE);
+        let ora_hits = brute_force_top_k(&f.oracles, query, k);
+        assert_top_k_sets_match(label, inf_hits, ora_hits, head);
+    }
+}
+
+/// A query-time override on a *standard* table must rank as the
+/// reference does at the override's pair. This is the pruning-correction
+/// path: the stored bounds belong to 1.2 / 0.75, so every bound is
+/// inflated by the correction factor, and a factor that came out too
+/// small would drop a qualifying doc and show up here as a set
+/// mismatch.
+#[test]
+fn oracle_query_time_override_matches_the_reference_at_that_pair() {
+    let f = &*STANDARD_FIXTURE;
+    let corp = corpus_with_prefix_terms();
+    for params in [
+        OracleBm25Params { k1: 1.6, b: 0.4 },
+        OracleBm25Params { k1: 0.6, b: 0.9 },
+        OracleBm25Params { k1: 1.2, b: 0.0 },
+    ] {
+        let oracles = build_oracles_with_params(&corp, SUPERFILES, params);
+        for (query, k, head) in [
+            ("rare-token-zzz", ORACLE_TOP_K_SMALL, 1),
+            ("rust", ORACLE_TOP_K, 3),
+            ("rust async", ORACLE_TOP_K, 2),
+        ] {
+            let hits = f
+                .infino
+                .reader()
+                .expect("reader")
+                .bm25_hits(
+                    "title",
+                    query,
+                    k,
+                    infino::Bm25SearchOptions::new()
+                        .with_stats(Bm25Stats::PerSuperfile)
+                        .with_bm25(params.k1, params.b),
+                )
+                .expect("bm25 with override");
+            let inf_hits = supertable_to_global_ids(&f.infino, hits, CHUNK_SIZE);
+            let ora_hits = brute_force_top_k(&oracles, query, k);
+            assert_top_k_sets_match(
+                &format!("override_k1={}_b={}_{query}", params.k1, params.b),
+                inf_hits,
+                ora_hits,
+                head,
+            );
+        }
+    }
+}
 
 // ---- Tests: query-shape coverage -------------------------------------
 

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -39,10 +39,7 @@ use infino::{
     Bm25SearchOptions,
     superfile::{
         builder::FtsConfig,
-        fts::{
-            reader::{Bm25Stats, BoolMode},
-            tokenize::Tokenizer,
-        },
+        fts::reader::{Bm25Stats, BoolMode},
     },
     supertable::{Supertable, SupertableOptions, query::SuperfileHit},
     test_helpers::{
@@ -149,33 +146,14 @@ fn corpus_with_prefix_terms() -> Vec<(u64, String)> {
 
 // ---- Supertable side -----------------------------------------------
 
+/// The fixture at the standard BM25 pair — the shape most of these
+/// tests want, so they do not have to name a pair they do not care
+/// about.
 fn build_supertable(corpus: &[(u64, String)], n_superfiles: usize) -> Supertable {
-    let pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(RAYON_POOL_THREADS)
-            .build()
-            .expect("pool"),
-    );
-    let _tk: Arc<dyn Tokenizer> = default_tokenizer();
-    let opts = SupertableOptions::new(schema_id_title(), vec![FtsConfig::new("title")], vec![])
-        .expect("opts")
-        .with_writer_pool(pool);
-
-    let st = Supertable::create(opts).expect("create");
-    let mut w = st.writer().expect("writer");
-    let chunk_size = corpus.len().div_ceil(n_superfiles);
-    for chunk in corpus.chunks(chunk_size) {
-        let titles =
-            LargeStringArray::from(chunk.iter().map(|(_, t)| t.as_str()).collect::<Vec<_>>());
-        let batch = RecordBatch::try_new(schema_id_title(), vec![Arc::new(titles)]).expect("batch");
-        w.append(&batch).expect("append");
-        w.commit().expect("commit");
-    }
-    drop(w);
-    st
+    build_supertable_with_params(corpus, n_superfiles, OracleBm25Params::default())
 }
 
-/// Same fixture, but every FTS column declares `params` — so the build
+/// The fixture, with every FTS column declaring `params` — so the build
 /// bakes its block-max bounds at that pair and the reader scores with
 /// it.
 fn build_supertable_with_params(

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -36,6 +36,7 @@ use std::{
 
 use arrow_array::{LargeStringArray, RecordBatch};
 use infino::{
+    Bm25SearchOptions,
     superfile::{
         builder::FtsConfig,
         fts::{
@@ -253,7 +254,7 @@ fn supertable_search_stats(
             "title",
             query,
             k,
-            infino::Bm25SearchOptions::new().with_stats(stats),
+            Bm25SearchOptions::new().with_stats(stats),
         )
         .expect("supertable bm25");
     supertable_to_global_ids(st, hits, chunk_size)
@@ -272,7 +273,7 @@ fn supertable_search_and_global(
             "title",
             query,
             k,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::And)
                 .with_stats(Bm25Stats::PerSuperfile),
         )
@@ -470,7 +471,7 @@ fn oracle_query_time_override_matches_the_reference_at_that_pair() {
                     "title",
                     query,
                     k,
-                    infino::Bm25SearchOptions::new()
+                    Bm25SearchOptions::new()
                         .with_stats(Bm25Stats::PerSuperfile)
                         .with_bm25(params.k1, params.b),
                 )
@@ -926,7 +927,7 @@ fn skip_path_hits(st: &Supertable, k: usize, chunk_size: usize) -> Vec<(u64, f32
             "title",
             "common",
             k,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
         )

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -210,7 +210,12 @@ fn supertable_search_stats(
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits_stats("title", query, k, BoolMode::Or, stats)
+        .bm25_hits(
+            "title",
+            query,
+            k,
+            infino::Bm25SearchOptions::new().with_stats(stats),
+        )
         .expect("supertable bm25");
     supertable_to_global_ids(st, hits, chunk_size)
 }
@@ -224,7 +229,14 @@ fn supertable_search_and_global(
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits_stats("title", query, k, BoolMode::And, Bm25Stats::PerSuperfile)
+        .bm25_hits(
+            "title",
+            query,
+            k,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::And)
+                .with_stats(Bm25Stats::PerSuperfile),
+        )
         .expect("supertable bm25 AND");
     supertable_to_global_ids(st, hits, chunk_size)
 }
@@ -774,7 +786,14 @@ fn skip_path_hits(st: &Supertable, k: usize, chunk_size: usize) -> Vec<(u64, f32
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits_stats("title", "common", k, BoolMode::Or, Bm25Stats::Global)
+        .bm25_hits(
+            "title",
+            "common",
+            k,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
+        )
         .expect("single-term global search");
     let scores: Vec<f32> = hits.iter().map(|h| h.score).collect();
     supertable_to_global_ids(st, hits, chunk_size)

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -29,8 +29,9 @@
 #![deny(clippy::unwrap_used)]
 
 use std::{
-    cmp::Reverse,
+    cmp::{Ordering, Reverse},
     collections::HashSet,
+    slice::from_ref,
     sync::{Arc, LazyLock},
 };
 
@@ -169,7 +170,14 @@ fn build_supertable_with_params(
     );
     let opts = SupertableOptions::new(
         schema_id_title(),
-        vec![FtsConfig::new("title").bm25(params.k1, params.b)],
+        // Positions are indexed so the phrase shape below is answerable.
+        // They change what the column can be asked, not how a term
+        // scores, so every non-phrase case grades the same as before.
+        vec![
+            FtsConfig::new("title")
+                .bm25(params.k1, params.b)
+                .positions(true),
+        ],
         vec![],
     )
     .expect("opts")
@@ -305,21 +313,31 @@ fn build_oracles(corpus: &[(u64, String)], n_superfiles: usize) -> Vec<BruteForc
         .collect()
 }
 
-/// Run per-superfile brute-force BM25 and merge into a global top-k
-/// in the same shape the supertable's fan-out produces.
-fn brute_force_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> Vec<u64> {
-    let tok = default_tokenizer();
-    let mut all: Vec<(u64, f32)> = Vec::new();
-    for o in oracles {
-        all.extend(o.top_k(query, k, tok.as_ref()));
-    }
+/// Merge per-superfile brute-force hits into a global top-k, in the
+/// same shape the supertable's fan-out produces: score descending,
+/// ties broken by ascending doc id.
+///
+/// Every oracle wrapper below differs only in which per-superfile
+/// scorer it calls, so the merge lives here once — four copies of a
+/// tie-break rule is four places for it to drift.
+fn merge_global_top_k(mut all: Vec<(u64, f32)>, k: usize) -> Vec<u64> {
     all.sort_by(|a, b| {
         b.1.partial_cmp(&a.1)
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .unwrap_or(Ordering::Equal)
             .then(a.0.cmp(&b.0))
     });
     all.truncate(k);
     all.into_iter().map(|(d, _)| d).collect()
+}
+
+/// Run per-superfile brute-force BM25 and merge into a global top-k.
+fn brute_force_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> Vec<u64> {
+    let tok = default_tokenizer();
+    let all = oracles
+        .iter()
+        .flat_map(|o| o.top_k(query, k, tok.as_ref()))
+        .collect();
+    merge_global_top_k(all, k)
 }
 
 /// Same as [`brute_force_top_k`] but for a multi-term explicit
@@ -330,33 +348,21 @@ fn brute_force_and_top_k(oracles: &[BruteForceBm25], query: &str, k: usize) -> V
     let tok = default_tokenizer();
     let mut terms: Vec<String> = Vec::new();
     tok.tokenize_each(query, &mut |t| terms.push(t.to_owned()));
-    let mut all: Vec<(u64, f32)> = Vec::new();
-    for o in oracles {
-        all.extend(o.top_k_terms_and(&terms, k));
-    }
-    all.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then(a.0.cmp(&b.0))
-    });
-    all.truncate(k);
-    all.into_iter().map(|(d, _)| d).collect()
+    let all = oracles
+        .iter()
+        .flat_map(|o| o.top_k_terms_and(&terms, k))
+        .collect();
+    merge_global_top_k(all, k)
 }
 
 /// Same as [`brute_force_top_k`] but for a multi-term explicit
 /// OR query (used to mirror the supertable's prefix expansion).
 fn brute_force_terms_top_k(oracles: &[BruteForceBm25], terms: &[String], k: usize) -> Vec<u64> {
-    let mut all: Vec<(u64, f32)> = Vec::new();
-    for o in oracles {
-        all.extend(o.top_k_terms(terms, k));
-    }
-    all.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then(a.0.cmp(&b.0))
-    });
-    all.truncate(k);
-    all.into_iter().map(|(d, _)| d).collect()
+    let all = oracles
+        .iter()
+        .flat_map(|o| o.top_k_terms(terms, k))
+        .collect();
+    merge_global_top_k(all, k)
 }
 
 fn assert_top_k_sets_match(label: &str, supertable: Vec<u64>, oracle: Vec<u64>, head_size: usize) {
@@ -395,6 +401,107 @@ static DECLARED_PARAM_FIXTURE: LazyLock<StandardFixture> = LazyLock::new(|| {
     StandardFixture { infino, oracles }
 });
 
+/// A query shape, carrying both the string the engine parses and the
+/// decomposition the oracle scores.
+///
+/// The two are derived from one value on purpose. Feeding the oracle
+/// from the engine's own parser — the convention elsewhere in the
+/// suite — makes a parsing change invisible here, because both sides
+/// would move together. These cases exist to grade *scoring* at a
+/// non-standard pair, so the clause structure is stated outright and a
+/// parser that stopped honouring a sigil would fail rather than agree
+/// with itself.
+enum QueryShape {
+    /// Bare terms, OR-combined — the default operator.
+    Or(&'static str),
+    /// Every term required (`+a +b`): the ranked-AND membership walk.
+    AllOf(&'static [&'static str]),
+    /// One exact phrase (`"a b"`): position-verified, and a different
+    /// kernel again — the phrase cursor composes its members' idfs and
+    /// its own term-level bound, so it reads a stored bound the single
+    /// and union paths never touch.
+    Phrase(&'static [&'static str]),
+}
+
+impl QueryShape {
+    /// The query string handed to the engine.
+    fn engine_query(&self) -> String {
+        match self {
+            Self::Or(q) => (*q).to_owned(),
+            Self::AllOf(terms) => terms
+                .iter()
+                .map(|t| format!("+{t}"))
+                .collect::<Vec<_>>()
+                .join(" "),
+            Self::Phrase(terms) => format!("\"{}\"", terms.join(" ")),
+        }
+    }
+
+    /// The reference top-k for the same shape.
+    fn oracle_top_k(&self, oracles: &[BruteForceBm25], k: usize) -> Vec<u64> {
+        match self {
+            Self::Or(q) => brute_force_top_k(oracles, q, k),
+            Self::AllOf(terms) => {
+                let musts: Vec<String> = terms.iter().map(|t| (*t).to_owned()).collect();
+                let all = oracles
+                    .iter()
+                    .flat_map(|o| o.top_k_atoms(&musts, &[], &[], &[], &[], &[], k))
+                    .collect();
+                merge_global_top_k(all, k)
+            }
+            Self::Phrase(terms) => {
+                // A bare quoted run is a *should* phrase, matching how
+                // the engine's clause split reads it with no sigil.
+                let phrase: Vec<String> = terms.iter().map(|t| (*t).to_owned()).collect();
+                let all = oracles
+                    .iter()
+                    .flat_map(|o| o.top_k_atoms(&[], &[], &[], from_ref(&phrase), &[], &[], k))
+                    .collect();
+                merge_global_top_k(all, k)
+            }
+        }
+    }
+}
+
+/// The shapes both parameter tests grade, so the declared-pair arm and
+/// the query-time-override arm cover exactly the same ground. Each
+/// entry is `(label, shape, k, head)`, where `head` is how many leading
+/// positions must match the reference exactly.
+///
+/// `+rust +async` and `"rust async"` are deliberately the same two
+/// terms: the phrase matches only where they are adjacent, while the
+/// must-query also takes `rust trait dyn impl async`. A phrase kernel
+/// that quietly degraded to an intersection would return that extra
+/// document and fail here.
+const QUERY_SHAPES: [(&str, QueryShape, usize, usize); 5] = [
+    (
+        "single_rare",
+        QueryShape::Or("rare-token-zzz"),
+        ORACLE_TOP_K_SMALL,
+        1,
+    ),
+    ("single_common", QueryShape::Or("rust"), ORACLE_TOP_K, 3),
+    ("two_term_or", QueryShape::Or("rust async"), ORACLE_TOP_K, 2),
+    // Both match sets are small and exact, so the head spans the whole
+    // result rather than a prefix of it. A prefix would compare only
+    // the top two, which both shapes agree on — the document that
+    // separates them (`rust trait dyn impl async`, matching the
+    // intersection but not the phrase) ranks third, and a head of 2
+    // would never look at it.
+    (
+        "two_term_and",
+        QueryShape::AllOf(&["rust", "async"]),
+        ORACLE_TOP_K,
+        ORACLE_TOP_K,
+    ),
+    (
+        "phrase",
+        QueryShape::Phrase(&["rust", "async"]),
+        ORACLE_TOP_K,
+        ORACLE_TOP_K,
+    ),
+];
+
 // ---- Tests: declared BM25 parameters ---------------------------------
 
 /// A column that declares a non-standard pair must rank exactly as the
@@ -404,19 +511,10 @@ static DECLARED_PARAM_FIXTURE: LazyLock<StandardFixture> = LazyLock::new(|| {
 #[test]
 fn oracle_declared_bm25_params_match_across_query_shapes() {
     let f = &*DECLARED_PARAM_FIXTURE;
-    for (label, query, k, head) in [
-        (
-            "declared_single_rare",
-            "rare-token-zzz",
-            ORACLE_TOP_K_SMALL,
-            1,
-        ),
-        ("declared_single_common", "rust", ORACLE_TOP_K, 3),
-        ("declared_two_term_or", "rust async", ORACLE_TOP_K, 2),
-    ] {
-        let inf_hits = supertable_search_global(&f.infino, query, k, CHUNK_SIZE);
-        let ora_hits = brute_force_top_k(&f.oracles, query, k);
-        assert_top_k_sets_match(label, inf_hits, ora_hits, head);
+    for (label, shape, k, head) in QUERY_SHAPES {
+        let inf_hits = supertable_search_global(&f.infino, &shape.engine_query(), k, CHUNK_SIZE);
+        let ora_hits = shape.oracle_top_k(&f.oracles, k);
+        assert_top_k_sets_match(&format!("declared_{label}"), inf_hits, ora_hits, head);
     }
 }
 
@@ -436,18 +534,15 @@ fn oracle_query_time_override_matches_the_reference_at_that_pair() {
         OracleBm25Params { k1: 1.2, b: 0.0 },
     ] {
         let oracles = build_oracles_with_params(&corp, SUPERFILES, params);
-        for (query, k, head) in [
-            ("rare-token-zzz", ORACLE_TOP_K_SMALL, 1),
-            ("rust", ORACLE_TOP_K, 3),
-            ("rust async", ORACLE_TOP_K, 2),
-        ] {
+        for (label, shape, k, head) in QUERY_SHAPES {
+            let query = shape.engine_query();
             let hits = f
                 .infino
                 .reader()
                 .expect("reader")
                 .bm25_hits(
                     "title",
-                    query,
+                    &query,
                     k,
                     Bm25SearchOptions::new()
                         .with_stats(Bm25Stats::PerSuperfile)
@@ -455,9 +550,9 @@ fn oracle_query_time_override_matches_the_reference_at_that_pair() {
                 )
                 .expect("bm25 with override");
             let inf_hits = supertable_to_global_ids(&f.infino, hits, CHUNK_SIZE);
-            let ora_hits = brute_force_top_k(&oracles, query, k);
+            let ora_hits = shape.oracle_top_k(&oracles, k);
             assert_top_k_sets_match(
-                &format!("override_k1={}_b={}_{query}", params.k1, params.b),
+                &format!("override_k1={}_b={}_{label}", params.k1, params.b),
                 inf_hits,
                 ora_hits,
                 head,

--- a/tests/supertable/query/fanout_concurrency.rs
+++ b/tests/supertable/query/fanout_concurrency.rs
@@ -46,6 +46,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    Bm25SearchOptions,
     superfile::{builder::FtsConfig, fts::reader::BoolMode},
     supertable::{
         Supertable, SupertableOptions,
@@ -203,7 +204,7 @@ fn run_bm25(st: &Supertable) -> Vec<(String, u32)> {
                 "title",
                 "rust",
                 K,
-                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
             )
             .expect("bm25"),
     )

--- a/tests/supertable/query/fanout_concurrency.rs
+++ b/tests/supertable/query/fanout_concurrency.rs
@@ -199,7 +199,12 @@ fn run_bm25(st: &Supertable) -> Vec<(String, u32)> {
     hit_key(
         &st.reader()
             .expect("reader")
-            .bm25_hits("title", "rust", K, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                "rust",
+                K,
+                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("bm25"),
     )
 }

--- a/tests/supertable/query/fanout_floor.rs
+++ b/tests/supertable/query/fanout_floor.rs
@@ -199,7 +199,12 @@ fn build_supertable() -> (Supertable, Vec<TempDir>) {
     let _ = consumer
         .reader()
         .expect("reader")
-        .bm25_hits("title", "common", K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "common",
+            K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("prewarm");
     consumer
         .wait_until_warm(WARM_PROMOTION_TIMEOUT)
@@ -349,7 +354,12 @@ fn fanout_floor_decomposition() {
             continue;
         }
         let hits = reader
-            .bm25_hits("title", term, K, BoolMode::Or)
+            .bm25_hits(
+                "title",
+                term,
+                K,
+                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            )
             .expect("bm25_hits");
         assert_eq!(
             !hits.is_empty(),
@@ -365,7 +375,12 @@ fn fanout_floor_decomposition() {
         });
         let (hits_p50, hits_flt) = time_p50(|| {
             let h = reader
-                .bm25_hits("title", term, K, BoolMode::Or)
+                .bm25_hits(
+                    "title",
+                    term,
+                    K,
+                    infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+                )
                 .expect("bm25_hits");
             std::hint::black_box(h);
         });
@@ -373,7 +388,15 @@ fn fanout_floor_decomposition() {
         // arithmetic `_id` resolve, no Parquet involvement.
         let (ids_p50, ids_flt) = time_p50(|| {
             let b = reader
-                .bm25_search("title", term, K, BoolMode::Or, Bm25Stats::Global, None)
+                .bm25_search(
+                    "title",
+                    term,
+                    K,
+                    infino::Bm25SearchOptions::new()
+                        .with_mode(BoolMode::Or)
+                        .with_stats(Bm25Stats::Global),
+                    None,
+                )
                 .expect("bm25_search");
             std::hint::black_box(b);
         });
@@ -386,8 +409,9 @@ fn fanout_floor_decomposition() {
                     "title",
                     term,
                     K,
-                    BoolMode::Or,
-                    Bm25Stats::Global,
+                    infino::Bm25SearchOptions::new()
+                        .with_mode(BoolMode::Or)
+                        .with_stats(Bm25Stats::Global),
                     Some(&["_id", "title", "score"]),
                 )
                 .expect("bm25_search");

--- a/tests/supertable/query/fanout_floor.rs
+++ b/tests/supertable/query/fanout_floor.rs
@@ -46,6 +46,7 @@ use arrow_array::{LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use infino::{
+    Bm25SearchOptions,
     superfile::{
         SuperfileReader,
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
@@ -203,7 +204,7 @@ fn build_supertable() -> (Supertable, Vec<TempDir>) {
             "title",
             "common",
             K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("prewarm");
     consumer
@@ -358,7 +359,7 @@ fn fanout_floor_decomposition() {
                 "title",
                 term,
                 K,
-                infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+                Bm25SearchOptions::new().with_mode(BoolMode::Or),
             )
             .expect("bm25_hits");
         assert_eq!(
@@ -379,7 +380,7 @@ fn fanout_floor_decomposition() {
                     "title",
                     term,
                     K,
-                    infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+                    Bm25SearchOptions::new().with_mode(BoolMode::Or),
                 )
                 .expect("bm25_hits");
             std::hint::black_box(h);
@@ -392,7 +393,7 @@ fn fanout_floor_decomposition() {
                     "title",
                     term,
                     K,
-                    infino::Bm25SearchOptions::new()
+                    Bm25SearchOptions::new()
                         .with_mode(BoolMode::Or)
                         .with_stats(Bm25Stats::Global),
                     None,
@@ -409,7 +410,7 @@ fn fanout_floor_decomposition() {
                     "title",
                     term,
                     K,
-                    infino::Bm25SearchOptions::new()
+                    Bm25SearchOptions::new()
                         .with_mode(BoolMode::Or)
                         .with_stats(Bm25Stats::Global),
                     Some(&["_id", "title", "score"]),

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -134,8 +134,9 @@ fn bm25_exact_term_loads_only_the_matching_part() {
             "title",
             "echo",
             BM25_TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             None,
         )
         .expect("bm25");
@@ -186,8 +187,9 @@ fn bm25_term_in_no_part_loads_nothing() {
             "title",
             "zoo",
             BM25_TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             None,
         )
         .expect("bm25");
@@ -871,8 +873,9 @@ fn eager_mode_query_paths_observationally_unchanged() {
             "title",
             "alpha",
             BM25_TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             None,
         )
         .expect("bm25");

--- a/tests/supertable/query/hierarchical.rs
+++ b/tests/supertable/query/hierarchical.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 use arrow_array::{LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    Bm25SearchOptions,
     superfile::{
         builder::FtsConfig,
         fts::reader::{Bm25Stats, BoolMode},
@@ -134,7 +135,7 @@ fn bm25_exact_term_loads_only_the_matching_part() {
             "title",
             "echo",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,
@@ -187,7 +188,7 @@ fn bm25_term_in_no_part_loads_nothing() {
             "title",
             "zoo",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,
@@ -873,7 +874,7 @@ fn eager_mode_query_paths_observationally_unchanged() {
             "title",
             "alpha",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,

--- a/tests/supertable/query/id_resolve.rs
+++ b/tests/supertable/query/id_resolve.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use arrow_array::{Decimal128Array, Float32Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    Bm25SearchOptions,
     superfile::{
         builder::FtsConfig,
         fts::reader::{Bm25Stats, BoolMode},
@@ -108,7 +109,7 @@ fn bare_projection_ids_match_id_page_read_path() {
             "title",
             "common",
             K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,
@@ -127,7 +128,7 @@ fn bare_projection_ids_match_id_page_read_path() {
             "title",
             "common",
             K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "score"]),
@@ -156,7 +157,7 @@ fn bare_projection_ids_match_id_page_read_path() {
             "title",
             &probe_token,
             PROBE_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,
@@ -167,7 +168,7 @@ fn bare_projection_ids_match_id_page_read_path() {
             "title",
             &probe_token,
             PROBE_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "score"]),

--- a/tests/supertable/query/id_resolve.rs
+++ b/tests/supertable/query/id_resolve.rs
@@ -104,7 +104,15 @@ fn bare_projection_ids_match_id_page_read_path() {
     // `common` is in every doc → hits span segments; per-doc unique
     // tokens keep scores distinct so rank order is meaningful.
     let bare = reader
-        .bm25_search("title", "common", K, BoolMode::Or, Bm25Stats::Global, None)
+        .bm25_search(
+            "title",
+            "common",
+            K,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
+            None,
+        )
         .expect("bare search");
     assert_eq!(bare.len(), 1, "single merged batch");
     let bare = &bare[0];
@@ -119,8 +127,9 @@ fn bare_projection_ids_match_id_page_read_path() {
             "title",
             "common",
             K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "score"]),
         )
         .expect("projected search");
@@ -147,8 +156,9 @@ fn bare_projection_ids_match_id_page_read_path() {
             "title",
             &probe_token,
             PROBE_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             None,
         )
         .expect("bare unique");
@@ -157,8 +167,9 @@ fn bare_projection_ids_match_id_page_read_path() {
             "title",
             &probe_token,
             PROBE_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "score"]),
         )
         .expect("projected unique");

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -26,6 +26,7 @@ use std::{collections::HashSet, sync::Arc};
 use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    Bm25SearchOptions,
     superfile::{
         builder::FtsConfig,
         fts::reader::{Bm25Stats, BoolMode},
@@ -276,7 +277,7 @@ fn bm25_global_stats_keeps_the_per_superfile_membership() {
             "title",
             "rust",
             TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::PerSuperfile),
         )
@@ -286,7 +287,7 @@ fn bm25_global_stats_keeps_the_per_superfile_membership() {
             "title",
             "rust",
             TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,
@@ -488,7 +489,7 @@ fn token_match_or_is_the_unranked_bm25_candidate_set() {
             "title",
             "rust",
             TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("bm25_search OR");
 
@@ -520,7 +521,7 @@ fn token_match_and_intersects_tokens() {
             "title",
             "rust systems",
             TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::And),
+            Bm25SearchOptions::new().with_mode(BoolMode::And),
         )
         .expect("bm25_search AND");
 
@@ -589,7 +590,7 @@ fn hybrid_search_unions_bm25_and_vector_and_orders_by_score() {
             "title",
             "rust",
             TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("bm25_search");
     let vector = reader
@@ -645,7 +646,7 @@ fn hybrid_search_doc_top_in_both_retrievers_ranks_first() {
             "title",
             "async",
             RANK_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("bm25_search");
     let vector = reader

--- a/tests/supertable/query/match_search.rs
+++ b/tests/supertable/query/match_search.rs
@@ -272,12 +272,13 @@ fn bm25_global_stats_keeps_the_per_superfile_membership() {
     let st = demo_two_superfiles();
     let reader = st.reader().expect("reader");
     let per_superfile_hits = reader
-        .bm25_hits_stats(
+        .bm25_hits(
             "title",
             "rust",
             TOP_K,
-            BoolMode::Or,
-            Bm25Stats::PerSuperfile,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::PerSuperfile),
         )
         .expect("per-superfile bm25");
     let global = reader
@@ -285,8 +286,9 @@ fn bm25_global_stats_keeps_the_per_superfile_membership() {
             "title",
             "rust",
             TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             None,
         )
         .expect("global-stats bm25");
@@ -482,7 +484,12 @@ fn token_match_or_is_the_unranked_bm25_candidate_set() {
         .token_match("title", "rust", BoolMode::Or)
         .expect("token_match OR");
     let bm25 = reader
-        .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "rust",
+            TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("bm25_search OR");
 
     assert!(
@@ -509,7 +516,12 @@ fn token_match_and_intersects_tokens() {
         .token_match("title", "rust systems", BoolMode::And)
         .expect("token_match AND");
     let bm25 = reader
-        .bm25_hits("title", "rust systems", TOP_K, BoolMode::And)
+        .bm25_hits(
+            "title",
+            "rust systems",
+            TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::And),
+        )
         .expect("bm25_search AND");
 
     assert!(!token.is_empty(), "AND of present tokens must match a doc");
@@ -573,7 +585,12 @@ fn hybrid_search_unions_bm25_and_vector_and_orders_by_score() {
         )
         .expect("hybrid_search");
     let bm25 = reader
-        .bm25_hits("title", "rust", TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "rust",
+            TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("bm25_search");
     let vector = reader
         .vector_hits("emb", &q, TOP_K, VectorSearchOptions::new(), None)
@@ -624,7 +641,12 @@ fn hybrid_search_doc_top_in_both_retrievers_ranks_first() {
         )
         .expect("hybrid_search");
     let bm25 = reader
-        .bm25_hits("title", "async", RANK_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "async",
+            RANK_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("bm25_search");
     let vector = reader
         .vector_hits("emb", &q, RANK_TOP_K, VectorSearchOptions::new(), None)

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -18,7 +18,8 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
-    ConnectOptions, Connection, FtsField, IndexSpec, Metric, connect, connect_with,
+    Bm25SearchOptions, ConnectOptions, Connection, FtsField, IndexSpec, Metric, connect,
+    connect_with,
     runtime_metrics::op_stats::{OpStats, with_op_stats},
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
@@ -131,7 +132,7 @@ fn scoped_fts_stats(st: &Supertable, query: &str) -> OpStats {
                 "title",
                 query,
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -166,7 +167,7 @@ fn a_scoped_bm25_query_reports_its_planned_ranges() {
                 "title",
                 "rust",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -179,7 +180,7 @@ fn a_scoped_bm25_query_reports_its_planned_ranges() {
                 "title",
                 "rust async web",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -216,7 +217,7 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
                 "title",
                 "rust",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -235,7 +236,7 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
                 "title",
                 "rust async web",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -276,7 +277,7 @@ fn global_ranges(st: &Supertable, q: &str, mode: BoolMode) -> u64 {
                 "title",
                 q,
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(mode)
                     .with_stats(Bm25Stats::Global),
             )
@@ -295,7 +296,7 @@ fn per_superfile_ranges(st: &Supertable, q: &str, mode: BoolMode) -> u64 {
                 "title",
                 q,
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(mode)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -412,7 +413,7 @@ fn a_scoped_bm25_query_reports_kernel_cpu() {
                     "title",
                     query,
                     TOP_K,
-                    infino::Bm25SearchOptions::new()
+                    Bm25SearchOptions::new()
                         .with_mode(BoolMode::Or)
                         .with_stats(Bm25Stats::PerSuperfile),
                 )
@@ -449,7 +450,7 @@ fn a_reader_minted_outside_the_scope_records_nothing() {
                 "title",
                 "rust",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -476,7 +477,7 @@ fn an_inline_df1_term_plans_no_posting_range() {
                 "title",
                 "rust",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -489,7 +490,7 @@ fn an_inline_df1_term_plans_no_posting_range() {
                 "title",
                 "rust filler0x0",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::PerSuperfile),
             )
@@ -607,7 +608,7 @@ fn a_scalar_projection_reports_materialized_rows() {
                 "title",
                 "rust",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 Some(&["title"]),
@@ -627,7 +628,7 @@ fn a_scalar_projection_reports_materialized_rows() {
                 "title",
                 "rust",
                 TOP_K,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(BoolMode::Or)
                     .with_stats(Bm25Stats::Global),
                 None,

--- a/tests/supertable/query/op_stats.rs
+++ b/tests/supertable/query/op_stats.rs
@@ -127,7 +127,14 @@ fn scoped_fts_stats(st: &Supertable, query: &str) -> OpStats {
     let (hits, stats) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats("title", query, TOP_K, BoolMode::Or, Bm25Stats::PerSuperfile)
+            .bm25_hits(
+                "title",
+                query,
+                TOP_K,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::PerSuperfile),
+            )
             .expect("bm25")
     });
     assert!(!hits.is_empty(), "fixture query {query:?} must match");
@@ -155,24 +162,26 @@ fn a_scoped_bm25_query_reports_its_planned_ranges() {
     let (_, one_term) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats(
+            .bm25_hits(
                 "title",
                 "rust",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::PerSuperfile),
             )
             .expect("bm25")
     });
     let (_, three_terms) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats(
+            .bm25_hits(
                 "title",
                 "rust async web",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::PerSuperfile),
             )
             .expect("bm25")
     });
@@ -203,12 +212,13 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
     let (_, one_term) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats(
+            .bm25_hits(
                 "title",
                 "rust",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::PerSuperfile),
             )
             .expect("bm25")
     });
@@ -221,12 +231,13 @@ fn fts_planned_ranges_pin_one_range_per_term_per_superfile() {
     let (_, three_terms) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats(
+            .bm25_hits(
                 "title",
                 "rust async web",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::PerSuperfile),
             )
             .expect("bm25")
     });
@@ -261,7 +272,14 @@ fn global_ranges(st: &Supertable, q: &str, mode: BoolMode) -> u64 {
     let (hits, stats) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats("title", q, TOP_K, mode, Bm25Stats::Global)
+            .bm25_hits(
+                "title",
+                q,
+                TOP_K,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(mode)
+                    .with_stats(Bm25Stats::Global),
+            )
             .expect("bm25")
     });
     assert!(!hits.is_empty(), "fixture query {q:?} must match");
@@ -273,7 +291,14 @@ fn per_superfile_ranges(st: &Supertable, q: &str, mode: BoolMode) -> u64 {
     let (hits, stats) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats("title", q, TOP_K, mode, Bm25Stats::PerSuperfile)
+            .bm25_hits(
+                "title",
+                q,
+                TOP_K,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(mode)
+                    .with_stats(Bm25Stats::PerSuperfile),
+            )
             .expect("bm25")
     });
     assert!(!hits.is_empty(), "fixture query {q:?} must match");
@@ -383,7 +408,14 @@ fn a_scoped_bm25_query_reports_kernel_cpu() {
             let query = if i % 2 == 0 { "rust" } else { "rust async web" };
             st.reader()
                 .expect("reader")
-                .bm25_hits_stats("title", query, TOP_K, BoolMode::Or, Bm25Stats::PerSuperfile)
+                .bm25_hits(
+                    "title",
+                    query,
+                    TOP_K,
+                    infino::Bm25SearchOptions::new()
+                        .with_mode(BoolMode::Or)
+                        .with_stats(Bm25Stats::PerSuperfile),
+                )
                 .expect("bm25");
         }
     });
@@ -413,12 +445,13 @@ fn a_reader_minted_outside_the_scope_records_nothing() {
     let reader = st.reader().expect("reader");
     let (hits, stats) = with_op_stats(|| {
         reader
-            .bm25_hits_stats(
+            .bm25_hits(
                 "title",
                 "rust",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::PerSuperfile),
             )
             .expect("bm25")
     });
@@ -439,24 +472,26 @@ fn an_inline_df1_term_plans_no_posting_range() {
     let (_, base) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats(
+            .bm25_hits(
                 "title",
                 "rust",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::PerSuperfile),
             )
             .expect("bm25")
     });
     let (_, with_inline) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats(
+            .bm25_hits(
                 "title",
                 "rust filler0x0",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::PerSuperfile,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::PerSuperfile),
             )
             .expect("bm25")
     });
@@ -572,8 +607,9 @@ fn a_scalar_projection_reports_materialized_rows() {
                 "title",
                 "rust",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 Some(&["title"]),
             )
             .expect("projected search")
@@ -591,8 +627,9 @@ fn a_scalar_projection_reports_materialized_rows() {
                 "title",
                 "rust",
                 TOP_K,
-                BoolMode::Or,
-                Bm25Stats::Global,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(BoolMode::Or)
+                    .with_stats(Bm25Stats::Global),
                 None,
             )
             .expect("bare search")

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -180,7 +180,8 @@ fn bm25_exact_term_skip_opens_only_matching_superfile() {
             "title",
             "nimblefox",
             BM25_TOP_K,
-            infino::supertable::query::fts::BoolMode::Or,
+            infino::Bm25SearchOptions::new()
+                .with_mode(infino::supertable::query::fts::BoolMode::Or),
         )
         .expect("query");
     assert_eq!(hits.len(), 1, "exactly one doc matches `nimblefox`");
@@ -277,7 +278,8 @@ fn bm25_search_with_no_matching_superfiles_opens_no_superfiles_at_all() {
             "title",
             "definitelynotpresent",
             BM25_TOP_K,
-            infino::supertable::query::fts::BoolMode::Or,
+            infino::Bm25SearchOptions::new()
+                .with_mode(infino::supertable::query::fts::BoolMode::Or),
         )
         .expect("query");
     assert!(hits.is_empty());
@@ -316,12 +318,13 @@ fn bm25_and_mode_skip_requires_all_terms_present_in_superfile() {
 
     let before = store.snapshot();
     let _hits = r
-        .bm25_hits_stats(
+        .bm25_hits(
             "title",
             "alpha beta",
             BM25_TOP_K,
-            infino::supertable::query::fts::BoolMode::And,
-            infino::Bm25Stats::PerSuperfile,
+            infino::Bm25SearchOptions::new()
+                .with_mode(infino::supertable::query::fts::BoolMode::And)
+                .with_stats(infino::Bm25Stats::PerSuperfile),
         )
         .expect("AND query");
 

--- a/tests/supertable/query/skip_pruning.rs
+++ b/tests/supertable/query/skip_pruning.rs
@@ -40,6 +40,7 @@ use std::{
 
 use bytes::Bytes;
 use infino::{
+    Bm25SearchOptions,
     superfile::{SuperfileReader, builder::FtsConfig, fts::tokenize::Tokenizer},
     supertable::{
         Supertable, SupertableOptions,
@@ -180,8 +181,7 @@ fn bm25_exact_term_skip_opens_only_matching_superfile() {
             "title",
             "nimblefox",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new()
-                .with_mode(infino::supertable::query::fts::BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(infino::supertable::query::fts::BoolMode::Or),
         )
         .expect("query");
     assert_eq!(hits.len(), 1, "exactly one doc matches `nimblefox`");
@@ -278,8 +278,7 @@ fn bm25_search_with_no_matching_superfiles_opens_no_superfiles_at_all() {
             "title",
             "definitelynotpresent",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new()
-                .with_mode(infino::supertable::query::fts::BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(infino::supertable::query::fts::BoolMode::Or),
         )
         .expect("query");
     assert!(hits.is_empty());
@@ -322,7 +321,7 @@ fn bm25_and_mode_skip_requires_all_terms_present_in_superfile() {
             "title",
             "alpha beta",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(infino::supertable::query::fts::BoolMode::And)
                 .with_stats(infino::Bm25Stats::PerSuperfile),
         )

--- a/tests/supertable/query/stored_fields.rs
+++ b/tests/supertable/query/stored_fields.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use arrow_array::{Int64Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    Bm25SearchOptions,
     superfile::{
         builder::FtsConfig,
         fts::reader::{Bm25Stats, BoolMode},
@@ -108,7 +109,7 @@ fn index_only_column_searches_but_rejects_projection() {
             "body",
             "signal",
             K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,
@@ -123,7 +124,7 @@ fn index_only_column_searches_but_rejects_projection() {
             "body",
             "signal",
             K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "rating", "score"]),
@@ -139,7 +140,7 @@ fn index_only_column_searches_but_rejects_projection() {
             "body",
             "signal",
             K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             Some(&["_id", "body", "score"]),

--- a/tests/supertable/query/stored_fields.rs
+++ b/tests/supertable/query/stored_fields.rs
@@ -104,7 +104,15 @@ fn index_only_column_searches_but_rejects_projection() {
 
     // Ranked search over the index-only column spans both segments.
     let batches = reader
-        .bm25_search("body", "signal", K, BoolMode::Or, Bm25Stats::Global, None)
+        .bm25_search(
+            "body",
+            "signal",
+            K,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
+            None,
+        )
         .expect("bm25 over index-only column");
     let n: usize = batches.iter().map(RecordBatch::num_rows).sum();
     assert_eq!(n, 2, "one signal doc per segment");
@@ -115,8 +123,9 @@ fn index_only_column_searches_but_rejects_projection() {
             "body",
             "signal",
             K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             Some(&["_id", "title", "rating", "score"]),
         )
         .expect("stored projection");
@@ -130,8 +139,9 @@ fn index_only_column_searches_but_rejects_projection() {
             "body",
             "signal",
             K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             Some(&["_id", "body", "score"]),
         )
         .expect_err("index-only column must not be projectable");

--- a/tests/supertable/query/term_stats.rs
+++ b/tests/supertable/query/term_stats.rs
@@ -16,7 +16,7 @@ use arrow_array::{ArrayRef, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
-    CompactionSettings, OptimizeOptions,
+    Bm25SearchOptions, CompactionSettings, OptimizeOptions,
     runtime_metrics::op_stats::with_op_stats,
     storage::StorageProvider,
     superfile::{
@@ -116,7 +116,7 @@ fn global_hits(st: &Supertable, query: &str, mode: BoolMode) -> Vec<(String, f32
             "title",
             query,
             TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(mode)
                 .with_stats(Bm25Stats::Global),
             Some(&["title", "score"]),
@@ -150,9 +150,7 @@ fn planned_ranges(st: &Supertable, query: &str, mode: BoolMode, stats: Bm25Stats
                 "title",
                 query,
                 TOP_K,
-                infino::Bm25SearchOptions::new()
-                    .with_mode(mode)
-                    .with_stats(stats),
+                Bm25SearchOptions::new().with_mode(mode).with_stats(stats),
             )
             .expect("bm25")
     });

--- a/tests/supertable/query/term_stats.rs
+++ b/tests/supertable/query/term_stats.rs
@@ -116,8 +116,9 @@ fn global_hits(st: &Supertable, query: &str, mode: BoolMode) -> Vec<(String, f32
             "title",
             query,
             TOP_K,
-            mode,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(mode)
+                .with_stats(Bm25Stats::Global),
             Some(&["title", "score"]),
         )
         .expect("bm25_search");
@@ -145,7 +146,14 @@ fn planned_ranges(st: &Supertable, query: &str, mode: BoolMode, stats: Bm25Stats
     let (hits, op) = with_op_stats(|| {
         st.reader()
             .expect("reader")
-            .bm25_hits_stats("title", query, TOP_K, mode, stats)
+            .bm25_hits(
+                "title",
+                query,
+                TOP_K,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(mode)
+                    .with_stats(stats),
+            )
             .expect("bm25")
     });
     assert!(!hits.is_empty(), "fixture query {query:?} must match");

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -31,6 +31,7 @@ use arrow_schema::{DataType, Field, Schema};
 use chrono::Utc;
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
+    Bm25SearchOptions,
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
         builder::FtsConfig,
@@ -190,7 +191,7 @@ async fn fts_query_excludes_tombstoned_row() {
             "title",
             "alpha",
             BM25_TOP_K,
-            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+            Bm25SearchOptions::new().with_mode(BoolMode::Or),
         )
         .expect("fts");
     assert_eq!(hits.len(), 2, "tombstoned row must be excluded");
@@ -813,7 +814,7 @@ fn tombstoned_superfile_does_not_raise_the_shared_phrase_floor() {
                     "title",
                     "\"alpha beta\"",
                     FLOOR_TOP_K,
-                    infino::Bm25SearchOptions::new()
+                    Bm25SearchOptions::new()
                         .with_mode(BoolMode::Or)
                         .with_stats(stats),
                     Some(&["title"]),

--- a/tests/supertable/query/tombstone_filter.rs
+++ b/tests/supertable/query/tombstone_filter.rs
@@ -186,7 +186,12 @@ async fn fts_query_excludes_tombstoned_row() {
     let hits = st
         .reader()
         .expect("reader")
-        .bm25_hits("title", "alpha", BM25_TOP_K, BoolMode::Or)
+        .bm25_hits(
+            "title",
+            "alpha",
+            BM25_TOP_K,
+            infino::Bm25SearchOptions::new().with_mode(BoolMode::Or),
+        )
         .expect("fts");
     assert_eq!(hits.len(), 2, "tombstoned row must be excluded");
     for hit in &hits {
@@ -808,8 +813,9 @@ fn tombstoned_superfile_does_not_raise_the_shared_phrase_floor() {
                     "title",
                     "\"alpha beta\"",
                     FLOOR_TOP_K,
-                    BoolMode::Or,
-                    stats,
+                    infino::Bm25SearchOptions::new()
+                        .with_mode(BoolMode::Or)
+                        .with_stats(stats),
                     Some(&["title"]),
                 )
                 .expect("phrase search");

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -287,7 +287,15 @@ fn run_bm25_queries(st: &Supertable) -> Vec<Vec<i128>> {
         .iter()
         .map(|q| {
             let batches = reader
-                .bm25_search("title", q, BM25_K, BoolMode::Or, Bm25Stats::Global, None)
+                .bm25_search(
+                    "title",
+                    q,
+                    BM25_K,
+                    infino::Bm25SearchOptions::new()
+                        .with_mode(BoolMode::Or)
+                        .with_stats(Bm25Stats::Global),
+                    None,
+                )
                 .unwrap_or_else(|e| panic!("bm25_search({q:?}) failed: {e}"));
             extract_sorted_ids(&batches)
         })

--- a/tests/supertable/storage/compact_azure.rs
+++ b/tests/supertable/storage/compact_azure.rs
@@ -65,7 +65,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
-    VectorSearchOptions,
+    Bm25SearchOptions, VectorSearchOptions,
     config::{
         CompactionSettings, Config, OptimizeOptions, StorageBackend, StorageColdFetchMode,
         StorageSettings, SupertableSettings, ThreadCount,
@@ -291,7 +291,7 @@ fn run_bm25_queries(st: &Supertable) -> Vec<Vec<i128>> {
                     "title",
                     q,
                     BM25_K,
-                    infino::Bm25SearchOptions::new()
+                    Bm25SearchOptions::new()
                         .with_mode(BoolMode::Or)
                         .with_stats(Bm25Stats::Global),
                     None,

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -506,8 +506,9 @@ async fn supertable_real_azure_round_trip() {
                 "title",
                 "alpha",
                 10,
-                infino::superfile::fts::reader::BoolMode::Or,
-                infino::Bm25Stats::Global,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(infino::superfile::fts::reader::BoolMode::Or)
+                    .with_stats(infino::Bm25Stats::Global),
                 None,
             )
             .map_err(|e| format!("cold BM25 over real Azure: {e}"))?;

--- a/tests/supertable/storage/smoke_azure.rs
+++ b/tests/supertable/storage/smoke_azure.rs
@@ -42,6 +42,7 @@ use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, Rec
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use infino::{
+    Bm25SearchOptions,
     config::{
         CompactionSettings, Config, StorageBackend, StorageColdFetchMode, StorageSettings,
         SupertableSettings,
@@ -506,7 +507,7 @@ async fn supertable_real_azure_round_trip() {
                 "title",
                 "alpha",
                 10,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(infino::superfile::fts::reader::BoolMode::Or)
                     .with_stats(infino::Bm25Stats::Global),
                 None,

--- a/tests/supertable/storage/smoke_gcs.rs
+++ b/tests/supertable/storage/smoke_gcs.rs
@@ -191,7 +191,15 @@ async fn supertable_real_gcs_round_trip() {
     let bm25 = consumer
         .reader()
         .expect("reader")
-        .bm25_search("title", "alpha", 10, BoolMode::Or, Bm25Stats::Global, None)
+        .bm25_search(
+            "title",
+            "alpha",
+            10,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
+            None,
+        )
         .expect("bm25 over real gcs");
     assert!(!bm25.is_empty(), "cold BM25 must find the alpha docs");
 

--- a/tests/supertable/storage/smoke_gcs.rs
+++ b/tests/supertable/storage/smoke_gcs.rs
@@ -28,6 +28,7 @@ use std::{collections::HashMap, sync::Arc};
 use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    Bm25SearchOptions,
     superfile::{
         builder::{FtsConfig, VectorConfig},
         fts::reader::{Bm25Stats, BoolMode},
@@ -195,7 +196,7 @@ async fn supertable_real_gcs_round_trip() {
             "title",
             "alpha",
             10,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use arrow_array::{Array, FixedSizeListArray, Float32Array, LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use infino::{
+    Bm25SearchOptions,
     config::{
         CompactionSettings, Config, StorageBackend, StorageColdFetchMode, StorageSettings,
         SupertableSettings,
@@ -245,7 +246,7 @@ async fn supertable_real_s3_lazy_vector_and_fts_round_trip() {
                 "title",
                 "alpha",
                 10,
-                infino::Bm25SearchOptions::new()
+                Bm25SearchOptions::new()
                     .with_mode(infino::superfile::fts::reader::BoolMode::Or)
                     .with_stats(infino::Bm25Stats::Global),
                 None,

--- a/tests/supertable/storage/smoke_s3.rs
+++ b/tests/supertable/storage/smoke_s3.rs
@@ -245,8 +245,9 @@ async fn supertable_real_s3_lazy_vector_and_fts_round_trip() {
                 "title",
                 "alpha",
                 10,
-                infino::superfile::fts::reader::BoolMode::Or,
-                infino::Bm25Stats::Global,
+                infino::Bm25SearchOptions::new()
+                    .with_mode(infino::superfile::fts::reader::BoolMode::Or)
+                    .with_stats(infino::Bm25Stats::Global),
                 None,
             )
             .map_err(|e| format!("cold BM25 over real S3: {e}"))?;

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -188,8 +188,9 @@ async fn writer_delete_tombstones_matching_rows() {
             "title",
             "bravo",
             FTS_TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             None,
         )
         .expect("fts");
@@ -271,8 +272,9 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
             "title",
             "bravo",
             FTS_TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             None,
         )
         .expect("pre-delete fts")
@@ -300,8 +302,9 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
             "title",
             "bravo",
             FTS_TOP_K,
-            BoolMode::Or,
-            Bm25Stats::Global,
+            infino::Bm25SearchOptions::new()
+                .with_mode(BoolMode::Or)
+                .with_stats(Bm25Stats::Global),
             None,
         )
         .expect("post-delete fts")

--- a/tests/supertable/writer_mutations.rs
+++ b/tests/supertable/writer_mutations.rs
@@ -17,7 +17,7 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::prelude::{Expr, col, lit};
 use infino::{
-    InfinoError,
+    Bm25SearchOptions, InfinoError,
     storage::{LocalFsStorageProvider, StorageProvider},
     superfile::{
         builder::FtsConfig,
@@ -188,7 +188,7 @@ async fn writer_delete_tombstones_matching_rows() {
             "title",
             "bravo",
             FTS_TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,
@@ -272,7 +272,7 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
             "title",
             "bravo",
             FTS_TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,
@@ -302,7 +302,7 @@ async fn delete_is_visible_to_other_handles_on_next_query() {
             "title",
             "bravo",
             FTS_TOP_K,
-            infino::Bm25SearchOptions::new()
+            Bm25SearchOptions::new()
                 .with_mode(BoolMode::Or)
                 .with_stats(Bm25Stats::Global),
             None,


### PR DESCRIPTION
Adds the `k1` / `b` BM25 similarity knobs: declared per FTS column at `create_table`, and overridable per search. Stopword and stemming options are a separate change.

## Why both declaration sites

Scoring parameters are naturally a query-time concern — retuning relevance should not require rebuilding an index. What makes that awkward here is the bound representation: the build writes the exact `f32` BM25 score per block, so a stored bound belongs to the parameters that produced it, and a query scoring with a different pair would prune against bounds that no longer hold.

Rather than change that representation, this keeps it and corrects the bound. Bound tightness is the measured single-term lever on this engine — the exact-`f32` bound is what won it — and a representation that defers the bound computation to query time was built and measured here earlier: a dead heat overall, with the union top-10 case regressing. So a column declares its pair and the build bakes bounds at it, and a query may score with a different pair with the bounds corrected for the difference.

## The correction factor

`k1` / `b` do not enter the score linearly, so there is no exact ratio — but there is a computable supremum. `idf` cancels, and the per-doc ratio between two parameter sets is monotone in `tf` tending to 1, so its supremum over `tf ≥ 1` is `max(1, (1+A)/(1+B))` per length bucket, where `A` and `B` are the two norm decode tables' entries. The max over the buckets documents actually occupy gives a scalar `R ≥ 1` that keeps every stored bound an upper bound under the new pair — loosening, never under-bounding, and exactly `1.0` when the pairs agree.

`R` composes into a multiply that was already there. The reader already rescales stored bounds for a query-time parameter the build cannot know — global-idf statistics, and the repeated-term `weight` — in `TermCursor::new`'s `idf_rescale` and `search_single_term_bmw`'s `bound_rescale`. Both factors are linear multipliers on a stored bound, and both are `1.0` on the default path, so the default path performs the same multiply it already performed, with one more factor folded into it at cursor-build time.

## Scope of the change

The hot kernel is already parameterized: `score_with_dl_norm_k1` is `idf_x_k1p1 · tf / (tf + dl_norm_k1)`, so the scoring loops — scalar, SIMD, union, AND, phrase — are untouched and only its two precomputed inputs move. `Bm25Params` owns that arithmetic; `NormTable` derives its 256-entry decode table from it.

**One latent bug fixed along the way**: `idf_x_k1p1` was built from the `bm25::K1` constant in four places, so a column with a declared pair would have multiplied by `1.2 + 1` while dividing by a norm table built at its own `k1`. Cursors now build it from the effective pair, and `TermCursor` keeps the bare `idf` so the phrase cursor composes member idfs directly instead of recovering them by dividing by a `(k1 + 1)` it would have to assume.

## Format and compatibility

No layout change, no new region, no section-version step. The pair is written into `inf.fts.columns` **unconditionally, defaults included** — unlike `positions` and `stored`, whose absence has exactly one possible meaning. A scoring parameter is the provenance of the stored bounds, and a reader that infers it will infer wrong the day the recommended default moves; the `rerank_codec` note in `supertable::manifest::options_hash` records that lesson from a real mismatch. A missing pair therefore means the standard values and nothing else, frozen as a format constant, so **every file written before this reads unchanged** and every derived quantity reduces to what it was.

The pair rides `new_from_reader` alongside the analyzer, positions and stored flag. Dropping it there would rebake a merged file's bounds at the standard values while the source superfiles kept their own, so one column would score two ways depending on which superfile a document landed in — and a compaction, not any user action, would be what changed the ranking. Same failure shape as the `rerank_codec` omission that path already had a regression test for.

## Signature changes

None of these appear in the published surface: `SupertableReader` is declared inside `test_visible!`, which is `pub` only under the `test-helpers` feature and `pub(crate)` otherwise, so a default-feature build — which is how `public-api.txt` is generated — has zero entries for it. `Supertable::bm25_search` *is* published, but its signature does not move here; it has taken `Bm25SearchOptions` since #465. In-repo call sites moved with them.

**That is not the same as "no caller breaks", and one did.** A crate that enables `test-helpers` gets the wider surface, and a change to any `test_visible!` item is invisible to both `cargo-public-api` and `cargo-semver-checks` — the latter is run with `default-features` precisely so it does not grade test-helpers internals. The bench engine wrapper enables that feature and calls `reader.bm25_search(...)`; it failed to compile against this branch until its call site was updated. No automation covers those consumers, so they have to be swept by hand.

- `SupertableReader::bm25_hits(column, query, k, mode)` → `(column, query, k, opts)`, and **`bm25_hits_stats` is removed**. That method existed only to pass one extra knob past `mode`; the statistics scope is now a field of `Bm25SearchOptions`, so keeping both would have been a parallel method for no remaining reason — and adding the parameter override on top would have needed a third variant.
- `SupertableReader::bm25_search(column, query, k, mode, stats, projection)` → `(column, query, k, opts, projection)`, and `Supertable::bm25_search` likewise. This is what lets a third knob arrive without a fourth positional.
- `SuperfileReader::prepare_clauses`, `run_prepared` and `bm25_search_or_range_prebuilt` each take `bm25: Option<Bm25Params>`, and a new private `fts_scored` resolves it. `prepare_clauses` and `run_prepared` must be given the *same* override: the cursors carry `idf · (k1 + 1)` from the pair they were built with, and scoring divides by a norm table derived from that pair.
- `FtsBuilder::register_column_with_tokenizer` takes the column's pair; `bm25::score` takes it too.

`bm25_hits` gets more verbose at simple call sites — `bm25_hits("t", "q", K, BoolMode::Or)` becomes a four-line struct construction. If that is the wrong trade, `impl Into<Bm25SearchOptions>` with a `From<BoolMode>` would keep the concise form compiling; say so and I will switch it.

## Surface additions

- `FtsField::bm25(k1, b)` and `FtsConfig::bm25`, validated at `SupertableOptions::new` with a typed error naming the column; persisted in the catalog's `TableEntry` and restored on reopen under the same frozen fallback.
- `Bm25SearchOptions::with_bm25(k1, b)` for the per-search override, validated before the fan-out starts.
- `Bm25Params` re-exported at the crate root, because it is named by the public `Bm25SearchOptions::bm25` field and its only other path (`superfile::fts::bm25`) is `pub` solely under the `test-helpers` feature — the type would otherwise appear on the contract while being unnameable in a default build. Its scorer internals (`dl_norm_k1`, `idf_x_k1p1`) stay `pub(crate)`.
- Both bindings: python `IndexSpec.fts(k1=, b=)` and `bm25_search(k1=, b=)`, with the hand-maintained `.pyi` updated and the typing sample exercising them; node `FtsOptions.k1/b` and `bm25Search`. Each requires the pair together or not at all — the two interact through the length norm, so a half-override scores with a combination the caller never chose.

## Versions: nothing further to bump

**Superfile format: no version change, and none is needed.** `src/superfile/format/` is untouched, `FORMAT_VERSION` is unchanged, and no FTS section version moves — every file this writes is still V5. Nothing in the reader derives behaviour from a version distinction here, because the pair is read from the column entry. Older files read unchanged: a missing pair can only mean the standard values, and every derived quantity then reduces to what it was.

The one on-disk difference is additive and forward-only: a newly written column entry carries `,"k1":1.2,"b":0.75` (18 bytes per FTS column) even at the defaults, and a *declared* column's stored bounds are that column's true maxes under its own pair. Files already on disk are never rewritten.

**Crate version: `0.7.0`, already stamped by #735 — this needs no further bump.** The published surface does move, though, so it is worth being precise rather than claiming otherwise: `public-api.txt` gains `Bm25Params`, `Bm25SearchOptions` gains `#[non_exhaustive]`, the `bm25` field and `with_bm25`, `FtsField::bm25` is added, and `Bm25SearchOptions` **loses its `Eq` derive**. The last two of those are breaking on a `0.x` line, which is exactly what the already-stamped minor covers. Practically nothing breaks — every construction site in this repo and in the only Rust consumer uses the builders, and nothing depended on `Eq` — but `cargo-semver-checks` grades the surface rather than the blast radius, and it is satisfied by the version #735 already set.

## Tests

**The correction is exact where it has to be.** An override scores identically to a file *baked* at that pair — same doc order, same scores — across four parameter pairs, four query shapes and three values of `k`. This is the test that catches a bound left too small, since a bound that under-states a score makes the block-max skip drop a qualifying document.

**Graded against the reference implementation at the pair.** `BruteForceBm25::with_params` makes the brute-force oracle score with the same pair, so a comparison means something rather than grading one similarity function against another. Two gates on it: a column declaring 1.6 / 0.4 ranks exactly as the reference does at 1.6 / 0.4 across single-rare, single-common and two-term-union shapes; and a query-time override on a *standard* table matches the reference at the override's pair for three pairs including `b = 0` — the pruning-correction path, where every stored bound is inflated by the factor.

**Every kernel that reads a stored bound.** Phrase and must-clause queries route through code the single-term and union tests never reach — the phrase cursor composes its members' idfs and its own term-level bound, and a `+must` clause runs the ranked-AND membership walk. A table baked at a pair is compared against a default table overridden to it, document-for-document and score-for-score, over a phrase, a two-must query and a phrase-plus-term mix.

**The composed factor.** What ships is `(idf / local_idf) · R`, and global statistics are the default, so the composed form is the common path rather than an edge case. An override is checked against a baked table under both `Global` and `PerSuperfile`.

**Pruning happens, and drops nothing.** A small `k` fills the top-k heap and engages the block-max skips where a `k` covering the whole match set does not, so the small-`k` head must equal the head of the unpruned run. Four parameter pairs, two small `k` values.

**The derivation itself.** `R` is never below any rescored score across 7 parameter pairs × 50 lengths × 6 term frequencies — the supremum property the whole correction rests on, pinned directly rather than through its uses. Plus `R == 1.0` for an unchanged pair and `>= 1.0` otherwise.

**Validation.** Seven out-of-range declared pairs — including `NaN` and infinity — are refused with the column named and both bounds in the message, and the four boundary values that must be accepted (`b = 0`, `b = 1`, tiny and large `k1`) are. The same bounds are enforced on the query-time override, checked before the fan-out starts.

**Persistence.** The pair round-trips through the column entry; a missing pair reads as the standard values; the decode table matches the closed form against the quantized length the scorer actually sees; and the pair survives a rebuild, so a compaction cannot silently rescore a column.

**Bindings, functionally and not just by type.** `mypy --strict` proves the signature exists; three python tests prove it works — a declared column and an overridden default table agree on titles and scores, passing one parameter without the other is refused on both the search and the create surfaces, and out-of-range pairs are refused.

## CI

`make check` (fmt, clippy `-D warnings` including the `remote` feature, bench-gate, doc-check), `make doctest`, `make test-remote`, `make public-api`, `scripts/check_api_parity.py` (20 covered), `make python-typecheck`; lib suite 2473 pass, supertable integration 337 pass.

`make coverage` did not finish locally — I terminated the run — so I am not quoting a number for it.

## Measurement

A same-box A/B of this branch against `main`, 962 queries across five command shapes, with the branch re-measured in a later slot to separate a real delta from measurement-position bias. Two results are solid because they do not depend on timing:

- **Identical results.** Zero count mismatches against `main` across all 962 queries × 5 command shapes. The default path returns what it returned before.
- **Index size +127 bytes** on 4.13 GB (0.000003%) — the always-written pair in `inf.fts.columns`, and independent confirmation that the two arms really were different binaries.

**On speed I am claiming nothing.** Every command except one flips sign between the two slots (TOP_10 `+4.5%` then `-2.8%`; TOP_100 `-16.3%` then `+2.9%`; COUNT `-4.9%` then `+0.9%`), which is the signature of position bias rather than a code effect. The run's noise floor is wider than any difference it shows, so it establishes neither a regression nor a win. An earlier run had reported a TOP_10 regression consistently in both slots; that did not reproduce here.



