### PR TITLE
fts: repair the tracing attributes the options change broke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ check:
 	# The `remote` transport is off in the shipped library, so the line above
 	# never lints it. Lint it explicitly (alongside `test-helpers`) or it rots.
 	cargo clippy --all-targets --features test-helpers,remote -- -D warnings
+	# `detailed-tracing` and `metering` are off by default, so neither line
+	# above compiles the `tracing::instrument` attributes they gate. Those
+	# attributes name a function's parameters, so a signature change breaks
+	# them while every default build stays green — and the break only
+	# surfaces in a downstream build that turns the feature on. Check them
+	# here instead of finding out there.
+	cargo check --features metering,detailed-tracing
 	$(MAKE) api-parity
 	$(MAKE) version-sync
 	$(MAKE) bench-gate

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -411,10 +411,6 @@ impl SupertableReader {
     /// sync→async bridge.
     ///
     /// [`AsciiLowerTokenizer`]: crate::superfile::fts::tokenize::AsciiLowerTokenizer
-    #[cfg_attr(
-        feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
-    )]
     /// Reject an out-of-range query-time override before the fan-out
     /// starts. A declared pair is validated at `create_table`; this is
     /// the same check for the per-search form, so a caller sees the
@@ -430,6 +426,10 @@ impl SupertableReader {
         }
     }
 
+    #[cfg_attr(
+        feature = "detailed-tracing",
+        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?opts.mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
+    )]
     pub(crate) async fn bm25_search_async(
         &self,
         column: &str,
@@ -2109,7 +2109,7 @@ impl Supertable {
     /// ```
     #[cfg_attr(
         feature = "detailed-tracing",
-        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
+        tracing::instrument(skip_all, fields(column = column, k = k, mode = ?opts.mode, role = self.role().as_str(), origin = OpOrigin::Query.as_str()))
     )]
     pub fn bm25_search(
         &self,


### PR DESCRIPTION
`cargo check --features detailed-tracing` fails on `main`. The feature gates `tracing::instrument` attributes that name a function's parameters by hand, and the BM25 options change moved two of them out from under their attribute. Bisected: the commit before it builds clean, `2d572feb` produces five errors.

## The two

**The attribute on `bm25_search_async` was re-pointed at a new function.** A validator inserted between the attribute and the function it belonged to now wears it, and that function is an associated `fn` with no `self`, `column`, `k` or `mode` — four of the five errors. The build break is the *lesser* harm here: `bm25_search_async` silently lost its instrumentation, so under `detailed-tracing` a span for the async BM25 kernel would simply have stopped being emitted. Nothing would have failed; the span would just be gone.

**The public wrapper's attribute still names `mode`** after the parameter became `opts`. The `debug!` on the very next line was updated to `?opts.mode`; the attribute above it was not.

The `count` / `token_match` attributes still reference `mode` correctly — those signatures still take one, and are left alone.

## Why it reached main green

`detailed-tracing` is declared in `Cargo.toml` and built by **nothing** in `Makefile` or `.github/workflows/`. Every default build, and both existing clippy lines, skip these attributes entirely. It surfaces only in a downstream build that turns the feature on — which is how it was found: the platform worker builds the engine with `metering,detailed-tracing`, and cannot compile against current `main`.

`make check` now runs `cargo check --features metering,detailed-tracing`. Verified it actually catches this: with the source fix reverted the guard reports six errors; with the fix, zero.

## Verification

- `cargo check` (default) — clean
- `cargo check --features detailed-tracing` — clean
- `cargo check --features metering,detailed-tracing` — clean
- guard reverted-source check — 6 errors, as intended

Worth noting the attributes name parameters as bare identifiers, so any future signature change breaks them the same way. The new guard turns that from a downstream discovery into a local one, but the underlying fragility stays.