### PR TITLE
vector: per-query hnsw beam override for benchmark sweeps

### DIFF
--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -19,7 +19,12 @@ path = "src/lib.rs"
 # a Python extension module must not install a second global allocator
 # into the interpreter process (it segfaults), so the module uses the
 # system allocator.
-infino = { path = "..", default-features = false, features = ["remote"] }
+# `test-helpers` (dep-free; a cfg gate) exposes the test-and-bench search
+# overrides — `VectorSearchOptions` and `vector_search_with_options` — that the
+# EXPERIMENTAL benchmark serve mode uses to sweep the hnsw beam per query. It is
+# excluded from the `cargo-public-api` snapshot, so the engine's public API
+# stays self-calibrated with no tuning knobs.
+infino = { path = "..", default-features = false, features = ["remote", "test-helpers"] }
 # Arrow is the interchange. The `pyarrow` feature pulls `arrow-pyarrow`
 # (pyo3 0.28), so pyo3 here is pinned to the SAME version to share types.
 arrow = { version = "58", features = ["pyarrow"] }

--- a/infino-python/src/bench_serve.rs
+++ b/infino-python/src/bench_serve.rs
@@ -29,7 +29,9 @@ use arrow_array::{
     Array, Decimal128Array, FixedSizeListArray, Float32Array, Int64Array, RecordBatch,
 };
 use arrow_schema::{DataType, Field, Schema};
