### PR TITLE
release: python 0.7.1

### DIFF
--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "infino-python"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-python"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Python-only patch release. Publishes the `infino` wheel 0.7.1, which includes the benchmark build+serve mode (`bench_serve_build_tcp`, #745) so a client can drive create/append/optimize/search over TCP.

Merging dispatches the Python publish to PyPI automatically.