### PR TITLE
release: python 0.7.2

### DIFF
--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "infino-python"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/infino-python/Cargo.toml
+++ b/infino-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infino-python"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Release PR stamped by the `Release prep` workflow (scope: `python`).

| Package | Version |
| ------- | ------- |
| crate   | 0.7.1  |
| node    | 0.7.1   |
| python  | 0.7.2 |

On merge, `Release on merge` tags and publishes whichever of these changed — see docs/versioning.md.