-use infino::{ConnectOptions, Connection, IndexSpec, Metric, Supertable, connect_with};
+use infino::{
+    ConnectOptions, Connection, IndexSpec, Metric, Supertable, VectorSearchOptions, connect_with,
+};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
@@ -205,7 +207,8 @@ pub fn bench_serve_tcp(
 //   CREATE  (1): u32 dim, u32 metric_len, metric_len bytes  -> u8 status
 //   APPEND  (2): u32 nrows, u32 dim, nrows*(i64 id + dim*f32) -> u8 status, u64 count
 //   OPTIMIZE(3): (none)                                       -> u8 status
-//   SEARCH  (4): u32 k, u32 dim, dim*f32                      -> u32 n, n*i64 dataset ids
+//   SEARCH  (4): u32 k, u32 ef, u32 dim, dim*f32              -> u32 n, n*i64 dataset ids
+//     (ef=0 serves the stamped k->ef curve; ef>0 walks this query at that beam)
 //   DROP    (5): (none)                                       -> u8 status
 // status: 0 = ok, 1 = error (followed by u32 msg_len, msg bytes).
 //
@@ -418,6 +421,10 @@ fn do_optimize(stream: &mut TcpStream, srv: &ServeState) -> std::io::Result<()> 
 
 fn do_search(stream: &mut TcpStream, srv: &ServeState) -> std::io::Result<()> {
     let k = read_u32(stream)? as usize;
+    // Per-query hnsw beam. 0 = serve at the graph's stamped k->ef curve; a
+    // positive value walks this query at that fixed beam, so a client can sweep
+    // ef against one resident graph without a rebuild or restart.
+    let ef = read_u32(stream)? as usize;
     let dim = read_u32(stream)? as usize;
     // Bound dim before allocating the query buffer; a garbage header is a
     // protocol error and the stream is already desynced, so close.
@@ -449,7 +456,10 @@ fn do_search(stream: &mut TcpStream, srv: &ServeState) -> std::io::Result<()> {
             );
             return Err(std::io::Error::other("dim mismatch"));
         }
-        let batches = match table.vector_search(&srv.col, &query, k, None, None) {
+        // Pass the per-query beam via the test-and-bench options path (off the
+        // public API); ef=0 leaves the engine's stamped curve in charge.
+        let opts = VectorSearchOptions::new().with_ef(ef);
+        let batches = match table.vector_search_with_options(&srv.col, &query, k, opts, None, None) {
             Ok(b) => b,
             Err(e) => {
                 // A transient engine error fails this one query rather than

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -1850,6 +1850,12 @@ pub struct VectorSearchOptions {
     /// IVF probe override. `None` → engine default for the query path.
     pub nprobe: Option<usize>,
     rerank_mult: Option<usize>,
+    /// `hnsw_ivf` serve-time beam override. `None` → the stamped k→ef curve
+    /// (or the `vector.hnsw_ef_search` config), exactly as today; `Some(ef)`
+    /// with `ef > 0` walks this query at that fixed beam. A test-and-bench
+    /// instrument (recall/latency sweeps of an already-built graph); ignored
+    /// under any non-graph serving path.
+    ef: Option<usize>,
 }
 
 impl VectorSearchOptions {
@@ -1884,6 +1890,19 @@ impl VectorSearchOptions {
     /// The configured rerank multiplier, if one was set.
     pub fn rerank_mult(&self) -> Option<usize> {
         self.rerank_mult
+    }
+
+    /// Set the `hnsw_ivf` serve-time beam (`ef`) for this query. Higher improves
+    /// recall at the cost of more work; overrides the stamped k→ef curve for an
+    /// already-built graph without a rebuild.
+    pub fn with_ef(mut self, ef: usize) -> Self {
+        self.ef = Some(ef);
+        self
+    }
+
+    /// The configured serve-time `ef` beam, if one was set.
+    pub(crate) fn ef(&self) -> Option<usize> {
+        self.ef
     }
 
     /// Resolve `(nprobe, rerank_mult)` for this query path.

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -4046,6 +4046,7 @@ impl SupertableReader {
         column: &str,
         query: &[f32],
         k: usize,
+        ef_opt: Option<usize>,
     ) -> Result<IndexOutcome<Vec<SuperfileHit>>, QueryError> {
         if k == 0 {
             return Ok(IndexOutcome::Ready(Vec::new()));
@@ -4103,8 +4104,12 @@ impl SupertableReader {
         // pre-curve bundle returns its single stamped `ef` for every `k`. A
         // non-zero `hnsw_ef_search` config overrides the curve with a fixed
         // serve-time beam — a rebuild-free knob for sweeping an already-built
-        // graph's recall/latency curve.
-        let ef_override = config::global().vector.hnsw_ef_search;
+        // graph's recall/latency curve. A per-query `ef_opt` (from the
+        // test-and-bench `VectorSearchOptions::with_ef`) takes precedence over
+        // the config so a sweep can vary the beam per request without a restart.
+        let ef_override = ef_opt
+            .filter(|&e| e > 0)
+            .unwrap_or_else(|| config::global().vector.hnsw_ef_search);
         let ef = if ef_override > 0 {
             ef_override
         } else {
@@ -4815,7 +4820,7 @@ impl SupertableReader {
             && hidden_vector_index
             && vcfg.search_mode == config::VectorSearchMode::HnswIvf
             && let Some(hits) = self
-                .hnsw_search(column, query, k)
+                .hnsw_search(column, query, k, options.ef())
                 .await?
                 .or_warn("hnsw search")
         {
@@ -11800,7 +11805,7 @@ mod tests {
         );
         assert!(
             matches!(
-                block_on(bare.hnsw_search("emb", &query, 5)).expect("hnsw search"),
+                block_on(bare.hnsw_search("emb", &query, 5, None)).expect("hnsw search"),
                 IndexOutcome::Unavailable(IndexUnavailable::NotHydrated)
             ),
             "the graph arm must decline an unpublished generation the same way"
@@ -11862,7 +11867,7 @@ mod tests {
         }
         // The mirror of `flat_search_declines_a_generation_that_published_a
         // _graph`: neither arm may answer from the other's index.
-        match block_on(served.hnsw_search("emb", &query, 5)).expect("hnsw search") {
+        match block_on(served.hnsw_search("emb", &query, 5, None)).expect("hnsw search") {
             IndexOutcome::Unavailable(IndexUnavailable::WrongKind { wanted }) => {
                 assert_eq!(wanted, "hnsw");
             }
@@ -11968,7 +11973,7 @@ mod tests {
         let served = hidden.reader().expect("hidden reader after publish");
 
         let hits = expect_ready(
-            block_on(served.hnsw_search("emb", &query, 5)).expect("hnsw search"),
+            block_on(served.hnsw_search("emb", &query, 5, None)).expect("hnsw search"),
             "the published graph",
         );
         assert!(!hits.is_empty(), "the graph must answer its own generation");
@@ -11985,19 +11990,19 @@ mod tests {
 
         assert!(
             matches!(
-                block_on(served.hnsw_search("emb", &query, 0)).expect("k=0"),
+                block_on(served.hnsw_search("emb", &query, 0, None)).expect("k=0"),
                 IndexOutcome::Ready(ref hits) if hits.is_empty()
             ),
             "k=0 is an empty answer, not a decline"
         );
-        match block_on(served.hnsw_search("sibling", &query, 5)).expect("column mismatch") {
+        match block_on(served.hnsw_search("sibling", &query, 5, None)).expect("column mismatch") {
             IndexOutcome::Unavailable(IndexUnavailable::ColumnMismatch { queried, index }) => {
                 assert_eq!(queried, "sibling");
                 assert_eq!(index, "emb");
             }
             other => panic!("expected ColumnMismatch, got {}", describe(other)),
         }
-        match block_on(served.hnsw_search("emb", &query[..GRAPH_FIXTURE_DIM - 1], 5))
+        match block_on(served.hnsw_search("emb", &query[..GRAPH_FIXTURE_DIM - 1], 5, None))
             .expect("dim mismatch")
         {
             IndexOutcome::Unavailable(IndexUnavailable::DimMismatch { queried, index }) => {


### PR DESCRIPTION
## What

Add an optional **per-query hnsw serve beam** (`ef`) to the test-and-bench search
path, so a benchmark can sweep the recall/latency curve of one already-built
graph without a rebuild or restart.

## Why

The `hnsw_ivf` serve beam comes from the stamped k→ef curve, or the
`hnsw_ef_search` config read once per process (`vector.rs`). A recall/latency
sweep therefore had to fix the beam for the server's whole lifetime — there was
no way to vary it per query. Standard vector benchmarks sweep the beam per
request against a single resident index, so they couldn't drive this engine that
way; the only alternative was rebuilding or restarting per point.

## How

- `VectorSearchOptions` gains `with_ef(ef)` (next to `nprobe`/`rerank_mult`),
  threaded to the graph walk: `None` keeps the stamped curve exactly as today, a
  positive value walks that query at the fixed beam.
- **Off the public API surface.** `VectorSearchOptions` and
  `vector_search_with_options` are gated behind `test-helpers` and excluded from
  the `cargo-public-api` snapshot, so the engine's public `vector_search` stays
  fully self-calibrated with no tuning knob — the beam override is a
  test-and-bench instrument, consistent with `nprobe`/`rerank_mult`.
- The benchmark serve mode carries the beam in its `SEARCH` frame and forwards
  it, so a client sweeps ef across one built graph over the wire.

## Validation

End-to-end sweep against the build+serve mode (glove-25-angular, 1.18M, cosine),
one build then the beam swept over the wire per query — no rebuild or restart
between points — a clean monotone recall/latency/throughput curve:

| ef | recall@10 | p95 | RPS (parallel=8) |
|---|---|---|---|
| 128 | 0.9468 | 0.60ms | 16788 |
| 256 | 0.9850 | 0.92ms | 11675 |
| 512 | 0.9967 | 1.50ms | 7548 |
| 1024 | 0.9993 | 2.34ms | 5017 |
| 2048 | 0.9997 | 3.68ms | 2834 |

Public-API path (`ef = None`) is unchanged; default-feature build carries no new
surface.
