### PR TITLE
fts: per-column stopwords and stemming on the analysis chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,7 @@ dependencies = [
  "rayon",
  "reqwest",
  "roaring",
+ "rust-stemmers",
  "rustc-hash",
  "rustix",
  "serde",
@@ -3662,6 +3663,16 @@ checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,13 @@ static_assertions = "1"
 # Tokenization: UAX#29 word segmentation for the Unicode-aware standard
 # analyzer (keeps non-ASCII text), alongside the built-in ASCII tokenizer.
 unicode-segmentation = "1"
+# Snowball stemmers for the per-column analysis chain's `stem=` filter.
+# The de-facto Rust snowball port, dual MIT / BSD-3-Clause, and its only
+# transitive dependencies are serde + serde_derive, already direct
+# dependencies here — so the graph grows by one node, not a subtree.
+# Vendoring the stemmer tables instead would put us on the hook for
+# correctness fixes to algorithms we do not own.
+rust-stemmers = "1.2"
 
 # Numerics
 rand = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,18 @@ unicode-segmentation = "1"
 # dependencies here — so the graph grows by one node, not a subtree.
 # Vendoring the stemmer tables instead would put us on the hook for
 # correctness fixes to algorithms we do not own.
+#
+# The range is a normal caret on purpose, NOT pinned with `=`. What has
+# to be guarded is the crate's *output*, not its version number: a
+# column persists the name `stem=english`, so the stemmer's rules are
+# on-disk format state, and a bump that changes one would leave columns
+# holding the old stems while queries produced new ones — silently.
+# Pinning the version would only defer that to whenever someone bumps
+# it, and would fight dependency resolution for every downstream
+# consumer meanwhile. `english_stemmer_output_is_frozen` in
+# superfile/fts/analysis.rs pins the observable behaviour instead, so a
+# bump that changes any stem fails CI and becomes a deliberate
+# decision — reject it, or ship `stem=english2` beside the old name.
 rust-stemmers = "1.2"
 
 # Numerics

--- a/benches/utils/executors.rs
+++ b/benches/utils/executors.rs
@@ -288,7 +288,7 @@ pub mod fts {
             SuperfileReader,
             fts::{
                 reader::BoolMode as InfinoBoolMode,
-                tokenize::{AsciiLowerTokenizer, Tokenizer},
+                tokenize::{AsciiLowerTokenizer, Phrase, Tokenizer},
             },
         },
         supertable::SupertableReader,
@@ -749,10 +749,11 @@ pub mod fts {
                 };
                 if !phrases.is_empty() {
                     let refs: Vec<&str> = terms.iter().map(|t| &**t).collect();
-                    let owned: Vec<Vec<String>> = phrases
-                        .into_iter()
-                        .map(|p| p.into_iter().map(|t| t.into_owned()).collect())
-                        .collect();
+                    // `Phrase::map` carries each term's offset across, so
+                    // a bench query on a stopworded column asks for the
+                    // spacing the parser derived rather than adjacency.
+                    let owned: Vec<Phrase<String>> =
+                        phrases.iter().map(|p| p.map(|t| t.to_string())).collect();
                     return self
                         .atoms_match_count(column, &refs, &owned, eff_mode, &[], &[])
                         .await

--- a/infino-node/Cargo.lock
+++ b/infino-node/Cargo.lock
@@ -2155,6 +2155,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "roaring",
+ "rust-stemmers",
  "rustc-hash",
  "rustix",
  "serde",
@@ -3222,6 +3223,16 @@ checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/infino-node/__test__/smoke.test.mjs
+++ b/infino-node/__test__/smoke.test.mjs
@@ -366,3 +366,46 @@ test("connectionMemoryBudgetBytes: 0 measures without enforcing", () => {
   docs.append([{ title: "the quick brown fox" }]);
   assert.equal(docs.bm25Search("title", "fox", 10).length, 1);
 });
+
+// The analysis filters resolve at `createTable`, not at `fts()` — `fts`
+// only records the strings. So this is where an unknown name surfaces,
+// and it had no coverage in either binding.
+//
+// The names are matched exactly, matching the engine's own resolver and
+// the python binding: an earlier version of this binding case-folded the
+// argument, so `stopwords: "English"` worked here and threw there for
+// the same call.
+test("analysis filter names resolve at createTable, exactly", () => {
+  const db = connect("memory://");
+
+  // The accepted spelling works end to end: stemming folds the
+  // inflection and the stopword never reaches the index.
+  const t = db.createTable(
+    "chained",
+    titleSchema(),
+    new IndexSpec().fts("title", { stopwords: "english", stemmer: "english", positions: true }),
+  );
+  t.append([{ title: "the quick brown foxes are running" }]);
+  assert.equal(t.bm25Search("title", "run", 10).length, 1);
+  assert.equal(t.bm25Search("title", "the", 10).length, 0);
+  assert.equal(t.bm25Search("title", '"brown foxes"', 10).length, 1);
+
+  // Wrong case is not accepted, and the error names what was passed.
+  for (const [opts, needle] of [
+    [{ stopwords: "English" }, "English"],
+    [{ stemmer: "ENGLISH" }, "ENGLISH"],
+    [{ stopwords: "german" }, "german"],
+  ]) {
+    let err;
+    try {
+      db.createTable(`bad-${needle}`, titleSchema(), new IndexSpec().fts("title", opts));
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err, `expected ${JSON.stringify(opts)} to throw`);
+    assert.ok(
+      String(err.message).includes(needle),
+      `error must name the value passed, got: ${err.message}`,
+    );
+  }
+});

--- a/infino-node/package-lock.json
+++ b/infino-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@infino-ai/infino",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@infino-ai/infino",
-      "version": "0.1.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17"
@@ -19,12 +19,12 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "infx-darwin-arm64": "0.1.0",
-        "infx-darwin-x64": "0.1.0",
-        "infx-linux-arm64-gnu": "0.1.0",
-        "infx-linux-arm64-musl": "0.1.0",
-        "infx-linux-x64-gnu": "0.1.0",
-        "infx-linux-x64-musl": "0.1.0"
+        "infx-darwin-arm64": "0.8.0",
+        "infx-darwin-x64": "0.8.0",
+        "infx-linux-arm64-gnu": "0.8.0",
+        "infx-linux-arm64-musl": "0.8.0",
+        "infx-linux-x64-gnu": "0.8.0",
+        "infx-linux-x64-musl": "0.8.0"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/infx-darwin-arm64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/infx-darwin-arm64/-/infx-darwin-arm64-0.1.0.tgz",
-      "integrity": "sha512-WtZNvW9CwrcYsw6ytXXDgbWmQdlsKMj/P0RGnfYxZ8+iqlVc4qBHvI1XCi0INlGSaTcD6t5ynwpoQwcEeAD2lg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/infx-darwin-arm64/-/infx-darwin-arm64-0.8.0.tgz",
+      "integrity": "sha512-XJ4VTJgWKD6LjNMq/blTu6ltcZIH+vh6hTxjaeZgq6A9HYI3uXcxoTSy3d969t1vGqOKnNWIfTzKxTnoCL4iBw==",
       "cpu": [
         "arm64"
       ],
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/infx-darwin-x64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/infx-darwin-x64/-/infx-darwin-x64-0.1.0.tgz",
-      "integrity": "sha512-XNqD8E8vs3Rno8VbkCqZaXaxnUzd6CW/0xrXYOOXBq8Tupqm9JjImBXHmuSWtX86RLBZDfzLhzhHnGs3EObwdw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/infx-darwin-x64/-/infx-darwin-x64-0.8.0.tgz",
+      "integrity": "sha512-Ehd8RoAWxUj29xN9O/hZsQ/C9aGL2sNdOXwtPvYYJM1YA4y+cbiHqVi+E8gfQ0+LEC++HZWF0v8fZqiD7u+EZw==",
       "cpu": [
         "x64"
       ],
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/infx-linux-arm64-gnu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/infx-linux-arm64-gnu/-/infx-linux-arm64-gnu-0.1.0.tgz",
-      "integrity": "sha512-KsQG7LY3PAbSimdrFikDenccnu+NLECV6Z9uCvKkdutoK5ExVeh8T/DfKqil1jbb7upXKZc2DF7e3iAfL6YexA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/infx-linux-arm64-gnu/-/infx-linux-arm64-gnu-0.8.0.tgz",
+      "integrity": "sha512-Km2lYX18DJAypm9t9nkI3kSw85w06AYHDbA/udSnXjOOGB3ZZostGm1ROysTj5oUh3BCkz3G2bWFC5FfG2b+tw==",
       "cpu": [
         "arm64"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/infx-linux-arm64-musl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/infx-linux-arm64-musl/-/infx-linux-arm64-musl-0.1.0.tgz",
-      "integrity": "sha512-Ptbb4eXBC8v1AjhgRZAk4aeHehZVJyMiW45nViCAUPLGeQlwB0YjZS1QVKmhuH6ajsMiIzhfTwlvnhPllKRzyw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/infx-linux-arm64-musl/-/infx-linux-arm64-musl-0.8.0.tgz",
+      "integrity": "sha512-/Amm6cEHmk1Z1TjEVHJDgxpTy5xzLjhBf2mD+JRDwH6KVdq1JtnfuKEbdELKoSSPbPu0PWXoEhhN615rzQBvmQ==",
       "cpu": [
         "arm64"
       ],
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/infx-linux-x64-gnu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/infx-linux-x64-gnu/-/infx-linux-x64-gnu-0.1.0.tgz",
-      "integrity": "sha512-fOmXgl6zAJy50hlyATeE7fx2OhoHAoWEPSUQC3Nu3Wwd6jO7kX8BRPzW7Ajmx2iL2wEhg/gufiFMJbBhxxoN6g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/infx-linux-x64-gnu/-/infx-linux-x64-gnu-0.8.0.tgz",
+      "integrity": "sha512-NFiTEBbz9Zd09LQ8aNYhuzUXR/ridE0/YF3vKfOD9v0fKX2nzIaxWPzIwpBFvgnTx9pIhH+sguhZojYL+Su/TQ==",
       "cpu": [
         "x64"
       ],
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/infx-linux-x64-musl": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/infx-linux-x64-musl/-/infx-linux-x64-musl-0.1.0.tgz",
-      "integrity": "sha512-ydLnmBMoUHZJLw9w0NjDZhbMpPgdsCepx7OZyEMylTSLj7XO+ihv1DLLSXA9kuqiAEVz/BvT5ReOFv88S5F1tQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/infx-linux-x64-musl/-/infx-linux-x64-musl-0.8.0.tgz",
+      "integrity": "sha512-mFOMr/94ZIkMaGeVumJY68BeMHC5LJ6PUyafi29RsH7cFqimPWtIgxzksK7DZVCpAh2++mJPZ8npElYH2PejTQ==",
       "cpu": [
         "x64"
       ],

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -48,7 +48,8 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::Expr;
 use infino::{
     Bm25SearchOptions, Bm25Stats, BoolMode, ColdFetchMode, CompactionSettings, GcError,
-    InfinoError, Metric, OptimizeError, OptimizeOptions as InfinoOptimizeOptions,
+    InfinoError, Metric, OptimizeError, OptimizeOptions as InfinoOptimizeOptions, Stemmer,
+    Stopwords,
 };
 
 // ---------------------------------------------------------------------------
@@ -129,6 +130,29 @@ fn metric_from_str(s: &str) -> Result<Metric> {
         other => Err(Error::new(
             Status::InvalidArg,
             format!("unknown metric {other:?}; use 'cosine', 'l2sq', or 'negdot'"),
+        )),
+    }
+}
+
+/// Parse a stopword-set name. Named built-in sets only; the error
+/// names the valid set rather than leaving the caller to guess.
+fn stopwords_from_name(s: &str) -> Result<Stopwords> {
+    match s.to_ascii_lowercase().as_str() {
+        "english" => Ok(Stopwords::English),
+        other => Err(Error::new(
+            Status::InvalidArg,
+            format!("unknown stopwords {other:?}; use 'english'"),
+        )),
+    }
+}
+
+/// Parse a stemmer name. Same shape as [`stopwords_from_name`].
+fn stemmer_from_name(s: &str) -> Result<Stemmer> {
+    match s.to_ascii_lowercase().as_str() {
+        "english" => Ok(Stemmer::English),
+        other => Err(Error::new(
+            Status::InvalidArg,
+            format!("unknown stemmer {other:?}; use 'english'"),
         )),
     }
 }
@@ -519,10 +543,19 @@ pub struct VectorFilter {
 #[napi]
 #[derive(Clone, Default)]
 pub struct IndexSpec {
-    /// `(column, analyzer, stored)`; `analyzer` `None` means the default.
-    fts: Vec<(String, Option<String>, bool, Option<f64>, Option<f64>)>,
+    /// One declared FTS column, as its options arrived.
+    fts: Vec<FtsDecl>,
     /// `(column, dim, metric)`.
     vectors: Vec<(String, u32, String)>,
+}
+
+/// One declared FTS column: the column name plus the options given for
+/// it, with the `Option`s still meaning "not given" so each falls back
+/// to the engine's own default rather than one restated here.
+#[derive(Clone)]
+struct FtsDecl {
+    column: String,
+    options: FtsOptions,
 }
 
 /// Per-column FTS options for `IndexSpec.fts`.
@@ -534,6 +567,33 @@ pub struct FtsOptions {
     /// split + lowercase, non-ASCII dropped). It is recorded with the
     /// table and cannot be changed afterwards.
     pub analyzer: Option<String>,
+    /// Remove this column's stopwords — the very common words whose
+    /// presence says almost nothing about what a document is about.
+    /// `"english"` is the only set; omit for none (the default).
+    ///
+    /// Applies to both sides: the words leave the index and they leave
+    /// a query, and each one removed leaves a hole in the token
+    /// positions, so an exact phrase still knows the words it matched
+    /// were not adjacent in the text. The trade is that once a word is
+    /// not indexed, no query can find it — declare it on prose, not on
+    /// short identifiers. Recorded with the table and unchangeable
+    /// afterwards, since it decides what is in the index.
+    pub stopwords: Option<String>,
+    /// Reduce this column's words to their stems, so a search for one
+    /// inflection finds the others (`running`, `runs`, `run`).
+    /// `"english"` is the only stemmer; omit for none (the default).
+    ///
+    /// Applies to both sides, like `stopwords`. The trade is precision:
+    /// stemming conflates words a reader would not, and there is no way
+    /// to ask for an unstemmed form on a stemmed column. Recorded with
+    /// the table and unchangeable afterwards.
+    pub stemmer: Option<String>,
+    /// Record token positions, which is what exact phrase queries
+    /// (`'"climate policy"'`) need. Default false: positions roughly
+    /// double the column's index footprint, so they are a per-column
+    /// opt-in. A column without them answers a phrase query with an
+    /// error naming the column, never a silent bag-of-words fallback.
+    pub positions: Option<bool>,
     /// Keep the raw text in the table (default true). `false` makes the
     /// column index-only: searchable, but the text is never stored, so
     /// it cannot be selected, projected, or filtered on (append/update
@@ -556,19 +616,16 @@ impl IndexSpec {
         Self::default()
     }
 
-    /// Mark `column` (a UTF-8 string column) as full-text indexed,
-    /// with optional per-column `options` (analyzer, stored, k1/b).
+    /// Mark `column` (a UTF-8 string column) as full-text indexed, with
+    /// optional per-column `options` (analyzer, stopwords, stemmer,
+    /// positions, stored, k1/b).
     #[napi]
     pub fn fts(&self, column: String, options: Option<FtsOptions>) -> Self {
         let mut next = self.clone();
-        let opts = options.unwrap_or_default();
-        next.fts.push((
+        next.fts.push(FtsDecl {
             column,
-            opts.analyzer,
-            opts.stored.unwrap_or(true),
-            opts.k1,
-            opts.b,
-        ));
+            options: options.unwrap_or_default(),
+        });
         next
     }
 
@@ -587,10 +644,27 @@ impl IndexSpec {
     /// Lower to the core `IndexSpec` builder.
     fn to_rust(&self) -> Result<infino::IndexSpec> {
         let mut spec = infino::IndexSpec::new();
-        for (column, analyzer, stored, k1, b) in &self.fts {
-            let mut field = infino::FtsField::new(column.clone()).stored(*stored);
+        for FtsDecl { column, options } in &self.fts {
+            let FtsOptions {
+                analyzer,
+                stopwords,
+                stemmer,
+                positions,
+                stored,
+                k1,
+                b,
+            } = options;
+            let mut field = infino::FtsField::new(column.clone())
+                .positions(positions.unwrap_or(false))
+                .stored(stored.unwrap_or(true));
             if let Some(a) = analyzer {
                 field = field.analyzer(a.clone());
+            }
+            if let Some(name) = stopwords {
+                field = field.stopwords(stopwords_from_name(name)?);
+            }
+            if let Some(name) = stemmer {
+                field = field.stemmer(stemmer_from_name(name)?);
             }
             // Both or neither: the two parameters interact through the
             // length norm, so half-overriding is a footgun.

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -577,7 +577,10 @@ pub struct FtsOptions {
     /// were not adjacent in the text. The trade is that once a word is
     /// not indexed, no query can find it — declare it on prose, not on
     /// short identifiers. Recorded with the table and unchangeable
-    /// afterwards, since it decides what is in the index.
+    /// afterwards, since it decides what is in the index: the words it
+    /// removed were never written, so changing it means re-ingesting
+    /// from the source text. With `stored: false` that text is never
+    /// kept, so the combination is permanent.
     pub stopwords: Option<String>,
     /// Reduce this column's words to their stems, so a search for one
     /// inflection finds the others (`running`, `runs`, `run`).
@@ -586,7 +589,11 @@ pub struct FtsOptions {
     /// Applies to both sides, like `stopwords`. The trade is precision:
     /// stemming conflates words a reader would not, and there is no way
     /// to ask for an unstemmed form on a stemmed column. Recorded with
-    /// the table and unchangeable afterwards.
+    /// the table and unchangeable afterwards: a stem is not invertible
+    /// — the index holds `run`, never the `running` it came from — so
+    /// changing it means re-ingesting from the source text, and with
+    /// `stored: false` that text is never kept, making the combination
+    /// permanent.
     pub stemmer: Option<String>,
     /// Record token positions, which is what exact phrase queries
     /// (`'"climate policy"'`) need. Default false: positions roughly

--- a/infino-node/src/lib.rs
+++ b/infino-node/src/lib.rs
@@ -134,27 +134,41 @@ fn metric_from_str(s: &str) -> Result<Metric> {
     }
 }
 
-/// Parse a stopword-set name. Named built-in sets only; the error
-/// names the valid set rather than leaving the caller to guess.
+/// Parse a stopword-set name. Named built-in sets only; the error names
+/// the valid set rather than leaving the caller to guess.
+///
+/// **Exact match, deliberately not case-folded.** These names are format
+/// vocabulary: the engine's own resolver is exact, and a column persists
+/// the name it was given. Accepting `"English"` here would mean this
+/// binding has a wider vocabulary than the format and must remember to
+/// normalize before persisting — a coupling that is one forgotten call
+/// away from writing a file the reader refuses. It would also diverge
+/// from the python binding, so the same call would work in one and throw
+/// in the other.
+///
+/// The asymmetry decides it: accepting more spellings later is additive,
+/// while tightening later breaks every caller who relied on the loose
+/// one. (The older `metric` argument *is* case-folded, which is an
+/// inconsistency in the other direction — worth reconciling, but not by
+/// widening a new surface to match an old one.)
 fn stopwords_from_name(s: &str) -> Result<Stopwords> {
-    match s.to_ascii_lowercase().as_str() {
-        "english" => Ok(Stopwords::English),
-        other => Err(Error::new(
+    Stopwords::from_name(s).ok_or_else(|| {
+        Error::new(
             Status::InvalidArg,
-            format!("unknown stopwords {other:?}; use 'english'"),
-        )),
-    }
+            format!("unknown stopwords {s:?} (valid: \"english\")"),
+        )
+    })
 }
 
-/// Parse a stemmer name. Same shape as [`stopwords_from_name`].
+/// Parse a stemmer name. Same exact-match rule as
+/// [`stopwords_from_name`], and for the same reasons.
 fn stemmer_from_name(s: &str) -> Result<Stemmer> {
-    match s.to_ascii_lowercase().as_str() {
-        "english" => Ok(Stemmer::English),
-        other => Err(Error::new(
+    Stemmer::from_name(s).ok_or_else(|| {
+        Error::new(
             Status::InvalidArg,
-            format!("unknown stemmer {other:?}; use 'english'"),
-        )),
-    }
+            format!("unknown stemmer {s:?} (valid: \"english\")"),
+        )
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/infino-python/Cargo.lock
+++ b/infino-python/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "roaring",
+ "rust-stemmers",
  "rustc-hash",
  "rustix",
  "serde",
@@ -3273,6 +3274,16 @@ checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -83,6 +83,13 @@ class Connection:
 
 class IndexSpec:
     def __init__(self) -> None: ...
+    # `stopwords="english"` drops the very common words from both the index
+    # and queries; `stemmer="english"` folds inflections onto one term, so a
+    # search for one finds the others. Both are off by default and recorded
+    # with the table — they decide what is in the index.
+    # `positions=True` records token positions, which exact phrase queries
+    # ('"climate policy"') need; off by default because positions roughly
+    # double the column's index footprint.
     # `stored=False` declares an index-only column: searchable, but the raw
     # text is never kept, so it cannot be selected, projected, or filtered on.
     # `k1` / `b` are the column's BM25 similarity parameters (defaults 1.2 and
@@ -91,6 +98,9 @@ class IndexSpec:
         self,
         column: str,
         analyzer: str | None = None,
+        stopwords: str | None = None,
+        stemmer: str | None = None,
+        positions: bool = False,
         stored: bool = True,
         k1: float | None = None,
         b: float | None = None,

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -86,7 +86,10 @@ class IndexSpec:
     # `stopwords="english"` drops the very common words from both the index
     # and queries; `stemmer="english"` folds inflections onto one term, so a
     # search for one finds the others. Both are off by default and recorded
-    # with the table — they decide what is in the index.
+    # with the table — they decide what is in the index, and there is no
+    # migration: changing either means re-ingesting from the source text.
+    # With `stored=False` that text is never kept, so the combination is
+    # permanent.
     # `positions=True` records token positions, which exact phrase queries
     # ('"climate policy"') need; off by default because positions roughly
     # double the column's index footprint.

--- a/infino-python/python/infino/_infino.pyi
+++ b/infino-python/python/infino/_infino.pyi
@@ -97,16 +97,19 @@ class IndexSpec:
     # text is never kept, so it cannot be selected, projected, or filtered on.
     # `k1` / `b` are the column's BM25 similarity parameters (defaults 1.2 and
     # 0.75); pass both or neither. The stored score bounds are built with them.
+    # The three analysis options are keyword-only and come after `b`, so
+    # existing positional calls keep their meaning.
     def fts(
         self,
         column: str,
         analyzer: str | None = None,
-        stopwords: str | None = None,
-        stemmer: str | None = None,
-        positions: bool = False,
         stored: bool = True,
         k1: float | None = None,
         b: float | None = None,
+        *,
+        stopwords: str | None = None,
+        stemmer: str | None = None,
+        positions: bool = False,
     ) -> IndexSpec: ...
     # `dim` must be in [16, 4096]; out-of-range raises at `create_table`.
     def vector(self, column: str, dim: int, metric: Metric) -> IndexSpec: ...

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -230,26 +230,25 @@ struct FtsDecl {
     b: Option<f32>,
 }
 
-/// Resolve the `stopwords=` argument. Named built-in sets only; the
-/// error names the valid set rather than leaving the caller to guess.
+/// Resolve the `stopwords=` argument through the engine's own resolver,
+/// so this binding's accepted spellings are exactly the format's — see
+/// [`Stopwords::from_name`], which is exact and not case-folded.
 fn stopwords_from_name(name: &str) -> PyResult<Stopwords> {
-    match name {
-        "english" => Ok(Stopwords::English),
-        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "IndexSpec.fts: unknown stopwords {other:?} (valid: \"english\")"
-        ))),
-    }
+    Stopwords::from_name(name).ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "IndexSpec.fts: unknown stopwords {name:?} (valid: \"english\")"
+        ))
+    })
 }
 
-/// Resolve the `stemmer=` argument. Same shape as
+/// Resolve the `stemmer=` argument; same rule as
 /// [`stopwords_from_name`].
 fn stemmer_from_name(name: &str) -> PyResult<Stemmer> {
-    match name {
-        "english" => Ok(Stemmer::English),
-        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "IndexSpec.fts: unknown stemmer {other:?} (valid: \"english\")"
-        ))),
-    }
+    Stemmer::from_name(name).ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "IndexSpec.fts: unknown stemmer {name:?} (valid: \"english\")"
+        ))
+    })
 }
 
 /// Declares which columns are full-text (BM25) and which are vector

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -33,7 +33,8 @@ use pyo3::types::{PyDict, PyList};
 
 use infino::{
     Bm25SearchOptions, Bm25Stats, BoolMode, ColdFetchMode, CompactionSettings, ConnectOptions,
-    GcError, InfinoError as CoreError, Metric, OptimizeError, OptimizeOptions, VectorFilter,
+    GcError, InfinoError as CoreError, Metric, OptimizeError, OptimizeOptions, Stemmer, Stopwords,
+    VectorFilter,
 };
 // Vector tuning knobs are a diagnostic-wheel-only surface; the type is off
 // the engine's public API and reachable only under `infino/test-helpers`.
@@ -214,10 +215,56 @@ fn connect(
     Ok(Connection { inner })
 }
 
-/// One declared FTS column: `(column, analyzer, stored, k1, b)`.
-/// `analyzer` `None` means the default; `k1` / `b` `None` means the
-/// column takes the standard BM25 pair.
-type FtsDecl = (String, Option<String>, bool, Option<f32>, Option<f32>);
+/// One declared FTS column, as its keyword arguments arrived.
+/// `analyzer` / `stopwords` / `stemmer` `None` mean the defaults;
+/// `k1` / `b` `None` mean the column takes the standard BM25 pair.
+struct FtsDecl {
+    column: String,
+    analyzer: Option<String>,
+    stopwords: Option<String>,
+    stemmer: Option<String>,
+    positions: bool,
+    stored: bool,
+    k1: Option<f32>,
+    b: Option<f32>,
+}
+
+impl Clone for FtsDecl {
+    fn clone(&self) -> Self {
+        Self {
+            column: self.column.clone(),
+            analyzer: self.analyzer.clone(),
+            stopwords: self.stopwords.clone(),
+            stemmer: self.stemmer.clone(),
+            positions: self.positions,
+            stored: self.stored,
+            k1: self.k1,
+            b: self.b,
+        }
+    }
+}
+
+/// Resolve the `stopwords=` argument. Named built-in sets only; the
+/// error names the valid set rather than leaving the caller to guess.
+fn stopwords_from_name(name: &str) -> PyResult<Stopwords> {
+    match name {
+        "english" => Ok(Stopwords::English),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "IndexSpec.fts: unknown stopwords {other:?} (valid: \"english\")"
+        ))),
+    }
+}
+
+/// Resolve the `stemmer=` argument. Same shape as
+/// [`stopwords_from_name`].
+fn stemmer_from_name(name: &str) -> PyResult<Stemmer> {
+    match name {
+        "english" => Ok(Stemmer::English),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "IndexSpec.fts: unknown stemmer {other:?} (valid: \"english\")"
+        ))),
+    }
+}
 
 /// Declares which columns are full-text (BM25) and which are vector
 /// (IVF kNN) indexed. Built fluently:
@@ -246,6 +293,24 @@ impl IndexSpec {
     /// raw text is never kept in the table, so it cannot be selected,
     /// projected, or filtered on (append/update batches still carry it).
     ///
+    /// `stopwords="english"` removes the very common words — the ones
+    /// whose presence says almost nothing about what a document is
+    /// about — from both the index and queries. `stemmer="english"`
+    /// reduces words to their stems, so a search for one inflection
+    /// finds the others (`running`, `runs`, `run`). Both are off by
+    /// default, apply to both sides of the search, and are recorded
+    /// with the table: they decide what is in the index, so neither can
+    /// be changed afterwards. Each trades something back — once a word
+    /// is not indexed no query can find it, and stemming conflates
+    /// words a reader would not — so declare them on prose, not on
+    /// short identifiers.
+    ///
+    /// `positions=True` records token positions, which is what exact
+    /// phrase queries (`'"climate policy"'`) need. Off by default
+    /// because positions roughly double the column's index footprint; a
+    /// column without them answers a phrase query with an error naming
+    /// the column, never a silent bag-of-words fallback.
+    ///
     /// `k1` and `b` are the column's BM25 similarity parameters —
     /// term-frequency saturation (`> 0`) and length normalization (in
     /// `[0, 1]`), defaulting to `1.2` and `0.75`. They are recorded
@@ -254,17 +319,39 @@ impl IndexSpec {
     /// may still score with a different pair (see `bm25_search`), which
     /// is the shape to reach for while tuning; declare the pair here
     /// once it is settled.
-    #[pyo3(signature = (column, analyzer = None, stored = true, k1 = None, b = None))]
+    #[pyo3(signature = (
+        column,
+        analyzer = None,
+        stopwords = None,
+        stemmer = None,
+        positions = false,
+        stored = true,
+        k1 = None,
+        b = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
     fn fts(
         &self,
         column: String,
         analyzer: Option<String>,
+        stopwords: Option<String>,
+        stemmer: Option<String>,
+        positions: bool,
         stored: bool,
         k1: Option<f32>,
         b: Option<f32>,
     ) -> Self {
         let mut next = self.clone();
-        next.fts.push((column, analyzer, stored, k1, b));
+        next.fts.push(FtsDecl {
+            column,
+            analyzer,
+            stopwords,
+            stemmer,
+            positions,
+            stored,
+            k1,
+            b,
+        });
         next
     }
 
@@ -282,10 +369,28 @@ impl IndexSpec {
     /// Lower to the core `IndexSpec` builder.
     fn to_rust(&self) -> PyResult<infino::IndexSpec> {
         let mut spec = infino::IndexSpec::new();
-        for (column, analyzer, stored, k1, b) in &self.fts {
-            let mut field = infino::FtsField::new(column.clone()).stored(*stored);
+        for decl in &self.fts {
+            let FtsDecl {
+                column,
+                analyzer,
+                stopwords,
+                stemmer,
+                positions,
+                stored,
+                k1,
+                b,
+            } = decl;
+            let mut field = infino::FtsField::new(column.clone())
+                .positions(*positions)
+                .stored(*stored);
             if let Some(a) = analyzer {
                 field = field.analyzer(a.clone());
+            }
+            if let Some(name) = stopwords {
+                field = field.stopwords(stopwords_from_name(name)?);
+            }
+            if let Some(name) = stemmer {
+                field = field.stemmer(stemmer_from_name(name)?);
             }
             // Both or neither, as at the search surface: the two
             // parameters interact through the length norm, so

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -312,27 +312,35 @@ impl IndexSpec {
     /// may still score with a different pair (see `bm25_search`), which
     /// is the shape to reach for while tuning; declare the pair here
     /// once it is settled.
+    // The three new options are appended **after** `b`, and behind `*`
+    // so they are keyword-only. Inserting them mid-signature would have
+    // silently changed what `fts("body", "standard", False)` means for
+    // every positional caller — every call site in this repo passes
+    // keywords past `column`, so no test here would have caught it.
+    // Keyword-only also means the next option added cannot repeat the
+    // mistake.
     #[pyo3(signature = (
         column,
         analyzer = None,
-        stopwords = None,
-        stemmer = None,
-        positions = false,
         stored = true,
         k1 = None,
         b = None,
+        *,
+        stopwords = None,
+        stemmer = None,
+        positions = false,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn fts(
         &self,
         column: String,
         analyzer: Option<String>,
-        stopwords: Option<String>,
-        stemmer: Option<String>,
-        positions: bool,
         stored: bool,
         k1: Option<f32>,
         b: Option<f32>,
+        stopwords: Option<String>,
+        stemmer: Option<String>,
+        positions: bool,
     ) -> Self {
         let mut next = self.clone();
         next.fts.push(FtsDecl {

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -305,6 +305,13 @@ impl IndexSpec {
     /// words a reader would not — so declare them on prose, not on
     /// short identifiers.
     ///
+    /// There is no migration: a removed stopword was never written and
+    /// a stem is not invertible, so changing either means building a
+    /// new table from the source text and re-ingesting. With
+    /// `stored=False` that source text is never kept, so the
+    /// combination is **permanent** — not even a full rebuild can undo
+    /// it.
+    ///
     /// `positions=True` records token positions, which is what exact
     /// phrase queries (`'"climate policy"'`) need. Off by default
     /// because positions roughly double the column's index footprint; a

--- a/infino-python/src/lib.rs
+++ b/infino-python/src/lib.rs
@@ -218,6 +218,7 @@ fn connect(
 /// One declared FTS column, as its keyword arguments arrived.
 /// `analyzer` / `stopwords` / `stemmer` `None` mean the defaults;
 /// `k1` / `b` `None` mean the column takes the standard BM25 pair.
+#[derive(Clone)]
 struct FtsDecl {
     column: String,
     analyzer: Option<String>,
@@ -227,21 +228,6 @@ struct FtsDecl {
     stored: bool,
     k1: Option<f32>,
     b: Option<f32>,
-}
-
-impl Clone for FtsDecl {
-    fn clone(&self) -> Self {
-        Self {
-            column: self.column.clone(),
-            analyzer: self.analyzer.clone(),
-            stopwords: self.stopwords.clone(),
-            stemmer: self.stemmer.clone(),
-            positions: self.positions,
-            stored: self.stored,
-            k1: self.k1,
-            b: self.b,
-        }
-    }
 }
 
 /// Resolve the `stopwords=` argument. Named built-in sets only; the

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -187,6 +187,30 @@ def test_fts_positional_arguments_keep_their_meaning():
         assert abs(a - b) < 1e-4
 
 
+def test_analysis_filter_names_resolve_at_create_table_exactly():
+    # The filters resolve in `to_rust()` at `create_table`, not at
+    # `fts()` — `fts` only records the strings — so this is where an
+    # unknown name surfaces, and neither binding covered it.
+    #
+    # Matched exactly, like the engine's own resolver: an earlier version
+    # of the node binding case-folded its argument, so `stopwords="English"`
+    # was accepted there and rejected here for the same call. Accepting
+    # more spellings later is additive; tightening later would not be.
+    db = infino.connect("memory://")
+    for bad, field in [("English", "stopwords"), ("ENGLISH", "stopwords"), ("german", "stopwords")]:
+        with pytest.raises(ValueError) as e:
+            db.create_table(
+                f"bad_{field}_{bad}", _title_schema(), infino.IndexSpec().fts("title", stopwords=bad)
+            )
+        assert bad in str(e.value)
+    for bad in ("English", "porter"):
+        with pytest.raises(ValueError) as e:
+            db.create_table(
+                f"bad_stem_{bad}", _title_schema(), infino.IndexSpec().fts("title", stemmer=bad)
+            )
+        assert bad in str(e.value)
+
+
 def test_analysis_options_are_keyword_only():
     # The analysis options sit behind `*`, so they can never be captured
     # positionally. That is what keeps the positional tail above stable

--- a/infino-python/tests/test_smoke.py
+++ b/infino-python/tests/test_smoke.py
@@ -141,6 +141,73 @@ def test_bm25_params_declared_and_overridden():
         assert abs(a - b) < 1e-4
 
 
+def test_fts_positional_arguments_keep_their_meaning():
+    # `IndexSpec.fts`'s positional order is API surface, and nothing else
+    # in this suite exercises it: every other call here passes keywords
+    # past `column`. So an option inserted mid-signature silently
+    # repositions `stored` / `k1` / `b` for downstream positional callers
+    # and no test fails. This pins the order so that change has to break
+    # here first.
+    #
+    # It has happened: the stopwords/stemmer/positions options were first
+    # added *before* `stored`, which turned `fts("body", "standard",
+    # False)` into a `TypeError` — caught in review, not by CI.
+    db = infino.connect("memory://")
+    titles = ["the quick brown fox", "a lazy dog", "quick thinking about foxes"]
+
+    # Slot 3 is `stored`, so a bool is accepted there. Under the broken
+    # signature this raised TypeError before doing anything.
+    index_only = db.create_table(
+        "index_only", _title_schema(), infino.IndexSpec().fts("title", "standard", False)
+    )
+    for title in titles:
+        index_only.append(_title_batch([title]))
+    # Searchable, since `stored` governs readback and not the index.
+    assert index_only.bm25_search("title", "quick", 10).num_rows == 2
+
+    # Slots 4 and 5 are `k1` and `b`. Checked by ranking rather than by
+    # the call merely succeeding: two floats would be accepted by any
+    # signature whose tail is float-shaped, so only the scores prove the
+    # values landed on the parameters they were meant for.
+    positional = db.create_table(
+        "positional", _title_schema(), infino.IndexSpec().fts("title", "standard", True, 1.6, 0.4)
+    )
+    keyword = db.create_table(
+        "keyword", _title_schema(), infino.IndexSpec().fts("title", k1=1.6, b=0.4)
+    )
+    for title in titles:
+        positional.append(_title_batch([title]))
+        keyword.append(_title_batch([title]))
+    from_positional = positional.bm25_search("title", "quick", 10, projection=["title", "score"])
+    from_keyword = keyword.bm25_search("title", "quick", 10, projection=["title", "score"])
+    assert from_positional.column("title").to_pylist() == from_keyword.column("title").to_pylist()
+    for a, b in zip(
+        from_positional.column("score").to_pylist(), from_keyword.column("score").to_pylist()
+    ):
+        assert abs(a - b) < 1e-4
+
+
+def test_analysis_options_are_keyword_only():
+    # The analysis options sit behind `*`, so they can never be captured
+    # positionally. That is what keeps the positional tail above stable
+    # as more options are added — the next one cannot repeat the
+    # mid-signature insertion that broke it.
+    with pytest.raises(TypeError):
+        infino.IndexSpec().fts("title", "standard", True, 1.6, 0.4, "english")
+    # And they still work by keyword, in any combination.
+    spec = infino.IndexSpec().fts(
+        "title", stopwords="english", stemmer="english", positions=True
+    )
+    db = infino.connect("memory://")
+    t = db.create_table("chained", _title_schema(), spec)
+    t.append(_title_batch(["the quick brown foxes are running"]))
+    # Stemming folds the inflection; the stopword never reaches the index.
+    assert t.bm25_search("title", "run", 10).num_rows == 1
+    assert t.bm25_search("title", "the", 10).num_rows == 0
+    # Positions were recorded, so an exact phrase resolves.
+    assert t.bm25_search("title", '"brown foxes"', 10).num_rows == 1
+
+
 def test_bm25_params_must_be_passed_together():
     # Overriding one parameter and inheriting the engine default for the
     # other would score with a combination the caller never chose, since

--- a/public-api.txt
+++ b/public-api.txt
@@ -185,6 +185,8 @@ impl !core::panic::unwind_safe::UnwindSafe for infino::OptimizeError
 #[non_exhaustive] pub enum infino::Stemmer
 pub infino::Stemmer::English
 pub infino::Stemmer::None
+impl infino::Stemmer
+pub fn infino::Stemmer::from_name(&str) -> core::option::Option<Self>
 impl core::clone::Clone for infino::Stemmer
 pub fn infino::Stemmer::clone(&self) -> infino::Stemmer
 impl core::cmp::Eq for infino::Stemmer
@@ -206,6 +208,8 @@ impl core::panic::unwind_safe::UnwindSafe for infino::Stemmer
 #[non_exhaustive] pub enum infino::Stopwords
 pub infino::Stopwords::English
 pub infino::Stopwords::None
+impl infino::Stopwords
+pub fn infino::Stopwords::from_name(&str) -> core::option::Option<Self>
 impl core::clone::Clone for infino::Stopwords
 pub fn infino::Stopwords::clone(&self) -> infino::Stopwords
 impl core::cmp::Eq for infino::Stopwords

--- a/public-api.txt
+++ b/public-api.txt
@@ -182,6 +182,48 @@ impl core::marker::Unpin for infino::OptimizeError
 impl core::marker::UnsafeUnpin for infino::OptimizeError
 impl !core::panic::unwind_safe::RefUnwindSafe for infino::OptimizeError
 impl !core::panic::unwind_safe::UnwindSafe for infino::OptimizeError
+#[non_exhaustive] pub enum infino::Stemmer
+pub infino::Stemmer::English
+pub infino::Stemmer::None
+impl core::clone::Clone for infino::Stemmer
+pub fn infino::Stemmer::clone(&self) -> infino::Stemmer
+impl core::cmp::Eq for infino::Stemmer
+impl core::cmp::PartialEq for infino::Stemmer
+pub fn infino::Stemmer::eq(&self, &infino::Stemmer) -> bool
+impl core::default::Default for infino::Stemmer
+pub fn infino::Stemmer::default() -> infino::Stemmer
+impl core::fmt::Debug for infino::Stemmer
+pub fn infino::Stemmer::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for infino::Stemmer
+impl core::marker::StructuralPartialEq for infino::Stemmer
+impl core::marker::Freeze for infino::Stemmer
+impl core::marker::Send for infino::Stemmer
+impl core::marker::Sync for infino::Stemmer
+impl core::marker::Unpin for infino::Stemmer
+impl core::marker::UnsafeUnpin for infino::Stemmer
+impl core::panic::unwind_safe::RefUnwindSafe for infino::Stemmer
+impl core::panic::unwind_safe::UnwindSafe for infino::Stemmer
+#[non_exhaustive] pub enum infino::Stopwords
+pub infino::Stopwords::English
+pub infino::Stopwords::None
+impl core::clone::Clone for infino::Stopwords
+pub fn infino::Stopwords::clone(&self) -> infino::Stopwords
+impl core::cmp::Eq for infino::Stopwords
+impl core::cmp::PartialEq for infino::Stopwords
+pub fn infino::Stopwords::eq(&self, &infino::Stopwords) -> bool
+impl core::default::Default for infino::Stopwords
+pub fn infino::Stopwords::default() -> infino::Stopwords
+impl core::fmt::Debug for infino::Stopwords
+pub fn infino::Stopwords::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for infino::Stopwords
+impl core::marker::StructuralPartialEq for infino::Stopwords
+impl core::marker::Freeze for infino::Stopwords
+impl core::marker::Send for infino::Stopwords
+impl core::marker::Sync for infino::Stopwords
+impl core::marker::Unpin for infino::Stopwords
+impl core::marker::UnsafeUnpin for infino::Stopwords
+impl core::panic::unwind_safe::RefUnwindSafe for infino::Stopwords
+impl core::panic::unwind_safe::UnwindSafe for infino::Stopwords
 #[non_exhaustive] pub struct infino::Bm25Params
 pub infino::Bm25Params::b: f32
 pub infino::Bm25Params::k1: f32
@@ -305,6 +347,9 @@ impl infino::FtsField
 pub fn infino::FtsField::analyzer(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn infino::FtsField::bm25(self, f32, f32) -> Self
 pub fn infino::FtsField::new(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn infino::FtsField::positions(self, bool) -> Self
+pub fn infino::FtsField::stemmer(self, infino::Stemmer) -> Self
+pub fn infino::FtsField::stopwords(self, infino::Stopwords) -> Self
 pub fn infino::FtsField::stored(self, bool) -> Self
 impl core::clone::Clone for infino::FtsField
 pub fn infino::FtsField::clone(&self) -> infino::FtsField

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -376,3 +376,119 @@ impl IndexSpec {
         (fts, vectors)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The lowered analyzer name for a single declared column.
+    fn analyzer_of(field: FtsField) -> String {
+        IndexSpec::new().fts(field).fts_analyzers().remove(0)
+    }
+
+    /// The three analysis setters commute. `FtsField` holds the base
+    /// name and the two filters separately and composes them only at
+    /// lowering, precisely so a caller cannot lose a filter by
+    /// declaring the base after it — which a naive "append to a string"
+    /// implementation would do.
+    #[test]
+    fn the_analysis_setters_commute() {
+        let want = "ascii_lower+stop=english+stem=english";
+        assert_eq!(
+            analyzer_of(
+                FtsField::new("t")
+                    .analyzer("ascii_lower")
+                    .stopwords(Stopwords::English)
+                    .stemmer(Stemmer::English)
+            ),
+            want
+        );
+        // Filters first, base last — the order that would drop them if
+        // `.analyzer()` reset the chain.
+        assert_eq!(
+            analyzer_of(
+                FtsField::new("t")
+                    .stemmer(Stemmer::English)
+                    .stopwords(Stopwords::English)
+                    .analyzer("ascii_lower")
+            ),
+            want
+        );
+        // And interleaved.
+        assert_eq!(
+            analyzer_of(
+                FtsField::new("t")
+                    .stopwords(Stopwords::English)
+                    .analyzer("ascii_lower")
+                    .stemmer(Stemmer::English)
+            ),
+            want
+        );
+    }
+
+    /// A composite name round-trips through `.analyzer()`, which is
+    /// what `open_table` relies on: it rebuilds the spec by handing the
+    /// recorded name straight back, so a chain that did not survive
+    /// that would silently reopen a table with a different analyzer
+    /// than its postings were built with.
+    #[test]
+    fn a_composite_name_round_trips_through_the_analyzer_setter() {
+        for name in [
+            "standard",
+            "ascii_lower",
+            "standard+stop=english",
+            "standard+stem=english",
+            "standard+stop=english+stem=english",
+            "ascii_lower+stop=english+stem=english",
+        ] {
+            assert_eq!(analyzer_of(FtsField::new("t").analyzer(name)), name);
+        }
+    }
+
+    /// A composite name sets the components it *names* and clears none,
+    /// so a filter setter after one replaces just that component and a
+    /// setter before one is not undone.
+    #[test]
+    fn a_composite_name_sets_only_what_it_names() {
+        // The name carries no stopword set, so the earlier setter stands.
+        assert_eq!(
+            analyzer_of(
+                FtsField::new("t")
+                    .stopwords(Stopwords::English)
+                    .analyzer("standard+stem=english")
+            ),
+            "standard+stop=english+stem=english"
+        );
+        // Turning a filter back off is explicit, never implied by a name.
+        assert_eq!(
+            analyzer_of(
+                FtsField::new("t")
+                    .analyzer("standard+stop=english+stem=english")
+                    .stopwords(Stopwords::None)
+            ),
+            "standard+stem=english"
+        );
+    }
+
+    /// An unresolvable analyzer passes through untouched, so
+    /// `create_table`'s error can name what the caller actually wrote
+    /// rather than a normalized form of it.
+    #[test]
+    fn an_unresolvable_analyzer_is_lowered_verbatim() {
+        for name in ["nonesuch", "standard+stop=german", "STANDARD"] {
+            assert_eq!(analyzer_of(FtsField::new("t").analyzer(name)), name);
+        }
+    }
+
+    /// The defaults, asserted where they are declared: `standard`, no
+    /// filters, no positions. A default column's analyzer name is the
+    /// bare base name, which is what keeps it byte-identical on disk to
+    /// one declared before chains existed.
+    #[test]
+    fn a_bare_declaration_takes_the_plain_standard_analyzer() {
+        let spec = IndexSpec::new().fts("body");
+        assert_eq!(spec.fts_analyzers(), vec![STANDARD_TOKENIZER.to_string()]);
+        assert_eq!(spec.fts_positions(), vec![false]);
+        assert_eq!(spec.fts_stored(), vec![true]);
+    }
+}

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -9,7 +9,7 @@
 use crate::superfile::{
     builder::FtsConfig,
     fts::{
-        analysis::{Base, Stemmer, Stopwords, chain_name, parse_chain_name},
+        analysis::{Stemmer, Stopwords},
         bm25::Bm25Params,
         tokenize::STANDARD_TOKENIZER,
     },
@@ -81,35 +81,13 @@ impl FtsField {
     /// cannot be changed afterwards.
     ///
     /// This names the *base* tokenizer. [`FtsField::stopwords`] and
-    /// [`FtsField::stemmer`] add filters on top of it, and the column's
-    /// recorded analyzer name is the whole chain
-    /// (`"standard+stop=english+stem=english"`). A composite name is
-    /// also accepted here, so a name read back from a table round-trips;
-    /// a filter setter then replaces that component of it.
+    /// [`FtsField::stemmer`] add filters on top of it, and each is
+    /// recorded as its own option — so the three setters are
+    /// independent and may be called in any order.
     ///
     /// Validated at `create_table`, with the column named in the error.
     pub fn analyzer(mut self, name: impl Into<String>) -> Self {
-        let name = name.into();
-        match parse_chain_name(&name) {
-            // A composite name sets the components it *names* and
-            // clears none, so the three setters commute: a base name
-            // never undoes a `.stopwords()` that came before it, and a
-            // filter setter after a composite name replaces just that
-            // component. To turn a filter off, name its `None`.
-            Some((base, stopwords, stemmer)) => {
-                self.analyzer = base.name().to_string();
-                if stopwords != Stopwords::None {
-                    self.stopwords = stopwords;
-                }
-                if stemmer != Stemmer::None {
-                    self.stemmer = stemmer;
-                }
-            }
-            // Unresolvable: kept verbatim so `create_table`'s error
-            // names the analyzer the caller actually wrote, rather than
-            // some normalized form of it.
-            None => self.analyzer = name,
-        }
+        self.analyzer = name.into();
         self
     }
 
@@ -224,23 +202,6 @@ impl FtsField {
         self.bm25 = Bm25Params::new(k1, b);
         self
     }
-
-    /// This column's whole analysis chain as one canonical analyzer
-    /// name — the single string that reaches the superfile's
-    /// `inf.fts.columns` entry, the catalog record, the remote wire and
-    /// the options-hash. A column with no filter yields its base name
-    /// unchanged, so a default column is byte-identical everywhere to
-    /// one declared before the chain existed.
-    ///
-    /// An analyzer name that does not resolve passes through untouched:
-    /// validation at `create_table` is what reports it, and it must
-    /// report the name as written.
-    fn chain_analyzer(&self) -> String {
-        match Base::from_name(&self.analyzer) {
-            Some(base) => chain_name(base, self.stopwords, self.stemmer).to_string(),
-            None => self.analyzer.clone(),
-        }
-    }
 }
 
 impl From<&str> for FtsField {
@@ -314,16 +275,25 @@ impl IndexSpec {
         self.fts.iter().map(|f| f.column.clone()).collect()
     }
 
-    /// FTS analyzer names, in declaration order (parallel to
-    /// [`fts_columns`](Self::fts_columns)).
-    ///
-    /// Each is the column's **whole** analysis chain as one canonical
-    /// composite name, so this is all the catalog record, the remote
-    /// create-table wire and the options-hash have to carry for
-    /// stopwords and stemming — see
-    /// [`FtsField::chain_analyzer`].
+    /// FTS **base** analyzer names, in declaration order (parallel to
+    /// [`fts_columns`](Self::fts_columns)). The stopword set and
+    /// stemmer are carried separately by
+    /// [`fts_stopwords`](Self::fts_stopwords) and
+    /// [`fts_stemmers`](Self::fts_stemmers).
     pub(crate) fn fts_analyzers(&self) -> Vec<String> {
-        self.fts.iter().map(|f| f.chain_analyzer()).collect()
+        self.fts.iter().map(|f| f.analyzer.clone()).collect()
+    }
+
+    /// FTS stopword sets, in declaration order (parallel to
+    /// [`fts_columns`](Self::fts_columns)).
+    pub(crate) fn fts_stopwords(&self) -> Vec<Stopwords> {
+        self.fts.iter().map(|f| f.stopwords).collect()
+    }
+
+    /// FTS stemmers, in declaration order (parallel to
+    /// [`fts_columns`](Self::fts_columns)).
+    pub(crate) fn fts_stemmers(&self) -> Vec<Stemmer> {
+        self.fts.iter().map(|f| f.stemmer).collect()
     }
 
     /// FTS positions flags, in declaration order (parallel to
@@ -362,7 +332,9 @@ impl IndexSpec {
             .iter()
             .map(|f| {
                 FtsConfig::new(f.column.clone())
-                    .analyzer(f.chain_analyzer())
+                    .analyzer(f.analyzer.clone())
+                    .stopwords(f.stopwords)
+                    .stemmer(f.stemmer)
                     .positions(f.positions)
                     .stored(f.stored)
                     .bm25(f.bm25.k1, f.bm25.b)
@@ -381,21 +353,32 @@ impl IndexSpec {
 mod tests {
     use super::*;
 
-    /// The lowered analyzer name for a single declared column.
-    fn analyzer_of(field: FtsField) -> String {
-        IndexSpec::new().fts(field).fts_analyzers().remove(0)
+    /// What a single declared column lowers to on each of the three
+    /// independent analysis surfaces.
+    fn analysis_of(field: FtsField) -> (String, Stopwords, Stemmer) {
+        let spec = IndexSpec::new().fts(field);
+        (
+            spec.fts_analyzers().remove(0),
+            spec.fts_stopwords().remove(0),
+            spec.fts_stemmers().remove(0),
+        )
     }
 
-    /// The three analysis setters commute. `FtsField` holds the base
-    /// name and the two filters separately and composes them only at
-    /// lowering, precisely so a caller cannot lose a filter by
-    /// declaring the base after it — which a naive "append to a string"
-    /// implementation would do.
+    /// The three analysis setters are independent: each carries its own
+    /// option through to its own persisted field, so they commute and
+    /// none can clobber another. Worth pinning even though it now falls
+    /// out of the representation — an earlier version composed them
+    /// into one string, where declaring the base last silently dropped
+    /// the filters.
     #[test]
     fn the_analysis_setters_commute() {
-        let want = "ascii_lower+stop=english+stem=english";
+        let want = (
+            "ascii_lower".to_string(),
+            Stopwords::English,
+            Stemmer::English,
+        );
         assert_eq!(
-            analyzer_of(
+            analysis_of(
                 FtsField::new("t")
                     .analyzer("ascii_lower")
                     .stopwords(Stopwords::English)
@@ -403,10 +386,8 @@ mod tests {
             ),
             want
         );
-        // Filters first, base last — the order that would drop them if
-        // `.analyzer()` reset the chain.
         assert_eq!(
-            analyzer_of(
+            analysis_of(
                 FtsField::new("t")
                     .stemmer(Stemmer::English)
                     .stopwords(Stopwords::English)
@@ -414,9 +395,8 @@ mod tests {
             ),
             want
         );
-        // And interleaved.
         assert_eq!(
-            analyzer_of(
+            analysis_of(
                 FtsField::new("t")
                     .stopwords(Stopwords::English)
                     .analyzer("ascii_lower")
@@ -426,47 +406,33 @@ mod tests {
         );
     }
 
-    /// A composite name round-trips through `.analyzer()`, which is
-    /// what `open_table` relies on: it rebuilds the spec by handing the
-    /// recorded name straight back, so a chain that did not survive
-    /// that would silently reopen a table with a different analyzer
-    /// than its postings were built with.
+    /// `.analyzer()` names the base tokenizer and nothing else. A
+    /// caller who passes a chain-shaped string gets it treated as an
+    /// analyzer name — which does not resolve, so `create_table`
+    /// rejects it naming what they wrote, rather than silently
+    /// interpreting it.
     #[test]
-    fn a_composite_name_round_trips_through_the_analyzer_setter() {
-        for name in [
-            "standard",
-            "ascii_lower",
-            "standard+stop=english",
-            "standard+stem=english",
-            "standard+stop=english+stem=english",
-            "ascii_lower+stop=english+stem=english",
-        ] {
-            assert_eq!(analyzer_of(FtsField::new("t").analyzer(name)), name);
-        }
-    }
-
-    /// A composite name sets the components it *names* and clears none,
-    /// so a filter setter after one replaces just that component and a
-    /// setter before one is not undone.
-    #[test]
-    fn a_composite_name_sets_only_what_it_names() {
-        // The name carries no stopword set, so the earlier setter stands.
+    fn the_analyzer_setter_names_only_the_base() {
+        let (analyzer, stop, stem) =
+            analysis_of(FtsField::new("t").analyzer("standard+stop=english"));
+        assert_eq!(analyzer, "standard+stop=english");
         assert_eq!(
-            analyzer_of(
+            (stop, stem),
+            (Stopwords::None, Stemmer::None),
+            "a chain-shaped string must not be silently decomposed"
+        );
+        // Turning a filter off is explicit, and independent of the base.
+        assert_eq!(
+            analysis_of(
                 FtsField::new("t")
                     .stopwords(Stopwords::English)
-                    .analyzer("standard+stem=english")
-            ),
-            "standard+stop=english+stem=english"
-        );
-        // Turning a filter back off is explicit, never implied by a name.
-        assert_eq!(
-            analyzer_of(
-                FtsField::new("t")
-                    .analyzer("standard+stop=english+stem=english")
                     .stopwords(Stopwords::None)
             ),
-            "standard+stem=english"
+            (
+                STANDARD_TOKENIZER.to_string(),
+                Stopwords::None,
+                Stemmer::None
+            )
         );
     }
 
@@ -475,8 +441,8 @@ mod tests {
     /// rather than a normalized form of it.
     #[test]
     fn an_unresolvable_analyzer_is_lowered_verbatim() {
-        for name in ["nonesuch", "standard+stop=german", "STANDARD"] {
-            assert_eq!(analyzer_of(FtsField::new("t").analyzer(name)), name);
+        for name in ["nonesuch", "STANDARD"] {
+            assert_eq!(analysis_of(FtsField::new("t").analyzer(name)).0, name);
         }
     }
 

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -134,7 +134,16 @@ impl FtsField {
     /// or titles.
     ///
     /// Recorded with the table and cannot be changed afterwards — it
-    /// decides what is in the index.
+    /// decides what is in the index, and there is no migration. A
+    /// filter's effect is not recoverable from the index it produced:
+    /// the tokens it removed were never written, so changing it means
+    /// building a new table from the source text and re-ingesting.
+    ///
+    /// Which makes one combination permanent. On a
+    /// [`stored(false)`](FtsField::stored) column the source text is
+    /// never kept, so there is nothing left to re-analyze — not even a
+    /// full rebuild can undo the choice. Declare a filter with
+    /// `stored(false)` only once you are sure of it.
     pub fn stopwords(mut self, stopwords: Stopwords) -> Self {
         self.stopwords = stopwords;
         self
@@ -156,7 +165,17 @@ impl FtsField {
     /// frequency, and so lowers its idf.
     ///
     /// Recorded with the table and cannot be changed afterwards — it
-    /// decides what is in the index.
+    /// decides what is in the index, and there is no migration. A
+    /// stem is not invertible: the index holds `run`, never the
+    /// `running` it came from, so changing or removing the stemmer
+    /// means building a new table from the source text and
+    /// re-ingesting.
+    ///
+    /// Which makes one combination permanent. On a
+    /// [`stored(false)`](FtsField::stored) column the source text is
+    /// never kept, so there is nothing left to re-analyze — not even a
+    /// full rebuild can undo the choice. Declare a filter with
+    /// `stored(false)` only once you are sure of it.
     pub fn stemmer(mut self, stemmer: Stemmer) -> Self {
         self.stemmer = stemmer;
         self

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -44,10 +44,10 @@ struct VectorIndex {
 #[derive(Debug, Clone)]
 pub struct FtsField {
     column: String,
-    /// The base analyzer name. The stopword set and stemmer are held
-    /// separately and composed onto it at lowering, so the two setters
-    /// and [`FtsField::analyzer`] may be called in any order and the
-    /// column still ends up with one canonical analyzer name.
+    /// The **base tokenizer** name. Called `analyzer` because that is
+    /// what the option is named on the public builder, but the value is
+    /// a tokenizer: the column's *analyzer* is this tokenizer plus the
+    /// two filters below, each of which is carried as its own option.
     analyzer: String,
     stopwords: Stopwords,
     stemmer: Stemmer,
@@ -275,9 +275,9 @@ impl IndexSpec {
         self.fts.iter().map(|f| f.column.clone()).collect()
     }
 
-    /// FTS **base** analyzer names, in declaration order (parallel to
-    /// [`fts_columns`](Self::fts_columns)). The stopword set and
-    /// stemmer are carried separately by
+    /// FTS **base tokenizer** names, in declaration order (parallel to
+    /// [`fts_columns`](Self::fts_columns)) — a column's analyzer is one
+    /// of these plus its filters, which are carried separately by
     /// [`fts_stopwords`](Self::fts_stopwords) and
     /// [`fts_stemmers`](Self::fts_stemmers).
     pub(crate) fn fts_analyzers(&self) -> Vec<String> {
@@ -408,7 +408,7 @@ mod tests {
 
     /// `.analyzer()` names the base tokenizer and nothing else. A
     /// caller who passes a chain-shaped string gets it treated as an
-    /// analyzer name — which does not resolve, so `create_table`
+    /// tokenizer name — which does not resolve, so `create_table`
     /// rejects it naming what they wrote, rather than silently
     /// interpreting it.
     #[test]
@@ -447,9 +447,9 @@ mod tests {
     }
 
     /// The defaults, asserted where they are declared: `standard`, no
-    /// filters, no positions. A default column's analyzer name is the
-    /// bare base name, which is what keeps it byte-identical on disk to
-    /// one declared before chains existed.
+    /// filters, no positions. A default column's recorded tokenizer is
+    /// the bare base name, which is what keeps it byte-identical on
+    /// disk to one declared before the filters existed.
     #[test]
     fn a_bare_declaration_takes_the_plain_standard_analyzer() {
         let spec = IndexSpec::new().fts("body");

--- a/src/catalog/index_spec.rs
+++ b/src/catalog/index_spec.rs
@@ -8,7 +8,11 @@
 
 use crate::superfile::{
     builder::FtsConfig,
-    fts::{bm25::Bm25Params, tokenize::STANDARD_TOKENIZER},
+    fts::{
+        analysis::{Base, Stemmer, Stopwords, chain_name, parse_chain_name},
+        bm25::Bm25Params,
+        tokenize::STANDARD_TOKENIZER,
+    },
     vector::{builder::VectorConfig, distance::Metric},
 };
 
@@ -40,7 +44,14 @@ struct VectorIndex {
 #[derive(Debug, Clone)]
 pub struct FtsField {
     column: String,
+    /// The base analyzer name. The stopword set and stemmer are held
+    /// separately and composed onto it at lowering, so the two setters
+    /// and [`FtsField::analyzer`] may be called in any order and the
+    /// column still ends up with one canonical analyzer name.
     analyzer: String,
+    stopwords: Stopwords,
+    stemmer: Stemmer,
+    positions: bool,
     stored: bool,
     bm25: Bm25Params,
 }
@@ -54,6 +65,9 @@ impl FtsField {
         Self {
             column: column.into(),
             analyzer: STANDARD_TOKENIZER.to_string(),
+            stopwords: Stopwords::None,
+            stemmer: Stemmer::None,
+            positions: false,
             stored: true,
             bm25: Bm25Params::STANDARD,
         }
@@ -65,8 +79,100 @@ impl FtsField {
     /// FTS column is tokenized with its own, so columns in one table
     /// may use different analyzers. It is recorded with the table and
     /// cannot be changed afterwards.
+    ///
+    /// This names the *base* tokenizer. [`FtsField::stopwords`] and
+    /// [`FtsField::stemmer`] add filters on top of it, and the column's
+    /// recorded analyzer name is the whole chain
+    /// (`"standard+stop=english+stem=english"`). A composite name is
+    /// also accepted here, so a name read back from a table round-trips;
+    /// a filter setter then replaces that component of it.
+    ///
+    /// Validated at `create_table`, with the column named in the error.
     pub fn analyzer(mut self, name: impl Into<String>) -> Self {
-        self.analyzer = name.into();
+        let name = name.into();
+        match parse_chain_name(&name) {
+            // A composite name sets the components it *names* and
+            // clears none, so the three setters commute: a base name
+            // never undoes a `.stopwords()` that came before it, and a
+            // filter setter after a composite name replaces just that
+            // component. To turn a filter off, name its `None`.
+            Some((base, stopwords, stemmer)) => {
+                self.analyzer = base.name().to_string();
+                if stopwords != Stopwords::None {
+                    self.stopwords = stopwords;
+                }
+                if stemmer != Stemmer::None {
+                    self.stemmer = stemmer;
+                }
+            }
+            // Unresolvable: kept verbatim so `create_table`'s error
+            // names the analyzer the caller actually wrote, rather than
+            // some normalized form of it.
+            None => self.analyzer = name,
+        }
+        self
+    }
+
+    /// Remove this column's stopwords — the very common words whose
+    /// presence in a document says almost nothing about what it is
+    /// about. Off by default.
+    ///
+    /// Applies to both sides: the words leave the index, and they leave
+    /// a query too, so searching `"the climate policy"` searches
+    /// `climate policy`. Each removed word leaves a **hole** in the
+    /// token positions, so an exact phrase still knows the words it
+    /// matched were not adjacent in the text: with the English set,
+    /// `"new york"` does not match `new the york`, and
+    /// `"end of the world"` matches only text with two words between
+    /// `end` and `world`.
+    ///
+    /// The trade is index size and speed against the handful of queries
+    /// that are *about* a stopword: once `the` is not indexed, no query
+    /// can find it — `"to be or not to be"` matches everything, because
+    /// nothing is left of it. Declare it on a column of prose where the
+    /// common words carry no signal, not on one holding short identifiers
+    /// or titles.
+    ///
+    /// Recorded with the table and cannot be changed afterwards — it
+    /// decides what is in the index.
+    pub fn stopwords(mut self, stopwords: Stopwords) -> Self {
+        self.stopwords = stopwords;
+        self
+    }
+
+    /// Reduce this column's words to their stems, so a search for one
+    /// inflection finds the others. Off by default.
+    ///
+    /// Applies to both sides — index and query — so
+    /// [`Stemmer::English`] makes `running`, `runs` and `run` one term
+    /// and any of them find all of them. Irregular forms it has no rule
+    /// for (`ran`, `went`) stay distinct.
+    ///
+    /// The trade is precision: stemming conflates words that a reader
+    /// would not, so a query for an exact word can return documents
+    /// carrying a relative of it, and there is no way to ask for the
+    /// unstemmed form on a stemmed column. It also shifts the scoring —
+    /// folding inflections together raises the merged term's document
+    /// frequency, and so lowers its idf.
+    ///
+    /// Recorded with the table and cannot be changed afterwards — it
+    /// decides what is in the index.
+    pub fn stemmer(mut self, stemmer: Stemmer) -> Self {
+        self.stemmer = stemmer;
+        self
+    }
+
+    /// Record token positions for this column, which is what exact
+    /// phrase queries (`"climate policy"`) need. Off by default.
+    ///
+    /// The trade is index size: positions roughly double the column's
+    /// full-text index footprint, so they are a per-column opt-in
+    /// rather than something every column pays for. A column without
+    /// them answers a phrase query with an error naming the column,
+    /// never a silent bag-of-words fallback that would return the wrong
+    /// documents.
+    pub fn positions(mut self, positions: bool) -> Self {
+        self.positions = positions;
         self
     }
 
@@ -98,6 +204,23 @@ impl FtsField {
     pub fn bm25(mut self, k1: f32, b: f32) -> Self {
         self.bm25 = Bm25Params::new(k1, b);
         self
+    }
+
+    /// This column's whole analysis chain as one canonical analyzer
+    /// name — the single string that reaches the superfile's
+    /// `inf.fts.columns` entry, the catalog record, the remote wire and
+    /// the options-hash. A column with no filter yields its base name
+    /// unchanged, so a default column is byte-identical everywhere to
+    /// one declared before the chain existed.
+    ///
+    /// An analyzer name that does not resolve passes through untouched:
+    /// validation at `create_table` is what reports it, and it must
+    /// report the name as written.
+    fn chain_analyzer(&self) -> String {
+        match Base::from_name(&self.analyzer) {
+            Some(base) => chain_name(base, self.stopwords, self.stemmer).to_string(),
+            None => self.analyzer.clone(),
+        }
     }
 }
 
@@ -174,8 +297,20 @@ impl IndexSpec {
 
     /// FTS analyzer names, in declaration order (parallel to
     /// [`fts_columns`](Self::fts_columns)).
+    ///
+    /// Each is the column's **whole** analysis chain as one canonical
+    /// composite name, so this is all the catalog record, the remote
+    /// create-table wire and the options-hash have to carry for
+    /// stopwords and stemming — see
+    /// [`FtsField::chain_analyzer`].
     pub(crate) fn fts_analyzers(&self) -> Vec<String> {
-        self.fts.iter().map(|f| f.analyzer.clone()).collect()
+        self.fts.iter().map(|f| f.chain_analyzer()).collect()
+    }
+
+    /// FTS positions flags, in declaration order (parallel to
+    /// [`fts_columns`](Self::fts_columns)).
+    pub(crate) fn fts_positions(&self) -> Vec<bool> {
+        self.fts.iter().map(|f| f.positions).collect()
     }
 
     /// FTS stored flags, in declaration order (parallel to
@@ -208,7 +343,8 @@ impl IndexSpec {
             .iter()
             .map(|f| {
                 FtsConfig::new(f.column.clone())
-                    .analyzer(f.analyzer.clone())
+                    .analyzer(f.chain_analyzer())
+                    .positions(f.positions)
                     .stored(f.stored)
                     .bm25(f.bm25.k1, f.bm25.b)
             })

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -53,15 +53,32 @@ pub(crate) struct TableEntry {
     pub(crate) schema_ipc: Vec<u8>,
     /// FTS-indexed column names.
     pub(crate) fts: Vec<String>,
-    /// FTS analyzer names, parallel to `fts` (`"ascii_lower"` /
-    /// `"standard"`). Every entry `create_table` writes carries one name
-    /// per FTS column; `open_table` requires the two lists to be the
-    /// same length rather than inferring an analyzer for a column that
-    /// lacks one. `serde(default)` only keeps the *rest* of the catalog
+    /// FTS analyzer names, parallel to `fts`. Each is a column's whole
+    /// analysis chain as one canonical name — a base tokenizer
+    /// (`"ascii_lower"` / `"standard"`) plus any stopword set and
+    /// stemmer (`"standard+stop=english+stem=english"`) — so the chain
+    /// needs no fields of its own here.
+    ///
+    /// Every entry `create_table` writes carries one name per FTS
+    /// column; `open_table` requires the two lists to be the same
+    /// length rather than inferring an analyzer for a column that lacks
+    /// one. `serde(default)` only keeps the *rest* of the catalog
     /// decodable — an entry that decodes to a short list is rejected per
     /// table, not silently patched.
     #[serde(default)]
     pub(crate) fts_analyzers: Vec<String>,
+    /// FTS positions flags, parallel to `fts` (`true` = token positions
+    /// recorded, which exact-phrase queries need). Absent in catalogs
+    /// written before positions were declarable; a missing or short
+    /// entry defaults to `false` on reopen — the only value such a
+    /// table can have been built with, since nothing could turn them on.
+    ///
+    /// Load-bearing on reopen beyond the query path: the flag joins the
+    /// table's options-hash, so losing it here would make a positional
+    /// table fail its own hash check rather than merely forget how to
+    /// answer a phrase.
+    #[serde(default)]
+    pub(crate) fts_positions: Vec<bool>,
     /// FTS stored flags, parallel to `fts` (`false` = index-only, the
     /// raw text is not kept in the table). Absent in catalogs written
     /// before index-only columns existed; a missing or short entry
@@ -195,6 +212,7 @@ mod tests {
             schema_ipc: schema_to_ipc(&sample_schema()).expect("ipc"),
             fts: vec!["title".into()],
             fts_analyzers: vec!["ascii_lower".into()],
+            fts_positions: vec![false],
             fts_stored: vec![true],
             fts_k1: vec![1.2],
             fts_b: vec![0.75],

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -67,6 +67,17 @@ pub(crate) struct TableEntry {
     /// table, not silently patched.
     #[serde(default)]
     pub(crate) fts_analyzers: Vec<String>,
+    /// FTS stopword-set names, parallel to `fts`; an empty string
+    /// means no set. Absent in catalogs written before the filter
+    /// existed, and a missing or short entry means no set — the only
+    /// thing such a catalog can describe, since nothing could have
+    /// asked for one.
+    #[serde(default)]
+    pub(crate) fts_stopwords: Vec<String>,
+    /// FTS stemmer names, parallel to `fts`; same empty-means-none and
+    /// same back-compat rule as `fts_stopwords`.
+    #[serde(default)]
+    pub(crate) fts_stemmers: Vec<String>,
     /// FTS positions flags, parallel to `fts` (`true` = token positions
     /// recorded, which exact-phrase queries need). Absent in catalogs
     /// written before positions were declarable; a missing or short
@@ -212,6 +223,8 @@ mod tests {
             schema_ipc: schema_to_ipc(&sample_schema()).expect("ipc"),
             fts: vec!["title".into()],
             fts_analyzers: vec!["ascii_lower".into()],
+            fts_stopwords: vec![String::new()],
+            fts_stemmers: vec![String::new()],
             fts_positions: vec![false],
             fts_stored: vec![true],
             fts_k1: vec![1.2],

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -53,15 +53,13 @@ pub(crate) struct TableEntry {
     pub(crate) schema_ipc: Vec<u8>,
     /// FTS-indexed column names.
     pub(crate) fts: Vec<String>,
-    /// FTS analyzer names, parallel to `fts`. Each is a column's whole
-    /// analysis chain as one canonical name — a base tokenizer
-    /// (`"ascii_lower"` / `"standard"`) plus any stopword set and
-    /// stemmer (`"standard+stop=english+stem=english"`) — so the chain
-    /// needs no fields of its own here.
+    /// FTS **base tokenizer** names, parallel to `fts` (`"ascii_lower"`
+    /// / `"standard"`). A column's analyzer is one of these plus the
+    /// filters in `fts_stopwords` / `fts_stemmers`.
     ///
     /// Every entry `create_table` writes carries one name per FTS
     /// column; `open_table` requires the two lists to be the same
-    /// length rather than inferring an analyzer for a column that lacks
+    /// length rather than inferring a tokenizer for a column that lacks
     /// one. `serde(default)` only keeps the *rest* of the catalog
     /// decodable — an entry that decodes to a short list is rejected per
     /// table, not silently patched.

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -435,6 +435,7 @@ impl Connection {
                         .map_err(|e| e.with_context("create_table", Some(name)))?,
                     fts: indexes.fts_columns(),
                     fts_analyzers: indexes.fts_analyzers(),
+                    fts_positions: indexes.fts_positions(),
                     fts_stored: indexes.fts_stored(),
                     fts_k1: indexes.fts_bm25().iter().map(|p| p.k1).collect(),
                     fts_b: indexes.fts_bm25().iter().map(|p| p.b).collect(),
@@ -583,6 +584,11 @@ impl Connection {
                     // written before index-only columns existed can only
                     // mean the text is stored.
                     let stored = entry.fts_stored.get(i).copied().unwrap_or(true);
+                    // Same rule for positions: a catalog written before
+                    // they were declarable describes a table built
+                    // without them, because nothing could have asked
+                    // for them.
+                    let positions = entry.fts_positions.get(i).copied().unwrap_or(false);
                     // And again for the BM25 pair: a catalog written before
                     // it was declarable can only describe a table built with
                     // the standard values, so the fallback is frozen there
@@ -592,6 +598,7 @@ impl Connection {
                     spec = spec.fts(
                         FtsField::new(column.clone())
                             .analyzer(analyzer)
+                            .positions(positions)
                             .stored(stored)
                             .bm25(k1, b),
                     );

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -85,7 +85,10 @@ use crate::{
     },
     superfile::{
         builder::FtsConfig,
-        fts::bm25,
+        fts::{
+            analysis::{Stemmer, Stopwords},
+            bm25,
+        },
         vector::{builder::VectorConfig, distance::Metric},
     },
     supertable::{
@@ -435,6 +438,16 @@ impl Connection {
                         .map_err(|e| e.with_context("create_table", Some(name)))?,
                     fts: indexes.fts_columns(),
                     fts_analyzers: indexes.fts_analyzers(),
+                    fts_stopwords: indexes
+                        .fts_stopwords()
+                        .iter()
+                        .map(|s| s.as_str().unwrap_or_default().to_string())
+                        .collect(),
+                    fts_stemmers: indexes
+                        .fts_stemmers()
+                        .iter()
+                        .map(|s| s.as_str().unwrap_or_default().to_string())
+                        .collect(),
                     fts_positions: indexes.fts_positions(),
                     fts_stored: indexes.fts_stored(),
                     fts_k1: indexes.fts_bm25().iter().map(|p| p.k1).collect(),
@@ -589,6 +602,32 @@ impl Connection {
                     // without them, because nothing could have asked
                     // for them.
                     let positions = entry.fts_positions.get(i).copied().unwrap_or(false);
+                    // Same rule for the analysis filters: a catalog
+                    // written before they existed, or one whose entry
+                    // is empty, describes a column with no filter. A
+                    // name that does not resolve is different — the
+                    // recorded analysis cannot be reproduced, so the
+                    // table is unusable rather than usable-with-a-guess.
+                    let stopwords = match entry.fts_stopwords.get(i).map(String::as_str) {
+                        None | Some("") => Stopwords::None,
+                        Some(set) => Stopwords::from_name(set).ok_or_else(|| {
+                            InfinoError::Backend(format!(
+                                "table '{name}' column {column:?} records unknown stopwords \
+                                 {set:?}"
+                            ))
+                            .with_context("open_table", Some(name))
+                        })?,
+                    };
+                    let stemmer = match entry.fts_stemmers.get(i).map(String::as_str) {
+                        None | Some("") => Stemmer::None,
+                        Some(stem) => Stemmer::from_name(stem).ok_or_else(|| {
+                            InfinoError::Backend(format!(
+                                "table '{name}' column {column:?} records unknown stemmer \
+                                 {stem:?}"
+                            ))
+                            .with_context("open_table", Some(name))
+                        })?,
+                    };
                     // And again for the BM25 pair: a catalog written before
                     // it was declarable can only describe a table built with
                     // the standard values, so the fallback is frozen there
@@ -598,6 +637,8 @@ impl Connection {
                     spec = spec.fts(
                         FtsField::new(column.clone())
                             .analyzer(analyzer)
+                            .stopwords(stopwords)
+                            .stemmer(stemmer)
                             .positions(positions)
                             .stored(stored)
                             .bm25(k1, b),
@@ -1874,24 +1915,21 @@ mod tests {
         );
     }
 
-    /// An analyzer name naming a filter this engine does not implement is
-    /// refused at create time rather than silently approximated — the
-    /// property the composite name exists to buy.
+    /// An unknown analyzer is refused at create time, naming what the
+    /// caller wrote. Filters are separate options now, so a
+    /// chain-shaped string is simply an analyzer name that does not
+    /// resolve — it must not be quietly interpreted as a chain.
     #[test]
-    fn an_unimplemented_analysis_filter_is_refused() {
+    fn an_unknown_analyzer_is_refused_and_a_chain_shaped_name_is_not_interpreted() {
         let conn = connect("memory://").expect("connect");
-        for name in [
-            "standard+stop=german",
-            "standard+stem=porter",
-            "standard+stem=english+stop=english",
-        ] {
+        for name in ["nonesuch", "standard+stop=english"] {
             let err = conn
                 .create_table(
                     "bad",
                     schema_id_title(),
                     IndexSpec::new().fts(FtsField::new("title").analyzer(name)),
                 )
-                .expect_err("an unimplemented chain must be rejected");
+                .expect_err("an unresolvable analyzer must be rejected");
             let msg = err.to_string();
             assert!(
                 msg.contains(name),

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1397,7 +1397,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        Bm25SearchOptions, BoolMode, Consistency,
+        Bm25SearchOptions, BoolMode, Consistency, Stemmer, Stopwords,
         catalog::manifest::CATALOG_PATH,
         supertable::manifest::commit::POINTER_PATH,
         test_helpers::{build_title_batch, schema_id_title},
@@ -1591,6 +1591,226 @@ mod tests {
             conn.open_table("docs"),
             Err(InfinoError::NotFound(_))
         ));
+    }
+
+    /// Stemming, end to end: one inflection finds the others because
+    /// both sides of the search run through the same chain.
+    #[test]
+    fn stemming_folds_inflections_end_to_end() {
+        let conn = connect("memory://").expect("connect");
+        let stemmed = conn
+            .create_table(
+                "stemmed",
+                schema_id_title(),
+                IndexSpec::new().fts(FtsField::new("title").stemmer(Stemmer::English)),
+            )
+            .expect("create stemmed table");
+        stemmed
+            .append(&build_title_batch(&[
+                "running late",
+                "she runs fast",
+                "a walk",
+            ]))
+            .expect("append");
+
+        // Every inflection reaches both documents holding one, whichever
+        // one the query spells.
+        for query in ["running", "runs", "run"] {
+            let hits = stemmed
+                .bm25_search("title", query, TOP_K, Bm25SearchOptions::new(), None)
+                .expect("bm25_search");
+            assert_eq!(
+                n_rows(&hits),
+                2,
+                "{query:?} must reach both inflections on a stemmed column"
+            );
+        }
+
+        // And the same corpus without the stemmer separates them, so the
+        // declaration is what changed the answer.
+        let plain = conn
+            .create_table("plain", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create plain table");
+        plain
+            .append(&build_title_batch(&[
+                "running late",
+                "she runs fast",
+                "a walk",
+            ]))
+            .expect("append");
+        let hits = plain
+            .bm25_search("title", "run", TOP_K, Bm25SearchOptions::new(), None)
+            .expect("bm25_search");
+        assert_eq!(
+            n_rows(&hits),
+            0,
+            "an unstemmed column matches the word only"
+        );
+    }
+
+    /// Stopword removal, end to end, including the consequence worth
+    /// being explicit about: once a word is not indexed, no query can
+    /// find it.
+    #[test]
+    fn stopwords_leave_the_index_and_the_query() {
+        let conn = connect("memory://").expect("connect");
+        let stopped = conn
+            .create_table(
+                "stopped",
+                schema_id_title(),
+                IndexSpec::new().fts(FtsField::new("title").stopwords(Stopwords::English)),
+            )
+            .expect("create stopped table");
+        stopped
+            .append(&build_title_batch(&["the fox and the hound", "a cat"]))
+            .expect("append");
+
+        // The content words still search normally.
+        let hits = stopped
+            .bm25_search("title", "fox", TOP_K, Bm25SearchOptions::new(), None)
+            .expect("bm25_search");
+        assert_eq!(n_rows(&hits), 1);
+
+        // A stopword leaves the query too, so a query of nothing but
+        // stopwords has no term left to match — not an error, no rows.
+        let hits = stopped
+            .bm25_search("title", "the and", TOP_K, Bm25SearchOptions::new(), None)
+            .expect("a stopword-only query is not an error");
+        assert_eq!(n_rows(&hits), 0, "nothing is left of the query to match");
+
+        // And a query mixing the two searches only what survives, so the
+        // stopword neither narrows nor widens the result.
+        let hits = stopped
+            .bm25_search("title", "the fox", TOP_K, Bm25SearchOptions::new(), None)
+            .expect("bm25_search");
+        assert_eq!(n_rows(&hits), 1);
+    }
+
+    /// The hole a removed stopword leaves is what keeps a phrase honest:
+    /// `"new york"` must not match `new the york`, and
+    /// `"end of the world"` must still match the text it came from.
+    #[test]
+    fn stopword_holes_keep_phrase_spacing_end_to_end() {
+        let conn = connect("memory://").expect("connect");
+        let table = conn
+            .create_table(
+                "phrases",
+                schema_id_title(),
+                IndexSpec::new().fts(
+                    FtsField::new("title")
+                        .stopwords(Stopwords::English)
+                        .positions(true),
+                ),
+            )
+            .expect("create table");
+        table
+            .append(&build_title_batch(&[
+                "new york city",                // 0: the words are adjacent
+                "new the york city",            // 1: a removed word sits between them
+                "the end of the world is nigh", // 2
+                "end world",                    // 3: no gap where the phrase wants one
+            ]))
+            .expect("append");
+
+        let phrase = |q: &str| -> usize {
+            n_rows(
+                &table
+                    .bm25_search("title", q, TOP_K, Bm25SearchOptions::new(), None)
+                    .expect("phrase search"),
+            )
+        };
+
+        // Adjacent in the text and adjacent in the phrase: a match. The
+        // document with a removed word between them is *not* one — its
+        // `york` sits one position further along, exactly where the hole
+        // left it.
+        assert_eq!(
+            phrase("\"new york\""),
+            1,
+            "only the text whose words are really adjacent"
+        );
+        // The query's own removed words become the spacing it asks for:
+        // `end` and `world` three positions apart, which is where the
+        // same chain put them in document 2 — and not in document 3,
+        // where they are adjacent.
+        assert_eq!(
+            phrase("\"end of the world\""),
+            1,
+            "the phrase asks for the spacing its own stopwords imply"
+        );
+        // Naming the surviving words as an adjacent phrase finds the
+        // document where they *are* adjacent, and only that one.
+        assert_eq!(phrase("\"end world\""), 1);
+    }
+
+    /// A chained column survives a reopen: the analyzer name carries the
+    /// whole chain through the catalog record, so query text is tokenized
+    /// the same way after reopening as before, and the table's
+    /// options-hash still verifies.
+    #[test]
+    fn a_chained_column_survives_reopen_on_storage() {
+        let (conn, _dir) = storage_conn();
+        {
+            let table = conn
+                .create_table(
+                    "docs",
+                    schema_id_title(),
+                    IndexSpec::new().fts(
+                        FtsField::new("title")
+                            .stopwords(Stopwords::English)
+                            .stemmer(Stemmer::English),
+                    ),
+                )
+                .expect("create_table");
+            table
+                .append(&build_title_batch(&["the running studies"]))
+                .expect("append");
+        }
+        // A fresh connection over the same root, so the spec is rebuilt
+        // from the catalog rather than reused from memory.
+        let uri = _dir.path().to_str().expect("utf8 path").to_string();
+        let reopened = connect(&uri).expect("reconnect");
+        let table = reopened.open_table("docs").expect("open_table");
+        let hits = table
+            .bm25_search(
+                "title",
+                "the studies",
+                TOP_K,
+                Bm25SearchOptions::new(),
+                None,
+            )
+            .expect("bm25_search after reopen");
+        assert_eq!(
+            n_rows(&hits),
+            1,
+            "the reopened table still stems and still drops stopwords"
+        );
+    }
+
+    /// An analyzer name naming a filter this engine does not implement is
+    /// refused at create time rather than silently approximated — the
+    /// property the composite name exists to buy.
+    #[test]
+    fn an_unimplemented_analysis_filter_is_refused() {
+        let conn = connect("memory://").expect("connect");
+        for name in [
+            "standard+stop=german",
+            "standard+stem=porter",
+            "standard+stem=english+stop=english",
+        ] {
+            let err = conn
+                .create_table(
+                    "bad",
+                    schema_id_title(),
+                    IndexSpec::new().fts(FtsField::new("title").analyzer(name)),
+                )
+                .expect_err("an unimplemented chain must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(name),
+                "the error must name the analyzer as written, got: {msg}"
+            );
+        }
     }
 
     #[test]

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1787,6 +1787,93 @@ mod tests {
         );
     }
 
+    /// The `positions` flag has to round-trip the catalog record, and
+    /// the failure is not the obvious one: the flag joins the table's
+    /// options-hash, so a record that lost it would make a positional
+    /// table fail its **own** hash check on reopen — refusing to open
+    /// at all — rather than merely forgetting how to answer a phrase.
+    #[test]
+    fn a_positional_column_reopens_and_still_answers_phrases() {
+        let (conn, dir) = storage_conn();
+        {
+            let table = conn
+                .create_table(
+                    "docs",
+                    schema_id_title(),
+                    IndexSpec::new().fts(FtsField::new("title").positions(true)),
+                )
+                .expect("create_table");
+            table
+                .append(&build_title_batch(&["new york city", "york new city"]))
+                .expect("append");
+            // The phrase works before the reopen, so a failure after it
+            // is the round-trip and not the declaration.
+            assert_eq!(
+                n_rows(
+                    &table
+                        .bm25_search(
+                            "title",
+                            "\"new york\"",
+                            TOP_K,
+                            Bm25SearchOptions::new(),
+                            None
+                        )
+                        .expect("phrase search")
+                ),
+                1
+            );
+        }
+        let uri = dir.path().to_str().expect("utf8 path").to_string();
+        let reopened = connect(&uri).expect("reconnect");
+        let table = reopened
+            .open_table("docs")
+            .expect("a positional table must reopen — losing the flag fails the options-hash");
+        assert_eq!(
+            n_rows(
+                &table
+                    .bm25_search(
+                        "title",
+                        "\"new york\"",
+                        TOP_K,
+                        Bm25SearchOptions::new(),
+                        None
+                    )
+                    .expect("phrase search after reopen")
+            ),
+            1,
+            "the reopened table still records positions"
+        );
+    }
+
+    /// The other half of exposing `positions`: a column without them
+    /// answers a phrase query with an error naming the column, never a
+    /// silent bag-of-words fallback that would return documents holding
+    /// the words in the wrong order.
+    #[test]
+    fn a_positionless_column_rejects_a_phrase_query() {
+        let conn = connect("memory://").expect("connect");
+        let table = conn
+            .create_table("docs", schema_id_title(), IndexSpec::new().fts("title"))
+            .expect("create_table");
+        table
+            .append(&build_title_batch(&["york new city"]))
+            .expect("append");
+        let err = table
+            .bm25_search(
+                "title",
+                "\"new york\"",
+                TOP_K,
+                Bm25SearchOptions::new(),
+                None,
+            )
+            .expect_err("a phrase on a positionless column must be an error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("title"),
+            "the error must name the column, got: {msg}"
+        );
+    }
+
     /// An analyzer name naming a filter this engine does not implement is
     /// refused at create time rather than silently approximated — the
     /// property the composite name exists to buy.

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1784,10 +1784,10 @@ mod tests {
         assert_eq!(phrase("\"end world\""), 1);
     }
 
-    /// A chained column survives a reopen: the analyzer name carries the
-    /// whole chain through the catalog record, so query text is tokenized
-    /// the same way after reopening as before, and the table's
-    /// options-hash still verifies.
+    /// A column with filters survives a reopen: the catalog record
+    /// carries the tokenizer and both filters, so query text is
+    /// tokenized the same way after reopening as before, and the
+    /// table's options-hash still verifies.
     #[test]
     fn a_chained_column_survives_reopen_on_storage() {
         let (conn, _dir) = storage_conn();
@@ -1915,9 +1915,57 @@ mod tests {
         );
     }
 
-    /// An unknown analyzer is refused at create time, naming what the
-    /// caller wrote. Filters are separate options now, so a
-    /// chain-shaped string is simply an analyzer name that does not
+    /// A catalog record naming a filter this engine cannot reproduce
+    /// makes the table unusable rather than usable-with-a-guess. Same
+    /// rule as the superfile entry: an *absent* filter means off, and a
+    /// *present* name that does not resolve is refused — analyzing
+    /// without the set the postings were built with is a different
+    /// index, not a degraded one.
+    #[test]
+    fn a_catalog_record_naming_an_unresolvable_filter_is_refused() {
+        for (field, bad) in [("fts_stopwords", "german"), ("fts_stemmers", "porter")] {
+            let (conn, dir) = storage_conn();
+            conn.create_table(
+                "docs",
+                schema_id_title(),
+                IndexSpec::new().fts(FtsField::new("title").stopwords(Stopwords::English)),
+            )
+            .expect("create_table");
+            // Rewrite just that column's filter name in the catalog,
+            // leaving everything else intact.
+            let path = dir.path().join(CATALOG_PATH);
+            let body = std::fs::read_to_string(&path).expect("read catalog");
+            let patched = body.replace(
+                &format!("\"{field}\":[\"english\"]"),
+                &format!("\"{field}\":[\"{bad}\"]"),
+            );
+            let patched = match patched == body {
+                // The stemmer list is empty in this fixture, so inject.
+                true => body.replace(
+                    &format!("\"{field}\":[\"\"]"),
+                    &format!("\"{field}\":[\"{bad}\"]"),
+                ),
+                false => patched,
+            };
+            assert_ne!(patched, body, "{field}: fixture did not patch");
+            std::fs::write(&path, &patched).expect("write catalog");
+
+            let uri = dir.path().to_str().expect("utf8 path").to_string();
+            let reopened = connect(&uri).expect("reconnect");
+            let err = reopened
+                .open_table("docs")
+                .expect_err("an unresolvable filter must be refused");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(bad) && msg.contains("title"),
+                "{field}: the error must name the value and the column, got: {msg}"
+            );
+        }
+    }
+
+    /// An unknown tokenizer is refused at create time, naming what the
+    /// caller wrote. The filters are separate options, so a
+    /// chain-shaped string is simply a tokenizer name that does not
     /// resolve — it must not be quietly interpreted as a chain.
     #[test]
     fn an_unknown_analyzer_is_refused_and_a_chain_shaped_name_is_not_interpreted() {

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -55,11 +55,13 @@ pub(crate) fn metric_str(metric: Metric) -> &'static str {
 /// provenance of the stored score bounds, and a server that filled in
 /// its own default would build bounds the client never asked for.
 ///
-/// `analyzer` carries a column's whole analysis chain as one canonical
-/// name (`"standard+stop=english+stem=english"`), so stopwords and
-/// stemming need no keys of their own — and a server that does not
-/// implement a filter rejects the unknown name instead of creating a
-/// table analyzed differently than the client asked for.
+/// `analyzer` names the **base** tokenizer; a stopword set and a
+/// stemmer ride as their own `stopwords` / `stemmer` keys, each emitted
+/// only when set. A server that does not implement a named filter must
+/// reject the request rather than build a table analyzed differently
+/// than the client asked for — which is the request schema's job
+/// (`additionalProperties: false`), not something an encoding trick in
+/// this client can guarantee.
 /// One BM25 parameter widened for JSON without picking up the noise of a
 /// naive `f32 as f64`: that cast is exact, so `1.2_f32` widens to
 /// `1.2000000476837158` and crosses the wire as those seventeen digits.
@@ -83,20 +85,30 @@ pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
             .zip(spec.fts_stored())
             .zip(spec.fts_bm25())
             .zip(spec.fts_positions())
-            .map(|((((column, analyzer), stored), bm25), positions)| {
-                let mut entry = serde_json::Map::new();
-                entry.insert("column".to_string(), json!(column));
-                entry.insert("analyzer".to_string(), json!(analyzer));
-                entry.insert("k1".to_string(), json!(param_as_f64(bm25.k1)));
-                entry.insert("b".to_string(), json!(param_as_f64(bm25.b)));
-                if !stored {
-                    entry.insert("stored".to_string(), json!(false));
-                }
-                if positions {
-                    entry.insert("positions".to_string(), json!(true));
-                }
-                Value::Object(entry)
-            })
+            .zip(spec.fts_stopwords())
+            .zip(spec.fts_stemmers())
+            .map(
+                |((((((column, analyzer), stored), bm25), positions), stopwords), stemmer)| {
+                    let mut entry = serde_json::Map::new();
+                    entry.insert("column".to_string(), json!(column));
+                    entry.insert("analyzer".to_string(), json!(analyzer));
+                    entry.insert("k1".to_string(), json!(param_as_f64(bm25.k1)));
+                    entry.insert("b".to_string(), json!(param_as_f64(bm25.b)));
+                    if !stored {
+                        entry.insert("stored".to_string(), json!(false));
+                    }
+                    if positions {
+                        entry.insert("positions".to_string(), json!(true));
+                    }
+                    if let Some(name) = stopwords.as_str() {
+                        entry.insert("stopwords".to_string(), json!(name));
+                    }
+                    if let Some(name) = stemmer.as_str() {
+                        entry.insert("stemmer".to_string(), json!(name));
+                    }
+                    Value::Object(entry)
+                },
+            )
             .collect();
         indexes.insert("fts".to_string(), Value::Array(fts));
     }

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -210,7 +210,7 @@ mod tests {
     use arrow_schema::{DataType, Field, FieldRef, Fields, Schema};
 
     use super::*;
-    use crate::FtsField;
+    use crate::{FtsField, Stemmer, Stopwords};
 
     #[test]
     fn index_spec_json_shape() {
@@ -225,6 +225,51 @@ mod tests {
         assert_eq!(
             json["vector"][0],
             json!({"column": "embedding", "dim": 384, "metric": "cosine"})
+        );
+    }
+
+    /// The analysis filters cross as their own keys, only when set, so
+    /// the server builds the index the client declared. A column with
+    /// no filter sends neither key, which is what keeps a default
+    /// request byte-identical to one from before the filters existed.
+    ///
+    /// A server that does not implement a named filter has to reject
+    /// the request — that is the request schema's job
+    /// (`additionalProperties: false`), which is why this client does
+    /// not smuggle the filters into the `analyzer` string to force a
+    /// rejection.
+    #[test]
+    fn index_spec_json_carries_the_analysis_filters_only_when_set() {
+        let spec = IndexSpec::new().fts(
+            FtsField::new("body")
+                .stopwords(Stopwords::English)
+                .stemmer(Stemmer::English),
+        );
+        assert_eq!(
+            index_spec_to_json(&spec)["fts"],
+            json!([{
+                "column": "body",
+                "analyzer": "standard",
+                "k1": 1.2,
+                "b": 0.75,
+                "stopwords": "english",
+                "stemmer": "english",
+            }])
+        );
+        // One filter, not both.
+        let spec = IndexSpec::new().fts(FtsField::new("body").stemmer(Stemmer::English));
+        assert_eq!(
+            index_spec_to_json(&spec)["fts"],
+            json!([{
+                "column": "body", "analyzer": "standard",
+                "k1": 1.2, "b": 0.75, "stemmer": "english",
+            }])
+        );
+        // And neither: no keys at all, not empty strings.
+        let spec = IndexSpec::new().fts("body");
+        assert_eq!(
+            index_spec_to_json(&spec)["fts"],
+            json!([{"column": "body", "analyzer": "standard", "k1": 1.2, "b": 0.75}])
         );
     }
 

--- a/src/catalog/remote/wire.rs
+++ b/src/catalog/remote/wire.rs
@@ -47,12 +47,19 @@ pub(crate) fn metric_str(metric: Metric) -> &'static str {
 /// are omitted (the server treats a missing key as "none").
 ///
 /// Each FTS entry is a `{column, analyzer, k1, b}` object — plus
-/// `stored: false` for an index-only column. The analyzer and the BM25
+/// `stored: false` for an index-only column and `positions: true` for a
+/// phrase-capable one. The analyzer and the BM25
 /// pair are always named rather than left to the server's own idea of a
 /// default, so a table is created with what this client resolved and the
 /// two can never drift apart. That matters most for the pair: it is the
 /// provenance of the stored score bounds, and a server that filled in
 /// its own default would build bounds the client never asked for.
+///
+/// `analyzer` carries a column's whole analysis chain as one canonical
+/// name (`"standard+stop=english+stem=english"`), so stopwords and
+/// stemming need no keys of their own — and a server that does not
+/// implement a filter rejects the unknown name instead of creating a
+/// table analyzed differently than the client asked for.
 /// One BM25 parameter widened for JSON without picking up the noise of a
 /// naive `f32 as f64`: that cast is exact, so `1.2_f32` widens to
 /// `1.2000000476837158` and crosses the wire as those seventeen digits.
@@ -75,7 +82,8 @@ pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
             .zip(spec.fts_analyzers())
             .zip(spec.fts_stored())
             .zip(spec.fts_bm25())
-            .map(|(((column, analyzer), stored), bm25)| {
+            .zip(spec.fts_positions())
+            .map(|((((column, analyzer), stored), bm25), positions)| {
                 let mut entry = serde_json::Map::new();
                 entry.insert("column".to_string(), json!(column));
                 entry.insert("analyzer".to_string(), json!(analyzer));
@@ -83,6 +91,9 @@ pub(crate) fn index_spec_to_json(spec: &IndexSpec) -> Value {
                 entry.insert("b".to_string(), json!(param_as_f64(bm25.b)));
                 if !stored {
                     entry.insert("stored".to_string(), json!(false));
+                }
+                if positions {
+                    entry.insert("positions".to_string(), json!(true));
                 }
                 Value::Object(entry)
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@ pub use superfile::VectorSearchOptions;
 /// Value types named by the public method signatures.
 pub use superfile::{
     fts::{
+        analysis::{Stemmer, Stopwords},
         bm25::Bm25Params,
         reader::{Bm25SearchOptions, Bm25Stats, BoolMode},
     },

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -4946,6 +4946,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn build_from_readers_analysis_chain_preserved_by_new_from_reader() {
+        // Same failure shape as the pair above, one layer nastier.
+        // `new_from_reader` rebuilds a column's analyzer from
+        // `tokenizer.name()`, and for a chained column that name is the
+        // whole chain. Drop a filter there and the merged file's
+        // postings are re-tokenized *unfiltered* while the source's
+        // were filtered — so a compaction, not any user action, would
+        // change which terms exist. (In practice the merge's own
+        // carry-compatibility check would reject the mismatch first,
+        // which turns the bug into a permanently failing background
+        // compaction rather than wrong answers — still a bug, and one
+        // nothing else here would catch.)
+        let chain = "standard+stop=english+stem=english";
+        let opts = BuilderOptions::new(
+            schema_with_fts(),
+            "doc_id",
+            vec![FtsConfig::new("title").analyzer(chain).positions(true)],
+            vec![],
+        );
+        let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+        let schema = b.opts.schema.clone();
+        b.add_batch(&batch_two_rows(&schema), &[])
+            .expect("add_batch");
+        let source_bytes = b.finish().expect("finish builder");
+
+        let reader = SuperfileReader::open(Bytes::from(source_bytes)).expect("open reader");
+        let source_cfg = reader
+            .fts()
+            .expect("fts index")
+            .fts_columns_config()
+            .next()
+            .expect("has column");
+        assert_eq!(source_cfg.tokenizer.name(), chain);
+        assert!(source_cfg.positions, "positions must reach the built file");
+
+        let (merged_bytes, _stats) =
+            SuperfileBuilder::build_from_readers(&[(Arc::new(reader), empty_bitmap())])
+                .expect("build_from_readers");
+        let merged = SuperfileReader::open(Bytes::from(merged_bytes)).expect("open merged");
+        let merged_cfg = merged
+            .fts()
+            .expect("fts index")
+            .fts_columns_config()
+            .next()
+            .expect("has column");
+        assert_eq!(
+            merged_cfg.tokenizer.name(),
+            chain,
+            "the analysis chain must survive a rebuild, or compaction \
+             silently re-tokenizes the column"
+        );
+        assert!(
+            merged_cfg.positions,
+            "the positions flag must survive a rebuild too"
+        );
+    }
+
+    #[tokio::test]
     async fn build_from_readers_fp32_codec_preserved_by_new_from_reader() {
         // new_from_reader previously omitted .with_rerank_codec, so an Fp32 source
         // produced a Sq8 merged output.  After the fix the codec round-trips exactly.

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -96,10 +96,11 @@ use crate::superfile::{
         kv,
     },
     fts::{
+        analysis::{Base, Stemmer, Stopwords, chain_name, chain_tokenizer},
         bm25,
         builder::FtsBuilder,
         reader::ColumnMeta,
-        tokenize::{AsciiLowerTokenizer, STANDARD_TOKENIZER, tokenizer_for_name},
+        tokenize::{AsciiLowerTokenizer, STANDARD_TOKENIZER},
     },
     stats::SuperfileStats,
     vector::{
@@ -130,12 +131,24 @@ use crate::superfile::{
 #[derive(Debug, Clone)]
 pub struct FtsConfig {
     pub column: String,
-    /// Analyzer (tokenizer) name applied to this column —
+    /// **Base** analyzer (tokenizer) name applied to this column —
     /// `"standard"` (the default) or `"ascii_lower"`. Resolved to a
-    /// tokenizer instance once, at builder construction; an unknown
+    /// tokenizer instance once, at builder construction, together with
+    /// [`FtsConfig::stopwords`] and [`FtsConfig::stemmer`]; an unknown
     /// name is a build error. Per column: each FTS column is tokenized
     /// with its own analyzer, so columns in one table may differ.
     pub analyzer: String,
+    /// Stopword set removed after the base tokenizer and before the
+    /// stemmer. Persisted in the column's `inf.fts.columns` entry as
+    /// `"stopwords"`, emitted only when set — so a column with no
+    /// stopwords keeps an entry byte-identical to one written before
+    /// the filter existed, and a reader of such an entry correctly
+    /// infers that no set was applied.
+    pub stopwords: Stopwords,
+    /// Stemmer applied to what survives the stopword set. Persisted as
+    /// `"stemmer"` under the same only-when-set rule as
+    /// [`FtsConfig::stopwords`].
+    pub stemmer: Stemmer,
     /// Record token positions for this column, enabling exact phrase
     /// queries against it. Off by default: positions roughly double
     /// the column's FTS index footprint, so the cost is a per-column
@@ -174,6 +187,8 @@ impl FtsConfig {
         Self {
             column: column.into(),
             analyzer: STANDARD_TOKENIZER.to_string(),
+            stopwords: Stopwords::None,
+            stemmer: Stemmer::None,
             positions: false,
             stored: true,
             bm25: bm25::Bm25Params::STANDARD,
@@ -184,6 +199,25 @@ impl FtsConfig {
     pub fn analyzer(mut self, name: impl Into<String>) -> Self {
         self.analyzer = name.into();
         self
+    }
+
+    /// Set the stopword set (see the field docs).
+    pub fn stopwords(mut self, stopwords: Stopwords) -> Self {
+        self.stopwords = stopwords;
+        self
+    }
+
+    /// Set the stemmer (see the field docs).
+    pub fn stemmer(mut self, stemmer: Stemmer) -> Self {
+        self.stemmer = stemmer;
+        self
+    }
+
+    /// This column's analysis as one derived identity string — the
+    /// value [`Tokenizer::name`] reports for its tokenizer. Never
+    /// persisted; see [`crate::superfile::fts::analysis`].
+    pub(crate) fn chain_name(&self) -> Option<&'static str> {
+        Base::from_name(&self.analyzer).map(|b| chain_name(b, self.stopwords, self.stemmer))
     }
 
     /// Record token positions (see the field docs).
@@ -398,10 +432,13 @@ impl BuilderOptions {
     }
 
     pub fn new_from_reader(reader: &SuperfileReader) -> Self {
-        // Recover each FTS column's analyzer from the source reader so a
-        // rebuild carries the analyzer the postings were built with. This
-        // is why an existing table keeps its recorded analyzer through
-        // compaction and optimize no matter what the engine's default is.
+        // Recover each FTS column's whole analysis chain from the source
+        // reader — base tokenizer *and* both filters — so a rebuild
+        // carries the analysis the postings were built with. This is why
+        // an existing table keeps its recorded analyzer through
+        // compaction and optimize no matter what the engine's default
+        // is; dropping a filter here would re-tokenize the merged file's
+        // postings unfiltered.
         //
         // The BM25 pair rides along for the same reason and with a sharper
         // consequence: dropping it here would rebake the merged file's
@@ -413,7 +450,9 @@ impl BuilderOptions {
             fts.fts_columns_config()
                 .map(|c| {
                     FtsConfig::new(c.name.clone())
-                        .analyzer(c.tokenizer.name())
+                        .analyzer(c.base.name())
+                        .stopwords(c.stopwords)
+                        .stemmer(c.stemmer)
                         .positions(c.positions)
                         .stored(c.stored)
                         .bm25(c.params.k1, c.params.b)
@@ -498,11 +537,16 @@ impl BuilderOptions {
                     own.column, other.name
                 )));
             }
-            let other_analyzer = other.tokenizer.name();
-            if own.analyzer != other_analyzer {
+            // Compare the whole analysis, not the base name: two columns
+            // sharing a base but differing in a filter hold different
+            // terms, so carrying one's postings into the other silently
+            // mixes two tokenizations.
+            let own_analysis = own.chain_name().unwrap_or(own.analyzer.as_str());
+            let other_analysis = other.tokenizer.name();
+            if own_analysis != other_analysis {
                 return Err(BuildError::FTSSchemaMismatch(format!(
                     "column {}: mismatched analyzer. self {} vs other {}",
-                    own.column, own.analyzer, other_analyzer
+                    own.column, own_analysis, other_analysis
                 )));
             }
             if own.positions != other.positions {
@@ -728,12 +772,16 @@ impl SuperfileBuilder {
             // column below registers its own analyzer explicitly.
             let mut fb = FtsBuilder::new(Arc::new(AsciiLowerTokenizer));
             for fc in &opts.fts_columns {
-                let tok = tokenizer_for_name(&fc.analyzer).ok_or_else(|| {
-                    BuildError::UnknownAnalyzer {
+                // The whole chain, not just the base: a column that
+                // declares a stopword set or a stemmer must be indexed
+                // through them, or the postings would hold unfiltered
+                // terms while every query filtered.
+                let base =
+                    Base::from_name(&fc.analyzer).ok_or_else(|| BuildError::UnknownAnalyzer {
                         column: fc.column.clone(),
                         analyzer: fc.analyzer.clone(),
-                    }
-                })?;
+                    })?;
+                let tok = chain_tokenizer(base, fc.stopwords, fc.stemmer);
                 fb.register_column_with_tokenizer(fc.column.clone(), fc.positions, tok, fc.bm25)?;
             }
             Some(fb)
@@ -2315,10 +2363,13 @@ fn check_user_column_name(name: &str) -> Result<(), BuildError> {
 ///
 /// Output shape per column:
 /// `{"name":"<escaped>","tokenizer":"<name>","k1":<f>,"b":<f>}`.
-/// `tokenizer` is that column's analyzer name (`"ascii_lower"` or
-/// `"standard"`), straight from `FtsConfig.analyzer` — the reader
-/// reconstructs the matching tokenizer from it for query-time
-/// tokenization.
+/// `tokenizer` is that column's **base** analyzer name (`"ascii_lower"`
+/// or `"standard"`), straight from `FtsConfig.analyzer`. A stopword set
+/// and a stemmer ride as `"stopwords"` / `"stemmer"`, each emitted only
+/// when set; the reader reconstructs the column's tokenizer from all
+/// three for query-time tokenization, and a missing filter field means
+/// the filter is off — the one thing a file written before it existed
+/// can mean.
 ///
 /// `k1` / `b` are written **unconditionally, defaults included**,
 /// unlike `positions` and `stored`. Those two are booleans whose
@@ -2356,6 +2407,21 @@ fn fts_columns_json(cols: &[FtsConfig]) -> String {
         s.push_str(&fts_param_json(c.bm25.k1));
         s.push_str(r#","b":"#);
         s.push_str(&fts_param_json(c.bm25.b));
+        // Analysis filters, each emitted only when set, so a column
+        // with neither keeps JSON byte-identical to a file written
+        // before they existed. A reader that does not know the field
+        // treats the filter as off, which degrades that column's
+        // results rather than making the file unreadable.
+        if let Some(name) = c.stopwords.as_str() {
+            s.push_str(r#","stopwords":""#);
+            s.push_str(name);
+            s.push('"');
+        }
+        if let Some(name) = c.stemmer.as_str() {
+            s.push_str(r#","stemmer":""#);
+            s.push_str(name);
+            s.push('"');
+        }
         // Emitted only when set: a positionless column's JSON stays
         // byte-identical to files written before positions existed
         // (the reader defaults a missing field to false).
@@ -4958,13 +5024,19 @@ mod tests {
         // which turns the bug into a permanently failing background
         // compaction rather than wrong answers — still a bug, and one
         // nothing else here would catch.)
-        let chain = "standard+stop=english+stem=english";
         let opts = BuilderOptions::new(
             schema_with_fts(),
             "doc_id",
-            vec![FtsConfig::new("title").analyzer(chain).positions(true)],
+            vec![
+                FtsConfig::new("title")
+                    .stopwords(Stopwords::English)
+                    .stemmer(Stemmer::English)
+                    .positions(true),
+            ],
             vec![],
         );
+        // The derived identity the reader will report for that column.
+        let chain = chain_name(Base::Standard, Stopwords::English, Stemmer::English);
         let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
         let schema = b.opts.schema.clone();
         b.add_batch(&batch_two_rows(&schema), &[])
@@ -4979,6 +5051,8 @@ mod tests {
             .next()
             .expect("has column");
         assert_eq!(source_cfg.tokenizer.name(), chain);
+        assert_eq!(source_cfg.stopwords, Stopwords::English);
+        assert_eq!(source_cfg.stemmer, Stemmer::English);
         assert!(source_cfg.positions, "positions must reach the built file");
 
         let (merged_bytes, _stats) =
@@ -4996,6 +5070,12 @@ mod tests {
             chain,
             "the analysis chain must survive a rebuild, or compaction \
              silently re-tokenizes the column"
+        );
+        assert_eq!(
+            (merged_cfg.stopwords, merged_cfg.stemmer),
+            (Stopwords::English, Stemmer::English),
+            "the filter components must survive too — the derived name is \
+             not something a rebuild can parse back"
         );
         assert!(
             merged_cfg.positions,

--- a/src/superfile/builder.rs
+++ b/src/superfile/builder.rs
@@ -2363,8 +2363,10 @@ fn check_user_column_name(name: &str) -> Result<(), BuildError> {
 ///
 /// Output shape per column:
 /// `{"name":"<escaped>","tokenizer":"<name>","k1":<f>,"b":<f>}`.
-/// `tokenizer` is that column's **base** analyzer name (`"ascii_lower"`
-/// or `"standard"`), straight from `FtsConfig.analyzer`. A stopword set
+/// `tokenizer` holds the column's base tokenizer name (`"ascii_lower"`
+/// or `"standard"`), straight from `FtsConfig.analyzer` — whose field
+/// name says `analyzer` only because that is what the public option is
+/// called. A stopword set
 /// and a stemmer ride as `"stopwords"` / `"stemmer"`, each emitted only
 /// when set; the reader reconstructs the column's tokenizer from all
 /// three for query-time tokenization, and a missing filter field means

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -34,9 +34,9 @@ pub enum BuildError {
     DuplicateColumnName(String),
 
     #[error(
-        "FTS column {column:?}: unknown analyzer {analyzer:?} (a base \
-         analyzer, \"standard\" or \"ascii_lower\", optionally followed \
-         by \"+stop=english\" and then \"+stem=english\")"
+        "FTS column {column:?}: unknown analyzer {analyzer:?} (valid: \
+         \"standard\", \"ascii_lower\"; stopwords and stemming are \
+         separate options, not part of this name)"
     )]
     UnknownAnalyzer { column: String, analyzer: String },
 

--- a/src/superfile/error.rs
+++ b/src/superfile/error.rs
@@ -34,8 +34,9 @@ pub enum BuildError {
     DuplicateColumnName(String),
 
     #[error(
-        "FTS column {column:?}: unknown analyzer {analyzer:?} (valid: \
-         \"ascii_lower\", \"standard\")"
+        "FTS column {column:?}: unknown analyzer {analyzer:?} (a base \
+         analyzer, \"standard\" or \"ascii_lower\", optionally followed \
+         by \"+stop=english\" and then \"+stem=english\")"
     )]
     UnknownAnalyzer { column: String, analyzer: String },
 

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -12,47 +12,9 @@ pub mod footer;
 pub const PROJECT_MAGIC: &[u8; 3] = b"INF";
 
 /// File-format version. Semver string. Bump major to break compatibility.
-///
-/// A minor is for a change a same-major reader could not otherwise
-/// tolerate — and by [`Version::is_compatible_with_current`]'s
-/// policy (unknown KV keys ignored, unknown JSON fields ignored) an
-/// additive field is already tolerated, so most additions do not earn
-/// one. What they do earn is a note here, because this doc-comment is
-/// the only written record of what a `1.x` superfile may contain.
-///
 /// 1.1.0: `inf.fts.columns` entries may carry `"stored":false` (index-only
 /// FTS columns, absent from the Parquet body); the field is emitted only
 /// when false, and same-major readers default a missing field to true.
-///
-/// Since 1.1.0, additively, a column entry may also carry:
-///
-/// - `"positions":true` — the column's index records token positions,
-///   which exact phrase queries need. Emitted only when true; a missing
-///   field means no positions, the only thing a file predating it can
-///   mean.
-/// - `"k1"` / `"b"` — the BM25 parameters a column's stored block-max
-///   bounds were baked at, written **unconditionally**, defaults
-///   included, because the pair is the provenance of those bounds and a
-///   reader that infers it will infer wrong the day the recommended
-///   default moves. An entry without them predates the field and can
-///   only have been built at the standard `1.2` / `0.75`, so that
-///   default is **frozen** and must not follow a later change to what
-///   the API recommends.
-/// - `"stopwords"` / `"stemmer"` — the analysis filters applied to the
-///   column, by name, each emitted only when set. Absent means the
-///   filter is off, which is the one thing a file written before it
-///   existed can mean, so a reader needs no guess. A reader that does
-///   not know the field at all treats the column as unfiltered, which
-///   costs that column's results until it rolls forward — the same
-///   trade taken for `k1` / `b`, and preferred over a marker that would
-///   make the file unopenable, because a lost-recall regression is
-///   recoverable and an unopenable table is an outage.
-///
-/// What is *not* ignorable is an unrecognized **value** of a field a
-/// reader does know — `"stopwords":"german"` on an engine shipping no
-/// German list. That fails the open, because there is no sound way to
-/// proceed: analyzing without a set the postings were built with is a
-/// different index, not a degraded one.
 pub const FORMAT_VERSION: &str = "1.1.0";
 
 /// CRC width in bytes (`u32` CRC-32C, little-endian) appended after a

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -38,21 +38,21 @@ pub const PROJECT_MAGIC: &[u8; 3] = b"INF";
 ///   only have been built at the standard `1.2` / `0.75`, so that
 ///   default is **frozen** and must not follow a later change to what
 ///   the API recommends.
+/// - `"stopwords"` / `"stemmer"` — the analysis filters applied to the
+///   column, by name, each emitted only when set. Absent means the
+///   filter is off, which is the one thing a file written before it
+///   existed can mean, so a reader needs no guess. A reader that does
+///   not know the field at all treats the column as unfiltered, which
+///   costs that column's results until it rolls forward — the same
+///   trade taken for `k1` / `b`, and preferred over a marker that would
+///   make the file unopenable, because a lost-recall regression is
+///   recoverable and an unopenable table is an outage.
 ///
-/// The one change since 1.1.0 that is *not* additive-and-ignorable, and
-/// deliberately so: a column's `"tokenizer"` may name an analysis chain
-/// rather than a bare tokenizer — a base name followed by the filters
-/// applied to it, `"standard+stop=english+stem=english"`. A filter
-/// could not have been a sibling field, because a same-major reader
-/// ignores an unknown field and an ignored analysis filter means query
-/// text is tokenized differently than the postings were built, which is
-/// wrong answers rather than an error. Nor does it take a version of
-/// its own: the tokenizer name is already the fail-loud channel every
-/// shipped reader honours — an unrecognized name fails the open — so an
-/// engine predating a filter refuses the file on the name alone, and a
-/// version bump would add nothing a reader consults. A column with no
-/// filter keeps its plain base name, so its entry stays byte-identical
-/// to one written before chains existed.
+/// What is *not* ignorable is an unrecognized **value** of a field a
+/// reader does know — `"stopwords":"german"` on an engine shipping no
+/// German list. That fails the open, because there is no sound way to
+/// proceed: analyzing without a set the postings were built with is a
+/// different index, not a degraded one.
 pub const FORMAT_VERSION: &str = "1.1.0";
 
 /// CRC width in bytes (`u32` CRC-32C, little-endian) appended after a

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -13,28 +13,47 @@ pub const PROJECT_MAGIC: &[u8; 3] = b"INF";
 
 /// File-format version. Semver string. Bump major to break compatibility.
 ///
+/// A minor is for a change a same-major reader could not otherwise
+/// tolerate — and by [`Version::is_compatible_with_current`]'s
+/// policy (unknown KV keys ignored, unknown JSON fields ignored) an
+/// additive field is already tolerated, so most additions do not earn
+/// one. What they do earn is a note here, because this doc-comment is
+/// the only written record of what a `1.x` superfile may contain.
+///
 /// 1.1.0: `inf.fts.columns` entries may carry `"stored":false` (index-only
 /// FTS columns, absent from the Parquet body); the field is emitted only
 /// when false, and same-major readers default a missing field to true.
 ///
-/// 1.2.0: `inf.fts.columns` entries carry `"k1"` / `"b"`, the BM25
-/// parameters a column's stored block-max bounds were baked at, written
-/// unconditionally. An entry without them predates the field and can
-/// only have been built at the standard `1.2` / `0.75`, so that default
-/// is **frozen** and must not follow a later change to what the API
-/// recommends.
+/// Since 1.1.0, additively, a column entry may also carry:
 ///
-/// 1.3.0: a column's `"tokenizer"` may name an analysis chain rather
-/// than a bare tokenizer — a base name followed by the filters applied
-/// to it, `"standard+stop=english+stem=english"`. Deliberately *not* an
-/// additive field: a same-major reader ignores an unknown field, and an
-/// ignored analysis filter means query text is tokenized differently
-/// than the postings were built, which is wrong answers rather than an
-/// error. The tokenizer name is instead the fail-loud channel every
-/// shipped reader already honours — an unrecognized name fails the open
-/// — so an engine predating a filter refuses the file. A column with no
-/// filter keeps its plain base name, so its entry stays byte-identical.
-pub const FORMAT_VERSION: &str = "1.3.0";
+/// - `"positions":true` — the column's index records token positions,
+///   which exact phrase queries need. Emitted only when true; a missing
+///   field means no positions, the only thing a file predating it can
+///   mean.
+/// - `"k1"` / `"b"` — the BM25 parameters a column's stored block-max
+///   bounds were baked at, written **unconditionally**, defaults
+///   included, because the pair is the provenance of those bounds and a
+///   reader that infers it will infer wrong the day the recommended
+///   default moves. An entry without them predates the field and can
+///   only have been built at the standard `1.2` / `0.75`, so that
+///   default is **frozen** and must not follow a later change to what
+///   the API recommends.
+///
+/// The one change since 1.1.0 that is *not* additive-and-ignorable, and
+/// deliberately so: a column's `"tokenizer"` may name an analysis chain
+/// rather than a bare tokenizer — a base name followed by the filters
+/// applied to it, `"standard+stop=english+stem=english"`. A filter
+/// could not have been a sibling field, because a same-major reader
+/// ignores an unknown field and an ignored analysis filter means query
+/// text is tokenized differently than the postings were built, which is
+/// wrong answers rather than an error. Nor does it take a version of
+/// its own: the tokenizer name is already the fail-loud channel every
+/// shipped reader honours — an unrecognized name fails the open — so an
+/// engine predating a filter refuses the file on the name alone, and a
+/// version bump would add nothing a reader consults. A column with no
+/// filter keeps its plain base name, so its entry stays byte-identical
+/// to one written before chains existed.
+pub const FORMAT_VERSION: &str = "1.1.0";
 
 /// CRC width in bytes (`u32` CRC-32C, little-endian) appended after a
 /// directory or after a subsection's payload. Defined once so the

--- a/src/superfile/format/mod.rs
+++ b/src/superfile/format/mod.rs
@@ -12,10 +12,29 @@ pub mod footer;
 pub const PROJECT_MAGIC: &[u8; 3] = b"INF";
 
 /// File-format version. Semver string. Bump major to break compatibility.
+///
 /// 1.1.0: `inf.fts.columns` entries may carry `"stored":false` (index-only
 /// FTS columns, absent from the Parquet body); the field is emitted only
 /// when false, and same-major readers default a missing field to true.
-pub const FORMAT_VERSION: &str = "1.1.0";
+///
+/// 1.2.0: `inf.fts.columns` entries carry `"k1"` / `"b"`, the BM25
+/// parameters a column's stored block-max bounds were baked at, written
+/// unconditionally. An entry without them predates the field and can
+/// only have been built at the standard `1.2` / `0.75`, so that default
+/// is **frozen** and must not follow a later change to what the API
+/// recommends.
+///
+/// 1.3.0: a column's `"tokenizer"` may name an analysis chain rather
+/// than a bare tokenizer — a base name followed by the filters applied
+/// to it, `"standard+stop=english+stem=english"`. Deliberately *not* an
+/// additive field: a same-major reader ignores an unknown field, and an
+/// ignored analysis filter means query text is tokenized differently
+/// than the postings were built, which is wrong answers rather than an
+/// error. The tokenizer name is instead the fail-loud channel every
+/// shipped reader already honours — an unrecognized name fails the open
+/// — so an engine predating a filter refuses the file. A column with no
+/// filter keeps its plain base name, so its entry stays byte-identical.
+pub const FORMAT_VERSION: &str = "1.3.0";
 
 /// CRC width in bytes (`u32` CRC-32C, little-endian) appended after a
 /// directory or after a subsection's payload. Defined once so the

--- a/src/superfile/fts/analysis.rs
+++ b/src/superfile/fts/analysis.rs
@@ -7,11 +7,34 @@
 //! ## Shape
 //!
 //! One base tokenizer ([`AsciiLowerTokenizer`] or
-//! [`StandardTokenizer`]) followed by up to two token filters, applied
-//! in the order Lucene's `EnglishAnalyzer` applies them: stopwords are
-//! removed from the *unstemmed* token, then what survives is stemmed.
-//! The order is not configurable and is baked into the chain's name, so
-//! there is exactly one canonical spelling per chain.
+//! [`StandardTokenizer`]) followed by up to two token filters:
+//! stopwords are removed from the *unstemmed* token, then what
+//! survives is stemmed. The order is not configurable and is baked
+//! into the chain's name, so there is exactly one canonical spelling
+//! per chain.
+//!
+//! Stopwords have to precede stemming because a stopword list is
+//! written in surface forms — `are`, `their`, `these` — and stemming
+//! first would leave the list matching neither those nor their stems
+//! reliably. It is also the order every filter-chain analyzer applies
+//! them in.
+//!
+//! ## Every filter here is opt-in, and the default is untouched
+//!
+//! A column that declares no filter is not wrapped at all
+//! ([`chain_tokenizer`] hands back the bare base tokenizer), keeps its
+//! plain analyzer name, and takes the same monomorphized ingest scan
+//! it always did. So the default column is byte-identical and
+//! code-path-identical to one declared before chains existed.
+//!
+//! That matters because the default is the parity surface, and it is
+//! not this module's to move. `standard` — tokenize and lowercase,
+//! no stopwords, no stemming — is what Lucene's default analyzer does:
+//! `IndexWriterConfig` defaults to `StandardAnalyzer`, whose no-arg
+//! constructor is documented as "builds an analyzer with no stop
+//! words" and which never stemmed. Anything that closes a remaining
+//! gap in `standard` itself belongs to the tokenizer and the scorer,
+//! not here; this module only adds filters a caller asks for by name.
 //!
 //! ## The chain is its name
 //!

--- a/src/superfile/fts/analysis.rs
+++ b/src/superfile/fts/analysis.rs
@@ -1,0 +1,587 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! The per-column analysis chain: a base tokenizer plus optional
+//! stopword removal and stemming, in that order.
+//!
+//! ## Shape
+//!
+//! One base tokenizer ([`AsciiLowerTokenizer`] or
+//! [`StandardTokenizer`]) followed by up to two token filters, applied
+//! in the order Lucene's `EnglishAnalyzer` applies them: stopwords are
+//! removed from the *unstemmed* token, then what survives is stemmed.
+//! The order is not configurable and is baked into the chain's name, so
+//! there is exactly one canonical spelling per chain.
+//!
+//! ## The chain is its name
+//!
+//! A chain persists as one composite analyzer name —
+//! `"standard+stop=english+stem=english"` — and nothing else. That is a
+//! deliberate choice over a sibling `"stemmer"` field in
+//! `inf.fts.columns`: an older reader *ignores* an unknown JSON field,
+//! and an ignored analysis filter means the reader tokenizes queries
+//! differently than the index was built, which is wrong answers rather
+//! than an error. The analyzer name is the one channel already shipped
+//! readers fail loud on — [`tokenizer_for_name`] returning `None` is an
+//! open error at every call site — so routing the whole chain through
+//! it makes an engine that predates a filter refuse the file instead of
+//! mis-ranking it.
+//!
+//! Carrying the chain in the name also means nothing else has to learn
+//! about it. The name is already what the catalog record
+//! (`TableEntry::fts_analyzers`), the remote create-table wire and the
+//! options-hash's `fts_analyzers` block carry, so a chained column
+//! rides all three unchanged, and a plain column's bytes stay
+//! byte-identical to today's in every one of them.
+//!
+//! Because the built-in sets are a closed set (no user-supplied word
+//! lists — those would need a sibling field and would give the name
+//! back its ambiguity), the reachable names are a finite table, which
+//! is what lets [`Tokenizer::name`] keep returning `&'static str`.
+//!
+//! ## Positions
+//!
+//! Stopword removal leaves a **hole**: the position ordinal a removed
+//! token would have occupied is skipped, so the tokens on either side
+//! of it are not adjacent. Without that, `"new york"` would phrase-match
+//! `"new the york"`. Holes reach the index through
+//! [`Tokenizer::tokenize_each_positioned`] and the query through
+//! [`ParsedQuery`]'s per-phrase offsets.
+//!
+//! Doc length counts the tokens the chain *emits*, which is what Lucene
+//! counts (`IndexingChain.PerField.invert` bumps `invertState.length`
+//! inside the `incrementToken` loop, so a token `StopFilter` dropped
+//! never reaches it) and what the carried postings of a merge preserve.
+
+use std::{any::Any, borrow::Cow, sync::Arc};
+
+use rust_stemmers::{Algorithm, Stemmer as Snowball};
+
+use super::tokenize::{
+    ASCII_LOWER_TOKENIZER, AsciiLowerTokenizer, STANDARD_TOKENIZER, StandardTokenizer, Tokenizer,
+};
+
+/// Stopword set applied to a column, after the base tokenizer and
+/// before the stemmer.
+///
+/// Named built-ins only. A user-supplied word list would have to
+/// persist beside the analyzer name, which is exactly the
+/// additive-and-ignorable shape the composite name exists to avoid; the
+/// extension path stays open as a future `+stop=custom` name whose
+/// sibling word list an older engine rejects on the unknown name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Stopwords {
+    /// Keep every token (the default).
+    #[default]
+    None,
+    /// Lucene's `EnglishAnalyzer.ENGLISH_STOP_WORDS_SET` — the 33-word
+    /// Snowball English list. See [`ENGLISH_STOPWORDS`].
+    English,
+}
+
+/// Stemmer applied to a column, after stopword removal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Stemmer {
+    /// Index tokens as written (the default).
+    #[default]
+    None,
+    /// Snowball English (Porter2), via `rust-stemmers`.
+    ///
+    /// Named `english` rather than `porter` in both the API and the
+    /// persisted name because the two are different algorithms:
+    /// Snowball's `english` *is* Porter2, whereas Lucene's
+    /// `PorterStemFilter` is the original Porter. Spelling this
+    /// `porter` would name the wrong one.
+    English,
+}
+
+/// Lucene's English stopword set (`EnglishAnalyzer.ENGLISH_STOP_WORDS_SET`),
+/// **sorted** so [`Stopwords::contains`] can binary-search it.
+///
+/// Sorted-slice + binary search rather than a hash set: 33 short words
+/// are searched in ~5 comparisons with no hashing and no lazy-init, and
+/// the length pre-filter below rejects most corpus tokens before the
+/// search runs at all.
+pub const ENGLISH_STOPWORDS: &[&str] = &[
+    "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it",
+    "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there", "these",
+    "they", "this", "to", "was", "will", "with",
+];
+
+/// Longest word in [`ENGLISH_STOPWORDS`]. A token longer than this
+/// cannot be a stopword, so one integer compare rejects the great
+/// majority of corpus tokens before any string work.
+const ENGLISH_STOPWORD_MAX_LEN: usize = 5;
+
+impl Stopwords {
+    /// Whether `token` — already lowercased by the base tokenizer, and
+    /// not yet stemmed — is in this set.
+    #[inline]
+    fn contains(self, token: &str) -> bool {
+        match self {
+            Stopwords::None => false,
+            Stopwords::English => {
+                token.len() <= ENGLISH_STOPWORD_MAX_LEN
+                    && ENGLISH_STOPWORDS.binary_search(&token).is_ok()
+            }
+        }
+    }
+}
+
+/// The base tokenizer a chain is built on — the two shipped analyzers,
+/// as a closed enum so the chain can call each one's monomorphized
+/// inherent scan instead of dispatching through `dyn Tokenizer` per
+/// token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Base {
+    /// [`AsciiLowerTokenizer`].
+    AsciiLower,
+    /// [`StandardTokenizer`].
+    Standard,
+}
+
+impl Base {
+    /// This base's own plain analyzer name — the chain name with no
+    /// filters.
+    pub(crate) fn name(self) -> &'static str {
+        chain_name(self, Stopwords::None, Stemmer::None)
+    }
+
+    /// Resolve a base analyzer name. Rejects a composite name; use
+    /// [`parse_chain_name`] for one of those.
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        match name {
+            ASCII_LOWER_TOKENIZER => Some(Base::AsciiLower),
+            STANDARD_TOKENIZER => Some(Base::Standard),
+            _ => None,
+        }
+    }
+
+    /// Scan `text` into `(token, position)` pairs where `position` is
+    /// the **gap-inclusive** ordinal: a run the base tokenizer itself
+    /// drops (`ascii_lower`'s non-ASCII rule) still consumes one.
+    ///
+    /// Monomorphized over `F` for the same reason the base tokenizers'
+    /// own `tokenize_each_inline` methods are: the ingest path's
+    /// interning closure has to inline into the scan loop.
+    #[inline]
+    fn scan_positioned<F: FnMut(&str, u64)>(self, text: &str, mut f: F) {
+        match self {
+            Base::AsciiLower => AsciiLowerTokenizer.tokenize_each_inline_positioned(text, f),
+            // `standard` drops nothing — every segment carrying an
+            // alphanumeric is emitted — so its emission ordinal is
+            // already the gap-inclusive position.
+            Base::Standard => {
+                let mut position = 0u64;
+                StandardTokenizer.tokenize_each_inline(text, |tok| {
+                    f(tok, position);
+                    position += 1;
+                });
+            }
+        }
+    }
+}
+
+/// A base tokenizer plus its stopword set and stemmer.
+///
+/// Constructed only through [`chain_tokenizer`] / [`tokenizer_for_name`],
+/// so a `ChainTokenizer` always carries at least one active filter — a
+/// chain with neither is the base tokenizer itself, under the base's own
+/// plain name, and must not be wrapped (wrapping it would change the
+/// persisted name and give up the base's downcast fast path for nothing).
+pub struct ChainTokenizer {
+    base: Base,
+    stopwords: Stopwords,
+    /// This chain's canonical composite name, from the static table in
+    /// [`chain_name`] — which is what keeps [`Tokenizer::name`] able to
+    /// return `&'static str`.
+    name: &'static str,
+    /// The Snowball stemmer, built once at construction.
+    /// `None` for [`Stemmer::None`].
+    snowball: Option<Snowball>,
+}
+
+// `rust_stemmers::Stemmer` holds a function pointer and no interior
+// mutability, so the chain is as shareable as the trait requires. Assert
+// it here rather than discovering it as an `impl Tokenizer` error.
+static_assertions::assert_impl_all!(Snowball: Send, Sync);
+
+impl std::fmt::Debug for ChainTokenizer {
+    /// Hand-written because `rust_stemmers::Stemmer` is not `Debug`.
+    /// Prints the canonical name, which determines every field.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChainTokenizer")
+            .field("name", &self.name)
+            .finish()
+    }
+}
+
+impl ChainTokenizer {
+    /// Apply the filter chain to one base token: `None` when the
+    /// stopword set removes it, otherwise the token to index (stemmed,
+    /// if a stemmer is configured).
+    ///
+    /// Borrowed when no stemmer runs or the stemmer returns its input
+    /// unchanged, which is the common case for already-stemmed forms.
+    #[inline]
+    fn filter<'t>(&self, token: &'t str) -> Option<Cow<'t, str>> {
+        if self.stopwords.contains(token) {
+            return None;
+        }
+        match &self.snowball {
+            None => Some(Cow::Borrowed(token)),
+            Some(s) => Some(s.stem(token)),
+        }
+    }
+
+    /// Monomorphized positional scan: `(token, position)` per emitted
+    /// token, where `position` is the gap-inclusive ordinal. A token the
+    /// stopword filter removes advances the ordinal without emitting —
+    /// the phrase hole.
+    ///
+    /// Same role as [`AsciiLowerTokenizer::tokenize_each_inline_positioned`],
+    /// and reached the same way: the FTS build path downcasts through
+    /// [`Tokenizer::as_any`] so the interning closure inlines into the
+    /// scan instead of paying an indirect call per token.
+    #[inline]
+    pub fn tokenize_each_inline_positioned<F: FnMut(&str, u64)>(&self, text: &str, mut f: F) {
+        self.base.scan_positioned(text, |tok, position| {
+            if let Some(t) = self.filter(tok) {
+                f(&t, position);
+            }
+        });
+    }
+
+    /// Monomorphized positionless scan — the same tokens
+    /// [`Self::tokenize_each_inline_positioned`] emits, with the
+    /// ordinal discarded, so the two can never disagree about which
+    /// tokens exist.
+    #[inline]
+    pub fn tokenize_each_inline<F: FnMut(&str)>(&self, text: &str, mut f: F) {
+        self.tokenize_each_inline_positioned(text, |tok, _position| f(tok));
+    }
+}
+
+impl Tokenizer for ChainTokenizer {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn tokenize<'a>(&'a self, text: &'a str) -> Box<dyn Iterator<Item = String> + 'a> {
+        let mut out = Vec::new();
+        self.tokenize_each_inline(text, |t| out.push(t.to_owned()));
+        Box::new(out.into_iter())
+    }
+
+    fn tokenize_each(&self, text: &str, f: &mut dyn FnMut(&str)) {
+        self.tokenize_each_inline(text, |t| f(t));
+    }
+
+    fn tokenize_each_positioned(&self, text: &str, f: &mut dyn FnMut(&str, u64)) {
+        self.tokenize_each_inline_positioned(text, |t, p| f(t, p));
+    }
+
+    /// Returns the chain itself, never the base it wraps. Two callers
+    /// depend on that: the FTS build path's downcast, which must reach
+    /// [`Self::tokenize_each_inline_positioned`] and not the base's
+    /// unfiltered scan; and the `LIKE` lowering, which recognizes a
+    /// column's analyzer by [`Tokenizer::name`] and must not mistake a
+    /// stemming column for a plain one (see `Analyzer::of`).
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// The query side runs the same chain, so a term is looked up in the
+    /// form it was indexed under. Always owned: a stemmed token is a new
+    /// string, and the stopword filter makes the borrowed/owned split
+    /// per token rather than per query, which is not worth a second scan
+    /// implementation on query-length input.
+    fn tokenize_each_query<'q>(&self, text: &'q str, f: &mut dyn FnMut(Cow<'q, str>)) {
+        self.tokenize_each_inline(text, |t| f(Cow::Owned(t.to_owned())));
+    }
+
+    /// Overridden because the stopword filter drops tokens: a quoted
+    /// phrase must carry the holes it left, or the phrase asks for
+    /// words closer together than the index put them and matches
+    /// nothing.
+    fn tokenize_each_query_positioned<'q>(
+        &self,
+        text: &'q str,
+        f: &mut dyn FnMut(Cow<'q, str>, u64),
+    ) {
+        self.tokenize_each_inline_positioned(text, |t, position| {
+            f(Cow::Owned(t.to_owned()), position)
+        });
+    }
+}
+
+/// The canonical composite name for a chain, or the base's own plain
+/// name when no filter is active.
+///
+/// The whole reachable set, spelled out: with named built-ins only, the
+/// chain has two bases × two stopword settings × two stemmer settings,
+/// so every name a column can carry is a `&'static str` here. That is
+/// what lets [`Tokenizer::name`] stay `&'static str` and the persisted
+/// name stay a closed vocabulary a reader either knows or rejects.
+///
+/// Component order is fixed (`stop` before `stem`, matching the order
+/// the filters run), so one chain has exactly one spelling.
+pub(crate) fn chain_name(base: Base, stopwords: Stopwords, stemmer: Stemmer) -> &'static str {
+    match (base, stopwords, stemmer) {
+        (Base::Standard, Stopwords::None, Stemmer::None) => STANDARD_TOKENIZER,
+        (Base::Standard, Stopwords::English, Stemmer::None) => "standard+stop=english",
+        (Base::Standard, Stopwords::None, Stemmer::English) => "standard+stem=english",
+        (Base::Standard, Stopwords::English, Stemmer::English) => {
+            "standard+stop=english+stem=english"
+        }
+        (Base::AsciiLower, Stopwords::None, Stemmer::None) => ASCII_LOWER_TOKENIZER,
+        (Base::AsciiLower, Stopwords::English, Stemmer::None) => "ascii_lower+stop=english",
+        (Base::AsciiLower, Stopwords::None, Stemmer::English) => "ascii_lower+stem=english",
+        (Base::AsciiLower, Stopwords::English, Stemmer::English) => {
+            "ascii_lower+stop=english+stem=english"
+        }
+    }
+}
+
+/// Build the tokenizer for a chain: the bare base tokenizer when no
+/// filter is active, otherwise a [`ChainTokenizer`].
+///
+/// A filterless chain must *not* be wrapped — the wrapper would persist
+/// under a composite name no plain column has and would hide the base
+/// from the build path's downcast, costing ingest throughput for no
+/// behaviour change.
+pub(crate) fn chain_tokenizer(
+    base: Base,
+    stopwords: Stopwords,
+    stemmer: Stemmer,
+) -> Arc<dyn Tokenizer> {
+    if stopwords == Stopwords::None && stemmer == Stemmer::None {
+        return match base {
+            Base::AsciiLower => Arc::new(AsciiLowerTokenizer),
+            Base::Standard => Arc::new(StandardTokenizer),
+        };
+    }
+    Arc::new(ChainTokenizer {
+        base,
+        stopwords,
+        name: chain_name(base, stopwords, stemmer),
+        snowball: match stemmer {
+            Stemmer::None => None,
+            Stemmer::English => Some(Snowball::create(Algorithm::English)),
+        },
+    })
+}
+
+/// Parse a composite analyzer name into its components, or `None` for
+/// anything this engine does not implement — an unknown base, an
+/// unknown filter, a filter named twice, or components out of canonical
+/// order.
+///
+/// Strict on purpose. This is the fail-loud channel: a name an engine
+/// cannot reproduce exactly must be refused, because tokenizing a query
+/// with an approximation of the chain the postings were built with
+/// returns wrong answers instead of an error.
+pub(crate) fn parse_chain_name(name: &str) -> Option<(Base, Stopwords, Stemmer)> {
+    let mut parts = name.split('+');
+    let base = Base::from_name(parts.next()?)?;
+    let mut stopwords = Stopwords::None;
+    let mut stemmer = Stemmer::None;
+    for part in parts {
+        match part {
+            // `stop` must precede `stem`, so a `stop` arriving after one
+            // was set — or after `stem` was — is not canonical.
+            "stop=english" if stopwords == Stopwords::None && stemmer == Stemmer::None => {
+                stopwords = Stopwords::English;
+            }
+            "stem=english" if stemmer == Stemmer::None => stemmer = Stemmer::English,
+            _ => return None,
+        }
+    }
+    // A filterless name reaches here only as the bare base name, which
+    // `chain_name` agrees on — so the round-trip below holds for it too.
+    match chain_name(base, stopwords, stemmer) == name {
+        true => Some((base, stopwords, stemmer)),
+        false => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chain(name: &str) -> Arc<dyn Tokenizer> {
+        let (base, stop, stem) = parse_chain_name(name).expect("known chain");
+        chain_tokenizer(base, stop, stem)
+    }
+
+    fn tokens(name: &str, text: &str) -> Vec<String> {
+        chain(name).tokenize(text).collect()
+    }
+
+    fn positioned(name: &str, text: &str) -> Vec<(String, u64)> {
+        let tok = chain(name);
+        let mut out = Vec::new();
+        tok.tokenize_each_positioned(text, &mut |t, p| out.push((t.to_owned(), p)));
+        out
+    }
+
+    #[test]
+    fn english_stopwords_are_sorted_and_within_the_length_bound() {
+        // `contains` binary-searches the slice behind a length
+        // pre-filter, so both invariants are load-bearing: an unsorted
+        // slice silently misses words, and a word longer than the bound
+        // is unreachable.
+        let mut sorted = ENGLISH_STOPWORDS.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(sorted, ENGLISH_STOPWORDS, "list must be sorted");
+        sorted.dedup();
+        assert_eq!(sorted.len(), ENGLISH_STOPWORDS.len(), "no duplicates");
+        for w in ENGLISH_STOPWORDS {
+            assert!(
+                w.len() <= ENGLISH_STOPWORD_MAX_LEN,
+                "{w:?} exceeds the length pre-filter bound"
+            );
+            assert!(Stopwords::English.contains(w), "{w:?} must be a stopword");
+        }
+        assert!(
+            !Stopwords::English.contains("theory"),
+            "prefix is not a hit"
+        );
+        assert!(!Stopwords::English.contains("th"));
+    }
+
+    #[test]
+    fn a_filterless_chain_is_the_bare_base_tokenizer() {
+        // Not merely an optimization: the wrapper would persist under a
+        // name no plain column carries, so the round-trip below is the
+        // format guarantee that a default column is unchanged.
+        for base in [Base::AsciiLower, Base::Standard] {
+            let tok = chain_tokenizer(base, Stopwords::None, Stemmer::None);
+            assert_eq!(tok.name(), chain_name(base, Stopwords::None, Stemmer::None));
+            assert!(
+                tok.as_any().downcast_ref::<ChainTokenizer>().is_none(),
+                "a filterless chain must not wrap"
+            );
+        }
+    }
+
+    #[test]
+    fn chain_names_round_trip_and_reject_non_canonical_spellings() {
+        for base in [Base::AsciiLower, Base::Standard] {
+            for stop in [Stopwords::None, Stopwords::English] {
+                for stem in [Stemmer::None, Stemmer::English] {
+                    let name = chain_name(base, stop, stem);
+                    assert_eq!(
+                        parse_chain_name(name),
+                        Some((base, stop, stem)),
+                        "{name:?} must round-trip"
+                    );
+                    assert_eq!(
+                        chain_tokenizer(base, stop, stem).name(),
+                        name,
+                        "{name:?}: the built tokenizer must report its own name"
+                    );
+                }
+            }
+        }
+        // Every rejection below is a name that would otherwise be
+        // tokenized by an approximation of the chain it asks for.
+        for bad in [
+            "nonesuch",
+            "standard+stem=english+stop=english", // components out of order
+            "standard+stop=english+stop=english", // repeated
+            "standard+stop=german",               // set we do not ship
+            "standard+stem=porter",               // a different algorithm
+            "standard+",
+            "+standard",
+            "standard+stem=english+",
+            "STANDARD",
+        ] {
+            assert_eq!(parse_chain_name(bad), None, "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn stopwords_are_removed_and_leave_a_position_hole() {
+        // The hole is what keeps `"new york"` from phrase-matching
+        // `"new the york"`: without it both index at positions 0, 1.
+        assert_eq!(
+            positioned("standard+stop=english", "new the york"),
+            vec![("new".to_string(), 0), ("york".to_string(), 2)]
+        );
+        // A leading and a trailing stopword each consume their ordinal
+        // too, so the kept tokens' *relative* spacing is preserved
+        // wherever they sit.
+        assert_eq!(
+            positioned("standard+stop=english", "the new york of"),
+            vec![("new".to_string(), 1), ("york".to_string(), 2)]
+        );
+        // Nothing but stopwords: no tokens, and no phantom position.
+        assert!(positioned("standard+stop=english", "the and of").is_empty());
+    }
+
+    #[test]
+    fn stemming_folds_inflections_onto_one_term() {
+        assert_eq!(
+            tokens("standard+stem=english", "running runs runner ran"),
+            vec!["run", "run", "runner", "ran"],
+            "Porter2 folds the regular inflections, not the irregular ones"
+        );
+        // Both filters, in the fixed order: the stopword set is matched
+        // against the *unstemmed* token, so `their` is removed as a
+        // stopword rather than stemmed first.
+        assert_eq!(
+            tokens(
+                "standard+stop=english+stem=english",
+                "their studies are running"
+            ),
+            vec!["studi", "run"]
+        );
+    }
+
+    #[test]
+    fn the_base_tokenizer_still_decides_the_token_alphabet() {
+        // `ascii_lower` drops a non-ASCII run whole and leaves its
+        // ordinal as a hole; the filters run on what survives that.
+        assert_eq!(
+            positioned("ascii_lower+stem=english", "Running café STUDIES"),
+            vec![("run".to_string(), 0), ("studi".to_string(), 2)]
+        );
+        // `standard` keeps non-ASCII, and the English stemmer leaves a
+        // word it has no rule for alone.
+        assert_eq!(
+            tokens("standard+stem=english", "Café Studies"),
+            vec!["café", "studi"]
+        );
+    }
+
+    #[test]
+    fn every_entry_point_emits_the_same_tokens() {
+        // `tokenize` / `tokenize_each` / `tokenize_each_query` /
+        // `tokenize_each_positioned` all route through one scan; a
+        // disagreement between them would index text under one form and
+        // query it under another.
+        let text = "The Running Studies of New York are here";
+        for name in [
+            "standard+stop=english",
+            "standard+stem=english",
+            "standard+stop=english+stem=english",
+            "ascii_lower+stop=english+stem=english",
+        ] {
+            let tok = chain(name);
+            let via_tokenize: Vec<String> = tok.tokenize(text).collect();
+            let mut via_each = Vec::new();
+            tok.tokenize_each(text, &mut |t| via_each.push(t.to_owned()));
+            let mut via_query = Vec::new();
+            tok.tokenize_each_query(text, &mut |t| via_query.push(t.into_owned()));
+            let via_positioned: Vec<String> =
+                positioned(name, text).into_iter().map(|(t, _)| t).collect();
+            assert_eq!(via_tokenize, via_each, "{name}: tokenize vs tokenize_each");
+            assert_eq!(via_tokenize, via_query, "{name}: tokenize vs query");
+            assert_eq!(
+                via_tokenize, via_positioned,
+                "{name}: tokenize vs positioned"
+            );
+        }
+    }
+}

--- a/src/superfile/fts/analysis.rs
+++ b/src/superfile/fts/analysis.rs
@@ -130,6 +130,24 @@ pub enum Stemmer {
 /// Lucene's English stopword set (`EnglishAnalyzer.ENGLISH_STOP_WORDS_SET`),
 /// **sorted** so [`Stopwords::contains`] can binary-search it.
 ///
+/// ## Frozen: this list is on-disk format state, not a tunable
+///
+/// A column persists the *name* `stop=english`, never the words — so
+/// this constant is what a reader reconstructs the column's analysis
+/// from, and editing it re-analyzes every column already built with it.
+/// Add a word and a query for it starts missing documents that contain
+/// it; remove one and queries tokenize differently than the postings
+/// were built. Both are wrong answers with no error, because the *name*
+/// still matches — exactly the failure the composite name exists to
+/// prevent, reached through the back door.
+///
+/// So it does not change. `english_stopword_set_is_frozen` pins every
+/// word and fails loudly if one moves. If a different list is ever
+/// genuinely wanted, it arrives as a **new name** (`stop=english2`)
+/// whose `parse_chain_name` arm is added beside this one, leaving files
+/// built under the old name reconstructible from the old list — never
+/// as an edit here.
+///
 /// Sorted-slice + binary search rather than a hash set: 33 short words
 /// are searched in ~5 comparisons with no hashing and no lazy-init, and
 /// the length pre-filter below rejects most corpus tokens before the
@@ -455,6 +473,89 @@ mod tests {
         let mut out = Vec::new();
         tok.tokenize_each_positioned(text, &mut |t, p| out.push((t.to_owned(), p)));
         out
+    }
+
+    /// The exact set a column declaring `stop=english` is analyzed
+    /// with, spelled out so a change to [`ENGLISH_STOPWORDS`] has to
+    /// come here and be argued for.
+    ///
+    /// This is not a restatement of the constant for its own sake. The
+    /// name `stop=english` is what reaches disk, so the words behind it
+    /// are format state: change them and every column already built
+    /// under that name is analyzed one way and queried another, with no
+    /// error, because the name still matches.
+    const FROZEN_ENGLISH_STOPWORDS: &[&str] = &[
+        "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is",
+        "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there",
+        "these", "they", "this", "to", "was", "will", "with",
+    ];
+
+    /// If this fails, do **not** update the expectation to match the
+    /// code. The words behind `stop=english` are on-disk format state
+    /// (see [`ENGLISH_STOPWORDS`]): every column already built under
+    /// that name would be silently analyzed one way and queried
+    /// another. A different list arrives as a new name —
+    /// `stop=english2`, with its own `parse_chain_name` arm and its own
+    /// frozen list — so files under the old name stay reconstructible.
+    #[test]
+    fn english_stopword_set_is_frozen() {
+        assert_eq!(
+            ENGLISH_STOPWORDS, FROZEN_ENGLISH_STOPWORDS,
+            "the `stop=english` word list changed. This is a format \
+             change, not a tuning change: columns already built under \
+             that name would be analyzed with the old list and queried \
+             with the new one, silently. Ship a new name instead."
+        );
+    }
+
+    /// The stemmer has the same problem one layer out, and worse: the
+    /// rules behind `stem=english` live in `rust-stemmers`, whose
+    /// version range admits any `1.x`, so a routine dependency bump
+    /// could change how an existing column's postings *would* be
+    /// tokenized while the postings themselves keep the old forms.
+    ///
+    /// These pairs are the observable contract. If a bump breaks this,
+    /// the bump is a format change — reject it or ship `stem=english2`;
+    /// do not re-record the expectations.
+    #[test]
+    fn english_stemmer_output_is_frozen() {
+        // Chosen to cover the Porter2 steps that actually differ
+        // between implementations: -ing/-ed removal with and without
+        // stem doubling, -ies/-y, -ational/-ate, -ness/-ful/-ment
+        // suffixes, short-word protection, and the irregulars it has no
+        // rule for.
+        let cases = [
+            ("running", "run"),
+            ("runs", "run"),
+            ("run", "run"),
+            ("runner", "runner"),
+            ("ran", "ran"),
+            ("studies", "studi"),
+            ("study", "studi"),
+            ("cities", "citi"),
+            ("relational", "relat"),
+            ("hopping", "hop"),
+            ("hoping", "hope"),
+            ("happiness", "happi"),
+            ("hopeful", "hope"),
+            ("argument", "argument"),
+            ("agreed", "agre"),
+            ("news", "news"),
+            ("sky", "sky"),
+            ("is", "is"),
+        ];
+        let tok = chain("standard+stem=english");
+        for (word, want) in cases {
+            let got: Vec<String> = tok.tokenize(word).collect();
+            assert_eq!(
+                got,
+                vec![want.to_string()],
+                "`stem=english` changed for {word:?}. This is a format \
+                 change: columns already built under that name hold the \
+                 old stems and would now be queried with new ones. \
+                 Reject the bump or ship a new name."
+            );
+        }
     }
 
     #[test]

--- a/src/superfile/fts/analysis.rs
+++ b/src/superfile/fts/analysis.rs
@@ -70,17 +70,26 @@ use super::tokenize::{
 /// extension path stays open as a future `+stop=custom` name whose
 /// sibling word list an older engine rejects on the unknown name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+// A second language is the obvious next addition, and adding an enum
+// variant is a breaking change unless the enum says otherwise. Callers
+// only ever *construct* these, never match on them, so the attribute
+// costs nothing and buys every later set a patch release.
+#[non_exhaustive]
 pub enum Stopwords {
     /// Keep every token (the default).
     #[default]
     None,
     /// Lucene's `EnglishAnalyzer.ENGLISH_STOP_WORDS_SET` — the 33-word
-    /// Snowball English list. See [`ENGLISH_STOPWORDS`].
+    /// Snowball English list: `a an and are as at be but by for if in
+    /// into is it no not of on or such that the their then there these
+    /// they this to was will with`.
     English,
 }
 
 /// Stemmer applied to a column, after stopword removal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// `#[non_exhaustive]` for the same reason as [`Stopwords`].
+#[non_exhaustive]
 pub enum Stemmer {
     /// Index tokens as written (the default).
     #[default]
@@ -102,7 +111,7 @@ pub enum Stemmer {
 /// are searched in ~5 comparisons with no hashing and no lazy-init, and
 /// the length pre-filter below rejects most corpus tokens before the
 /// search runs at all.
-pub const ENGLISH_STOPWORDS: &[&str] = &[
+pub(crate) const ENGLISH_STOPWORDS: &[&str] = &[
     "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it",
     "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there", "these",
     "they", "this", "to", "was", "will", "with",

--- a/src/superfile/fts/analysis.rs
+++ b/src/superfile/fts/analysis.rs
@@ -36,31 +36,43 @@
 //! gap in `standard` itself belongs to the tokenizer and the scorer,
 //! not here; this module only adds filters a caller asks for by name.
 //!
-//! ## The chain is its name
+//! ## Persistence: two additive fields, and a derived identity
 //!
-//! A chain persists as one composite analyzer name —
-//! `"standard+stop=english+stem=english"` — and nothing else. That is a
-//! deliberate choice over a sibling `"stemmer"` field in
-//! `inf.fts.columns`: an older reader *ignores* an unknown JSON field,
-//! and an ignored analysis filter means the reader tokenizes queries
-//! differently than the index was built, which is wrong answers rather
-//! than an error. The analyzer name is the one channel already shipped
-//! readers fail loud on — [`tokenizer_for_name`] returning `None` is an
-//! open error at every call site — so routing the whole chain through
-//! it makes an engine that predates a filter refuse the file instead of
-//! mis-ranking it.
+//! A column persists its base analyzer name plus, only when set, a
+//! `stopwords` and a `stemmer` field. Both are ordinary additive
+//! fields: absent means the filter is off, which is the one thing a
+//! file written before the filter existed can mean, so a current
+//! reader infers the right analysis from an old file with no special
+//! handling.
 //!
-//! Carrying the chain in the name also means nothing else has to learn
-//! about it. The name is already what the catalog record
-//! (`TableEntry::fts_analyzers`), the remote create-table wire and the
-//! options-hash's `fts_analyzers` block carry, so a chained column
-//! rides all three unchanged, and a plain column's bytes stay
-//! byte-identical to today's in every one of them.
+//! The chain also has a **name** — `"standard+stop=english+stem=english"`
+//! from [`chain_name`] — but it is derived in memory and never written.
+//! It exists because three places have to reason about a column's
+//! analysis as one value, and reading three fields at each of them
+//! would be three chances to forget one:
 //!
-//! Because the built-in sets are a closed set (no user-supplied word
-//! lists — those would need a sibling field and would give the name
-//! back its ambiguity), the reachable names are a finite table, which
-//! is what lets [`Tokenizer::name`] keep returning `&'static str`.
+//!   - the `LIKE` prune lowering, which recognizes analyzers by
+//!     [`Tokenizer::name`] and must decline to bound a column whose
+//!     terms are not substring-preserving images of its text;
+//!   - the merge carry check, which compares analyzer names to refuse
+//!     merging differently-analyzed superfiles;
+//!   - the table's options-hash, which needs analysis in its identity.
+//!
+//! Keeping the name out of the format is what makes a *rollback* a
+//! degradation rather than an outage. An engine predating a filter
+//! ignores its field and analyzes the column as unfiltered — wrong
+//! answers on that column until it rolls forward, recoverable — where a
+//! composite name it could not parse would make the table refuse to
+//! open. The precedent is deliberate: the same trade decided against
+//! marking these files with a new FTS section version, on the grounds
+//! that a lost-recall regression is recoverable and an unopenable table
+//! is an outage.
+//!
+//! What is *not* ignorable is an unrecognized **value** of a field the
+//! reader does know: `"stopwords":"german"` on an engine that ships no
+//! German list is refused, because there is no sound way to proceed —
+//! the analysis cannot be reproduced. Unknown field, degrade; unknown
+//! value, error.
 //!
 //! ## Positions
 //!
@@ -144,9 +156,9 @@ pub enum Stemmer {
 /// So it does not change. `english_stopword_set_is_frozen` pins every
 /// word and fails loudly if one moves. If a different list is ever
 /// genuinely wanted, it arrives as a **new name** (`stop=english2`)
-/// whose `parse_chain_name` arm is added beside this one, leaving files
-/// built under the old name reconstructible from the old list — never
-/// as an edit here.
+/// resolved by a new arm in [`Stopwords::from_name`] beside this one,
+/// leaving files built under the old name reconstructible from the old
+/// list — never as an edit here.
 ///
 /// Sorted-slice + binary search rather than a hash set: 33 short words
 /// are searched in ~5 comparisons with no hashing and no lazy-init, and
@@ -197,8 +209,7 @@ impl Base {
         chain_name(self, Stopwords::None, Stemmer::None)
     }
 
-    /// Resolve a base analyzer name. Rejects a composite name; use
-    /// [`parse_chain_name`] for one of those.
+    /// Resolve a base analyzer name.
     pub(crate) fn from_name(name: &str) -> Option<Self> {
         match name {
             ASCII_LOWER_TOKENIZER => Some(Base::AsciiLower),
@@ -234,7 +245,7 @@ impl Base {
 
 /// A base tokenizer plus its stopword set and stemmer.
 ///
-/// Constructed only through [`chain_tokenizer`] / [`tokenizer_for_name`],
+/// Constructed only through [`chain_tokenizer`],
 /// so a `ChainTokenizer` always carries at least one active filter — a
 /// chain with neither is the base tokenizer itself, under the base's own
 /// plain name, and must not be wrapped (wrapping it would change the
@@ -365,17 +376,20 @@ impl Tokenizer for ChainTokenizer {
     }
 }
 
-/// The canonical composite name for a chain, or the base's own plain
-/// name when no filter is active.
+/// A chain's identity as one string — the base's plain name when no
+/// filter is active, otherwise the base followed by its filters.
 ///
-/// The whole reachable set, spelled out: with named built-ins only, the
-/// chain has two bases × two stopword settings × two stemmer settings,
-/// so every name a column can carry is a `&'static str` here. That is
-/// what lets [`Tokenizer::name`] stay `&'static str` and the persisted
-/// name stay a closed vocabulary a reader either knows or rejects.
+/// **Derived, never persisted.** It is what [`Tokenizer::name`] reports,
+/// so the three places that reason about a column's analysis as a single
+/// value get it from one place (see the module docs). The format stores
+/// the components as separate fields instead, and nothing parses this
+/// back — a chain is only ever built from its components.
 ///
-/// Component order is fixed (`stop` before `stem`, matching the order
-/// the filters run), so one chain has exactly one spelling.
+/// Every reachable string is a `&'static str` here because the built-in
+/// sets are a closed set: two bases × two stopword settings × two
+/// stemmer settings. Component order is fixed (`stop` before `stem`,
+/// matching the order the filters run), so one chain has exactly one
+/// spelling and the options-hash is stable.
 pub(crate) fn chain_name(base: Base, stopwords: Stopwords, stemmer: Stemmer) -> &'static str {
     match (base, stopwords, stemmer) {
         (Base::Standard, Stopwords::None, Stemmer::None) => STANDARD_TOKENIZER,
@@ -422,36 +436,44 @@ pub(crate) fn chain_tokenizer(
     })
 }
 
-/// Parse a composite analyzer name into its components, or `None` for
-/// anything this engine does not implement — an unknown base, an
-/// unknown filter, a filter named twice, or components out of canonical
-/// order.
-///
-/// Strict on purpose. This is the fail-loud channel: a name an engine
-/// cannot reproduce exactly must be refused, because tokenizing a query
-/// with an approximation of the chain the postings were built with
-/// returns wrong answers instead of an error.
-pub(crate) fn parse_chain_name(name: &str) -> Option<(Base, Stopwords, Stemmer)> {
-    let mut parts = name.split('+');
-    let base = Base::from_name(parts.next()?)?;
-    let mut stopwords = Stopwords::None;
-    let mut stemmer = Stemmer::None;
-    for part in parts {
-        match part {
-            // `stop` must precede `stem`, so a `stop` arriving after one
-            // was set — or after `stem` was — is not canonical.
-            "stop=english" if stopwords == Stopwords::None && stemmer == Stemmer::None => {
-                stopwords = Stopwords::English;
-            }
-            "stem=english" if stemmer == Stemmer::None => stemmer = Stemmer::English,
-            _ => return None,
+impl Stopwords {
+    /// The name this set persists under, or `None` for
+    /// [`Stopwords::None`] — which is written by omitting the field.
+    pub(crate) fn as_str(self) -> Option<&'static str> {
+        match self {
+            Stopwords::None => None,
+            Stopwords::English => Some("english"),
         }
     }
-    // A filterless name reaches here only as the bare base name, which
-    // `chain_name` agrees on — so the round-trip below holds for it too.
-    match chain_name(base, stopwords, stemmer) == name {
-        true => Some((base, stopwords, stemmer)),
-        false => None,
+
+    /// Resolve a persisted name. `None` for a name this engine cannot
+    /// reproduce, which every caller turns into an error rather than a
+    /// silent fallback: analyzing with a set we do not have is not a
+    /// degradation, it is a different index.
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "english" => Some(Stopwords::English),
+            _ => None,
+        }
+    }
+}
+
+impl Stemmer {
+    /// The name this stemmer persists under; see
+    /// [`Stopwords::as_str`].
+    pub(crate) fn as_str(self) -> Option<&'static str> {
+        match self {
+            Stemmer::None => None,
+            Stemmer::English => Some("english"),
+        }
+    }
+
+    /// Resolve a persisted name; see [`Stopwords::from_name`].
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "english" => Some(Stemmer::English),
+            _ => None,
+        }
     }
 }
 
@@ -459,9 +481,20 @@ pub(crate) fn parse_chain_name(name: &str) -> Option<(Base, Stopwords, Stemmer)>
 mod tests {
     use super::*;
 
+    /// Build the chain whose derived name is `name`. A test lookup, not
+    /// a parser — nothing in the engine turns a name back into
+    /// components, because the format stores the components.
     fn chain(name: &str) -> Arc<dyn Tokenizer> {
-        let (base, stop, stem) = parse_chain_name(name).expect("known chain");
-        chain_tokenizer(base, stop, stem)
+        for base in [Base::AsciiLower, Base::Standard] {
+            for stop in [Stopwords::None, Stopwords::English] {
+                for stem in [Stemmer::None, Stemmer::English] {
+                    if chain_name(base, stop, stem) == name {
+                        return chain_tokenizer(base, stop, stem);
+                    }
+                }
+            }
+        }
+        panic!("no chain has the name {name:?}");
     }
 
     fn tokens(name: &str, text: &str) -> Vec<String> {
@@ -495,8 +528,8 @@ mod tests {
     /// (see [`ENGLISH_STOPWORDS`]): every column already built under
     /// that name would be silently analyzed one way and queried
     /// another. A different list arrives as a new name —
-    /// `stop=english2`, with its own `parse_chain_name` arm and its own
-    /// frozen list — so files under the old name stay reconstructible.
+    /// `stop=english2`, with its own `from_name` arm and its own frozen
+    /// list — so files under the old name stay reconstructible.
     #[test]
     fn english_stopword_set_is_frozen() {
         assert_eq!(
@@ -598,17 +631,20 @@ mod tests {
         }
     }
 
+    /// Every chain has a distinct derived name, and the tokenizer built
+    /// from a set of components reports it. Distinctness is what the
+    /// three consumers of the name depend on: the `LIKE` lowering, the
+    /// merge carry check, and the options-hash all treat two columns as
+    /// differently analyzed exactly when their names differ.
     #[test]
-    fn chain_names_round_trip_and_reject_non_canonical_spellings() {
+    fn every_chain_has_a_distinct_derived_name() {
+        let mut seen: Vec<&str> = Vec::new();
         for base in [Base::AsciiLower, Base::Standard] {
             for stop in [Stopwords::None, Stopwords::English] {
                 for stem in [Stemmer::None, Stemmer::English] {
                     let name = chain_name(base, stop, stem);
-                    assert_eq!(
-                        parse_chain_name(name),
-                        Some((base, stop, stem)),
-                        "{name:?} must round-trip"
-                    );
+                    assert!(!seen.contains(&name), "{name:?} is not unique");
+                    seen.push(name);
                     assert_eq!(
                         chain_tokenizer(base, stop, stem).name(),
                         name,
@@ -617,20 +653,29 @@ mod tests {
                 }
             }
         }
-        // Every rejection below is a name that would otherwise be
-        // tokenized by an approximation of the chain it asks for.
-        for bad in [
-            "nonesuch",
-            "standard+stem=english+stop=english", // components out of order
-            "standard+stop=english+stop=english", // repeated
-            "standard+stop=german",               // set we do not ship
-            "standard+stem=porter",               // a different algorithm
-            "standard+",
-            "+standard",
-            "standard+stem=english+",
-            "STANDARD",
-        ] {
-            assert_eq!(parse_chain_name(bad), None, "{bad:?} must be rejected");
+        assert_eq!(
+            seen.len(),
+            8,
+            "two bases x two stopword sets x two stemmers"
+        );
+    }
+
+    /// The persisted field values round-trip, and a value this engine
+    /// cannot reproduce resolves to `None` so the caller can refuse the
+    /// file. An unknown *field* is ignorable — an unknown *value* of a
+    /// known field is not, because there is no sound way to proceed.
+    #[test]
+    fn filter_names_round_trip_and_unknown_values_are_refused() {
+        assert_eq!(Stopwords::English.as_str(), Some("english"));
+        assert_eq!(Stemmer::English.as_str(), Some("english"));
+        // `None` is written by omitting the field, so it has no name.
+        assert_eq!(Stopwords::None.as_str(), None);
+        assert_eq!(Stemmer::None.as_str(), None);
+        assert_eq!(Stopwords::from_name("english"), Some(Stopwords::English));
+        assert_eq!(Stemmer::from_name("english"), Some(Stemmer::English));
+        for unknown in ["german", "porter", "English", "", "none"] {
+            assert_eq!(Stopwords::from_name(unknown), None, "{unknown:?}");
+            assert_eq!(Stemmer::from_name(unknown), None, "{unknown:?}");
         }
     }
 

--- a/src/superfile/fts/analysis.rs
+++ b/src/superfile/fts/analysis.rs
@@ -6,6 +6,14 @@
 //!
 //! ## Shape
 //!
+//! A word on names. Here *tokenizer* means the thing that splits text
+//! — `standard` or `ascii_lower` — and *analyzer* means the whole
+//! chain: that tokenizer plus its filters. The public builder's option
+//! is spelled `.analyzer(...)` for historical reasons but takes a
+//! tokenizer name, and the persisted field is spelled `"tokenizer"`,
+//! which is accurate. Before filters existed the two words were
+//! interchangeable for this engine; they no longer are.
+//!
 //! One base tokenizer ([`AsciiLowerTokenizer`] or
 //! [`StandardTokenizer`]) followed by up to two token filters:
 //! stopwords are removed from the *unstemmed* token, then what
@@ -23,7 +31,7 @@
 //!
 //! A column that declares no filter is not wrapped at all
 //! ([`chain_tokenizer`] hands back the bare base tokenizer), keeps its
-//! plain analyzer name, and takes the same monomorphized ingest scan
+//! plain tokenizer name, and takes the same monomorphized ingest scan
 //! it always did. So the default column is byte-identical and
 //! code-path-identical to one declared before chains existed.
 //!
@@ -38,7 +46,7 @@
 //!
 //! ## Persistence: two additive fields, and a derived identity
 //!
-//! A column persists its base analyzer name plus, only when set, a
+//! A column persists its base tokenizer name plus, only when set, a
 //! `stopwords` and a `stemmer` field. Both are ordinary additive
 //! fields: absent means the filter is off, which is the one thing a
 //! file written before the filter existed can mean, so a current
@@ -54,7 +62,7 @@
 //!   - the `LIKE` prune lowering, which recognizes analyzers by
 //!     [`Tokenizer::name`] and must decline to bound a column whose
 //!     terms are not substring-preserving images of its text;
-//!   - the merge carry check, which compares analyzer names to refuse
+//!   - the merge carry check, which compares these identities to refuse
 //!     merging differently-analyzed superfiles;
 //!   - the table's options-hash, which needs analysis in its identity.
 //!
@@ -100,7 +108,7 @@ use super::tokenize::{
 /// before the stemmer.
 ///
 /// Named built-ins only. A user-supplied word list would have to
-/// persist beside the analyzer name, which is exactly the
+/// persist beside the tokenizer name, which is exactly the
 /// additive-and-ignorable shape the composite name exists to avoid; the
 /// extension path stays open as a future `+stop=custom` name whose
 /// sibling word list an older engine rejects on the unknown name.
@@ -203,13 +211,13 @@ pub(crate) enum Base {
 }
 
 impl Base {
-    /// This base's own plain analyzer name — the chain name with no
-    /// filters.
+    /// This base's own plain tokenizer name — the chain identity with
+    /// no filters.
     pub(crate) fn name(self) -> &'static str {
         chain_name(self, Stopwords::None, Stemmer::None)
     }
 
-    /// Resolve a base analyzer name.
+    /// Resolve a base tokenizer name.
     pub(crate) fn from_name(name: &str) -> Option<Self> {
         match name {
             ASCII_LOWER_TOKENIZER => Some(Base::AsciiLower),

--- a/src/superfile/fts/analysis.rs
+++ b/src/superfile/fts/analysis.rs
@@ -454,11 +454,21 @@ impl Stopwords {
         }
     }
 
-    /// Resolve a persisted name. `None` for a name this engine cannot
-    /// reproduce, which every caller turns into an error rather than a
-    /// silent fallback: analyzing with a set we do not have is not a
-    /// degradation, it is a different index.
-    pub(crate) fn from_name(name: &str) -> Option<Self> {
+    /// Resolve a set by name — `"english"` — or `None` for a name this
+    /// engine cannot reproduce.
+    ///
+    /// **Exact match, and the single source of truth for the spelling.**
+    /// Every caller turns `None` into an error rather than a silent
+    /// fallback: analyzing with a set we do not have is not a degraded
+    /// index, it is a different one. Public because the language
+    /// bindings take this name as a string from their callers and must
+    /// resolve it the same way the format does — three private copies of
+    /// the same match is how they drift, and one of them case-folded
+    /// while the others did not.
+    ///
+    /// Case-folding is deliberately absent: accepting more spellings
+    /// later is additive, tightening later is not.
+    pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "english" => Some(Stopwords::English),
             _ => None,
@@ -476,8 +486,9 @@ impl Stemmer {
         }
     }
 
-    /// Resolve a persisted name; see [`Stopwords::from_name`].
-    pub(crate) fn from_name(name: &str) -> Option<Self> {
+    /// Resolve a stemmer by name — `"english"`; same exact-match rule and
+    /// same rationale as [`Stopwords::from_name`].
+    pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "english" => Some(Stemmer::English),
             _ => None,

--- a/src/superfile/fts/builder.rs
+++ b/src/superfile/fts/builder.rs
@@ -97,6 +97,7 @@ use crate::superfile::{
         checksum::{crc32c, crc32c_append},
     },
     fts::{
+        analysis::ChainTokenizer,
         bm25,
         dict::{DictBuilder, StreamingDictBuilder},
         fst_value::{FstValue, INLINE_TF_MAX},
@@ -1887,6 +1888,12 @@ impl FtsBuilder {
             .as_ref()
             .as_any()
             .downcast_ref::<StandardTokenizer>();
+        // A column with a stopword set or a stemmer tokenizes through
+        // the chain, which wraps one of the two above. It gets its own
+        // monomorphized arm for the same reason they do, and it must be
+        // reached through the *chain's* scan — the base's would index
+        // the unfiltered tokens.
+        let chain_tok = tokenizer.as_ref().as_any().downcast_ref::<ChainTokenizer>();
         let mut tokens_in_doc: u64 = 0;
 
         let positional = self.columns[col_idx].positions;
@@ -1955,6 +1962,8 @@ impl FtsBuilder {
                 ascii.tokenize_each_inline(text, &mut on_token);
             } else if let Some(standard) = standard_tok {
                 standard.tokenize_each_inline(text, &mut on_token);
+            } else if let Some(chain) = chain_tok {
+                chain.tokenize_each_inline(text, &mut on_token);
             } else {
                 tokenizer.tokenize_each(text, &mut on_token);
             }
@@ -2017,13 +2026,22 @@ impl FtsBuilder {
                     record(tok, tokens_in_doc);
                     tokens_in_doc += 1;
                 });
+            } else if let Some(chain) = chain_tok {
+                // Gap-aware: a token the chain's stopword filter removes
+                // advances the position ordinal but emits nothing, and
+                // the doc length counts only what is emitted — the token
+                // count Lucene's norms are built from too.
+                chain.tokenize_each_inline_positioned(text, |tok, position| {
+                    record(tok, position);
+                    tokens_in_doc += 1;
+                });
             } else {
-                // A custom tokenizer can't report dropped tokens through
-                // the current trait, so positions are plain emission
-                // ordinals; a tokenizer that silently drops tokens will
-                // not leave phrase gaps (see the `Tokenizer` trait docs).
-                tokenizer.tokenize_each(text, &mut |tok| {
-                    record(tok, tokens_in_doc);
+                // A custom tokenizer reports its own gap-inclusive
+                // positions through the trait; the default numbering is
+                // consecutive, which is correct for one that drops
+                // nothing (see the `Tokenizer` trait docs).
+                tokenizer.tokenize_each_positioned(text, &mut |tok, position| {
+                    record(tok, position);
                     tokens_in_doc += 1;
                 });
             }
@@ -2140,6 +2158,12 @@ impl FtsBuilder {
             .as_ref()
             .as_any()
             .downcast_ref::<StandardTokenizer>();
+        // A column with a stopword set or a stemmer tokenizes through
+        // the chain, which wraps one of the two above. It gets its own
+        // monomorphized arm for the same reason they do, and it must be
+        // reached through the *chain's* scan — the base's would index
+        // the unfiltered tokens.
+        let chain_tok = tokenizer.as_ref().as_any().downcast_ref::<ChainTokenizer>();
         let mut tokens_in_doc: u64 = 0;
         let positional = self.columns[col_idx].positions;
 
@@ -2186,6 +2210,8 @@ impl FtsBuilder {
                 ascii.tokenize_each_inline(text, &mut on_token);
             } else if let Some(standard) = standard_tok {
                 standard.tokenize_each_inline(text, &mut on_token);
+            } else if let Some(chain) = chain_tok {
+                chain.tokenize_each_inline(text, &mut on_token);
             } else {
                 tokenizer.tokenize_each(text, &mut on_token);
             }
@@ -2255,12 +2281,21 @@ impl FtsBuilder {
                     record(tok, tokens_in_doc);
                     tokens_in_doc += 1;
                 });
+            } else if let Some(chain) = chain_tok {
+                // Gap-aware: a token the chain's stopword filter removes
+                // advances the position ordinal but emits nothing, and
+                // the doc length counts only what is emitted — the token
+                // count Lucene's norms are built from too.
+                chain.tokenize_each_inline_positioned(text, |tok, position| {
+                    record(tok, position);
+                    tokens_in_doc += 1;
+                });
             } else {
-                // A custom tokenizer can't report dropped tokens through
-                // the current trait, so positions are plain emission
-                // ordinals (see the `Tokenizer` trait docs).
-                tokenizer.tokenize_each(text, &mut |tok| {
-                    record(tok, tokens_in_doc);
+                // A custom tokenizer reports its own gap-inclusive
+                // positions through the trait (see the `Tokenizer`
+                // trait docs).
+                tokenizer.tokenize_each_positioned(text, &mut |tok, position| {
+                    record(tok, position);
                     tokens_in_doc += 1;
                 });
             }
@@ -4093,7 +4128,7 @@ fn sort_partition_to_file<const N: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::default_tokenizer as tokenizer;
+    use crate::{superfile::fts::tokenize::Phrase, test_helpers::default_tokenizer as tokenizer};
 
     /// The radix path (n >= `RADIX_SORT_MIN_TRIPLES`) must deliver
     /// `(lex_rank, doc_id)` order even when a term's docs arrive out of
@@ -5102,7 +5137,9 @@ mod tests {
             (&["filler", "medium"], 79),
         ];
         for (terms, want) in phrases {
-            let phrase = vec![terms.iter().map(|t| t.to_string()).collect()];
+            let phrase = vec![Phrase::adjacent(
+                terms.iter().map(|t| t.to_string()).collect(),
+            )];
             let a = v3
                 .atoms_match_count("title", &[], &phrase, BoolMode::And, &[], &[])
                 .await

--- a/src/superfile/fts/mod.rs
+++ b/src/superfile/fts/mod.rs
@@ -4,6 +4,7 @@
 //! Full-text search subsystem — the BM25 + posting list + FST term
 //! dictionary stack lives here.
 
+pub mod analysis;
 pub mod bm25;
 pub mod builder;
 pub mod dict;

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -1876,6 +1876,36 @@ fn header_postings_length(header: &[u8]) -> Result<usize, FtsError> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The reader refuses to open a column whose entry names a filter
+    /// this engine cannot reproduce, and names the field and the value
+    /// so the operator can see which engine version is needed.
+    ///
+    /// Asserted through `open` rather than on the resolver alone: the
+    /// resolver is where the decision is made, but the `map_err` that
+    /// turns it into a read error is the part a caller actually sees,
+    /// and a `?` dropped there would let the column open unfiltered.
+    #[tokio::test]
+    async fn open_refuses_a_column_naming_an_unreproducible_filter() {
+        let (blob, json) = build_blob();
+        // Sanity: the fixture opens before it is tampered with, so a
+        // failure below is the filter and not the fixture.
+        FtsReader::open(blob.clone(), &json).expect("untampered fixture opens");
+        for (field, value) in [("stopwords", "german"), ("stemmer", "porter")] {
+            let patched = json.replace(
+                r#""tokenizer":"#,
+                &format!(r#""{field}":"{value}","tokenizer":"#),
+            );
+            assert_ne!(patched, json, "{field}: fixture did not patch");
+            let err = FtsReader::open(blob.clone(), &patched)
+                .expect_err("an unreproducible filter must fail the open");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(field) && msg.contains(value),
+                "{field}: the error must name the field and value, got: {msg}"
+            );
+        }
+    }
     use std::collections::HashSet;
 
     use super::{super::test_util::*, *};

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -45,13 +45,14 @@ use crate::superfile::{
         },
     },
     fts::{
+        analysis::{Base, chain_tokenizer},
         bm25,
         builder::{DOC_LENGTHS_ENTRY_SIZE, TERM_META_SIZE},
         dict::{DictReader, make_key},
         fst_value::FstValue,
         positions::decode_run,
         posting::{self, BLOCK_LEN, ENCODING_BITSET, decode_block_doc_ids},
-        tokenize::{Phrase, Tokenizer, tokenizer_for_name},
+        tokenize::{Phrase, Tokenizer},
     },
     lazy_source::{LazyByteSource, PrefetchedSource, RangeCoalescePlan, Source},
 };
@@ -925,12 +926,24 @@ impl FtsReader {
                 avgdl,
                 params,
             );
-            let tokenizer = tokenizer_for_name(&col_cfg.tokenizer).ok_or_else(|| {
+            let base = Base::from_name(&col_cfg.tokenizer).ok_or_else(|| {
                 FtsError::Read(ReadError::MalformedVersion(format!(
                     "inf.fts.columns: unknown tokenizer {:?} for column {:?}",
                     col_cfg.tokenizer, col_cfg.name
                 )))
             })?;
+            // A filter the entry names but this engine does not ship
+            // cannot be worked around: analyzing without it would query
+            // the column differently than its postings were built. An
+            // *absent* filter field is the opposite case and needs no
+            // guess — it means the filter is off.
+            let (stopwords, stemmer) = col_cfg.filters().map_err(|(field, value)| {
+                FtsError::Read(ReadError::MalformedVersion(format!(
+                    "inf.fts.columns: unknown {field} {value:?} for column {:?}",
+                    col_cfg.name
+                )))
+            })?;
+            let tokenizer = chain_tokenizer(base, stopwords, stemmer);
             columns.push(ColumnMeta {
                 name: col_cfg.name.clone(),
                 doc_lengths_range: doc_lengths_offset..array_end,
@@ -942,6 +955,9 @@ impl FtsReader {
                 bound_scale: 1.0,
                 positions: col_cfg.positions,
                 tokenizer,
+                base,
+                stopwords,
+                stemmer,
                 stored: col_cfg.stored,
             });
             column_id_by_name.insert(col_cfg.name.clone(), i as u32);

--- a/src/superfile/fts/reader/core.rs
+++ b/src/superfile/fts/reader/core.rs
@@ -51,7 +51,7 @@ use crate::superfile::{
         fst_value::FstValue,
         positions::decode_run,
         posting::{self, BLOCK_LEN, ENCODING_BITSET, decode_block_doc_ids},
-        tokenize::{Tokenizer, tokenizer_for_name},
+        tokenize::{Phrase, Tokenizer, tokenizer_for_name},
     },
     lazy_source::{LazyByteSource, PrefetchedSource, RangeCoalescePlan, Source},
 };
@@ -75,9 +75,9 @@ pub(crate) struct ClauseLists<'a> {
     pub musts: &'a [&'a str],
     pub shoulds: &'a [&'a str],
     pub negatives: &'a [&'a str],
-    pub must_phrases: &'a [Vec<String>],
-    pub should_phrases: &'a [Vec<String>],
-    pub negative_phrases: &'a [Vec<String>],
+    pub must_phrases: &'a [Phrase<String>],
+    pub should_phrases: &'a [Phrase<String>],
+    pub negative_phrases: &'a [Phrase<String>],
     /// Per-term global idf for [`Bm25Stats::Global`], the default;
     /// `None` scores with [`Bm25Stats::PerSuperfile`] local idf.
     pub global_idf: Option<&'a GlobalTermIdf>,
@@ -1169,7 +1169,7 @@ impl FtsReader {
         &self,
         column_id: u32,
         terms: &[&str],
-        phrases: &[Vec<String>],
+        phrases: &[Phrase<String>],
         global_idf: Option<&GlobalTermIdf>,
         prefetched: Option<&FetchedTermMemo>,
     ) -> Result<(Vec<Option<AnyCursor>>, u64), FtsError> {
@@ -1264,6 +1264,7 @@ impl FtsReader {
                 cursors,
                 positions,
                 positional,
+                phrase.offsets().to_vec(),
                 col_meta.params,
             )?)));
         }

--- a/src/superfile/fts/reader/count.rs
+++ b/src/superfile/fts/reader/count.rs
@@ -19,7 +19,7 @@ use crate::{
         ReadError,
         error::FtsError,
         format::fts::U32_BYTES,
-        fts::{builder::TERM_META_SIZE, dict::make_key, fst_value::FstValue},
+        fts::{builder::TERM_META_SIZE, dict::make_key, fst_value::FstValue, tokenize::Phrase},
     },
 };
 
@@ -125,7 +125,7 @@ impl FtsReader {
         &self,
         column: &str,
         terms: &[&str],
-        phrases: &[Vec<String>],
+        phrases: &[Phrase<String>],
         mode: BoolMode,
     ) -> Result<(Vec<u32>, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
@@ -157,10 +157,10 @@ impl FtsReader {
         &self,
         column: &str,
         terms: &[&str],
-        phrases: &[Vec<String>],
+        phrases: &[Phrase<String>],
         mode: BoolMode,
         neg_terms: &[&str],
-        neg_phrases: &[Vec<String>],
+        neg_phrases: &[Phrase<String>],
     ) -> Result<(u64, MatchWork), FtsError> {
         let column_id = self.resolve_column_id(column)?;
         // Unranked: idf is irrelevant to the match set, so build local.

--- a/src/superfile/fts/reader/metadata.rs
+++ b/src/superfile/fts/reader/metadata.rs
@@ -342,6 +342,47 @@ impl OpenOptions {
 mod tests {
     use bytes::Bytes;
 
+    /// The two boundary rules the analysis fields live by, asserted on
+    /// the deserializer directly because both are invisible in a
+    /// round-trip through our own writer.
+    ///
+    /// Absent means off: a file written before the filters existed has
+    /// no such field, and that can only mean it was built unfiltered —
+    /// so a current reader infers the right analysis with no guess. An
+    /// unrecognized *value* is the opposite case and must not be
+    /// tolerated: analyzing without a set the postings were built with
+    /// is a different index, not a degraded one.
+    #[test]
+    fn absent_analysis_fields_mean_off_and_unknown_values_are_refused() {
+        let entry: FtsColumnConfig =
+            serde_json::from_str(r#"{"name":"body","tokenizer":"standard"}"#).expect("parse");
+        assert_eq!(entry.stopwords, None);
+        assert_eq!(entry.stemmer, None);
+        assert_eq!(
+            entry.filters().expect("no filters resolves"),
+            (Stopwords::None, Stemmer::None)
+        );
+
+        let entry: FtsColumnConfig = serde_json::from_str(
+            r#"{"name":"body","tokenizer":"standard","stopwords":"english","stemmer":"english"}"#,
+        )
+        .expect("parse");
+        assert_eq!(
+            entry.filters().expect("known filters resolve"),
+            (Stopwords::English, Stemmer::English)
+        );
+
+        // A filter this engine does not ship, in either field.
+        let entry: FtsColumnConfig =
+            serde_json::from_str(r#"{"name":"body","tokenizer":"standard","stopwords":"german"}"#)
+                .expect("the field parses; resolving it is what fails");
+        assert_eq!(entry.filters(), Err(("stopwords", "german")));
+        let entry: FtsColumnConfig =
+            serde_json::from_str(r#"{"name":"body","tokenizer":"standard","stemmer":"porter"}"#)
+                .expect("parse");
+        assert_eq!(entry.filters(), Err(("stemmer", "porter")));
+    }
+
     use super::{super::test_util::*, *};
     use crate::superfile::fts::{
         builder::FtsBuilder, reader::FtsReader, tokenize::AsciiLowerTokenizer,

--- a/src/superfile/fts/reader/metadata.rs
+++ b/src/superfile/fts/reader/metadata.rs
@@ -9,7 +9,11 @@ use std::{ops::Range, sync::Arc};
 
 use serde::Deserialize;
 
-use crate::superfile::fts::{bm25, tokenize::Tokenizer};
+use crate::superfile::fts::{
+    analysis::{Base, Stemmer, Stopwords},
+    bm25,
+    tokenize::Tokenizer,
+};
 
 /// Per-doc BM25 length normalizer, quantized to one byte per doc.
 ///
@@ -200,10 +204,21 @@ pub struct ColumnMeta {
     /// `inf.fts.columns`); phrase queries require it.
     pub positions: bool,
     /// Tokenizer for this column, reconstructed at open time from the
-    /// `tokenizer` name in `inf.fts.columns`. Query terms for this
-    /// column must be tokenized with it to match how the column was
-    /// indexed.
+    /// `tokenizer` name in `inf.fts.columns` plus its `stopwords` /
+    /// `stemmer` fields. Query terms for this column must be tokenized
+    /// with it to match how the column was indexed.
     pub tokenizer: Arc<dyn Tokenizer>,
+    /// The column's base tokenizer, kept beside the assembled
+    /// [`ColumnMeta::tokenizer`] so a rebuild can reconstruct the same
+    /// chain from its components. `Tokenizer::name` reports the chain's
+    /// derived identity, which is not a name any lookup accepts back.
+    pub(crate) base: Base,
+    /// The column's stopword set, kept for the same reason as
+    /// [`ColumnMeta::base`].
+    pub stopwords: Stopwords,
+    /// The column's stemmer, kept for the same reason as
+    /// [`ColumnMeta::base`].
+    pub stemmer: Stemmer,
     /// Whether the column's raw text is kept in the Parquet body (from
     /// `inf.fts.columns`). Index-only columns (`false`) are searchable
     /// but absent from the stored schema, so they cannot be read back;
@@ -247,12 +262,40 @@ pub struct FtsColumnConfig {
     /// default ([`bm25::B`]) as [`FtsColumnConfig::k1`].
     #[serde(default = "default_b")]
     pub b: f32,
+    /// Stopword set applied to this column, by name. Absent means no
+    /// set — the one thing a file written before the filter existed can
+    /// mean, so a missing field needs no guess. A *present* name this
+    /// engine does not ship is a different matter and fails the open:
+    /// there is no sound way to analyze without a set the index was
+    /// built with.
+    #[serde(default)]
+    pub stopwords: Option<String>,
+    /// Stemmer applied to this column, by name; same absent-means-off
+    /// and unknown-name-fails rules as [`FtsColumnConfig::stopwords`].
+    #[serde(default)]
+    pub stemmer: Option<String>,
 }
 
 impl FtsColumnConfig {
     /// The parameters this column's bounds were baked at.
     pub fn params(&self) -> bm25::Bm25Params {
         bm25::Bm25Params::new(self.k1, self.b)
+    }
+
+    /// This column's analysis filters. `Err` carries the offending
+    /// field name and value for an entry naming a filter this engine
+    /// cannot reproduce — the caller turns that into a read error
+    /// rather than analyzing the column some other way.
+    pub fn filters(&self) -> Result<(Stopwords, Stemmer), (&'static str, &str)> {
+        let stopwords = match &self.stopwords {
+            None => Stopwords::None,
+            Some(name) => Stopwords::from_name(name).ok_or(("stopwords", name.as_str()))?,
+        };
+        let stemmer = match &self.stemmer {
+            None => Stemmer::None,
+            Some(name) => Stemmer::from_name(name).ok_or(("stemmer", name.as_str()))?,
+        };
+        Ok((stopwords, stemmer))
     }
 }
 

--- a/src/superfile/fts/reader/phrase.rs
+++ b/src/superfile/fts/reader/phrase.rs
@@ -166,7 +166,7 @@ impl PhraseMember {
 /// Doc-at-a-time cursor over an exact phrase: the members'
 /// intersection drives doc alignment, and a doc matches only when the
 /// members' positions verify the phrase's spacing (member `i` at
-/// `p + offsets[i]` for some anchor `p`). Scores as one BM25 atom with `tf` = the number
+/// `p + position_offsets[i]` for some anchor `p`). Scores as one BM25 atom with `tf` = the number
 /// of verified anchors and `idf` = Σ member idf. Exposes the same
 /// notion of term- and block-level upper bounds as [`TermCursor`], so
 /// the atom walks can prune with it:
@@ -175,9 +175,14 @@ impl PhraseMember {
 /// the BM25 tf-factor is monotone in tf.
 pub(super) struct PhraseCursor {
     pub(super) members: Vec<PhraseMember>,
-    /// Each member's token-position offset from the phrase's first
+    /// Each member's **token-position** offset from the phrase's first
     /// member, in `members` (query) order — strictly ascending, first
     /// entry `0`.
+    ///
+    /// Named for the unit on purpose: [`PhraseMember`] also carries
+    /// `run_offsets` and `cached_run_offset`, which are **byte** offsets
+    /// into a term's positions blob. Confusing the two would be a
+    /// correctness bug, not a type error.
     ///
     /// Plain `0..n` for a phrase whose words were adjacent in the
     /// query, which is every phrase on a column with no analysis
@@ -185,7 +190,7 @@ pub(super) struct PhraseCursor {
     /// middle of the phrase gets a gap here, so the verification asks
     /// for the members exactly as far apart as the same chain put them
     /// at index time — see `Phrase` in `fts::tokenize`.
-    pub(super) offsets: Vec<u32>,
+    pub(super) position_offsets: Vec<u32>,
     /// Member indices in ascending posting-list length (rarest first).
     /// The doc-alignment in [`Self::seek_match`] is a set intersection —
     /// order-independent — so it probes members rarest-first: the short
@@ -272,7 +277,7 @@ impl PhraseCursor {
             idf_sum,
             term_max_bm25: idf_sum * min_scaled_bound,
             members,
-            offsets,
+            position_offsets: offsets,
             align_order,
             current_doc: 0,
             current_tf: 0,
@@ -487,7 +492,8 @@ impl PhraseCursor {
     /// probe is a binary search over a per-doc-tf-sized slice.
     pub(super) fn verify_at_aligned(&mut self, aligned: u32) -> Result<u32, FtsError> {
         // Staged, rarest-first, lazy-decode verification. A phrase match
-        // starting at position `s` has member `j` at `s + offsets[j]`,
+        // starting at position `s` has member `j` at
+        // `s + position_offsets[j]`,
         // so any
         // member can seed the candidate starts: the rarest member (by
         // posting length — `align_order[0]`) seeds them, then each
@@ -508,7 +514,7 @@ impl PhraseCursor {
         // bit-test and its block is not yet decoded; on the ranked path it
         // was already decoded by `skip_to`, so this is a no-op there.
         let anchor = self.align_order[0];
-        let anchor_off = self.offsets[anchor];
+        let anchor_off = self.position_offsets[anchor];
         self.members[anchor].cursor.materialize_at(aligned);
         self.members[anchor].decode_current_positions()?;
         self.verify_scratch.clear();
@@ -525,9 +531,9 @@ impl PhraseCursor {
             self.members[j].cursor.materialize_at(aligned);
             self.members[j].decode_current_positions()?;
             let plist = &self.members[j].pos_scratch;
-            let off = self.offsets[j];
+            let off = self.position_offsets[j];
             // Compact the survivors in place: keep a start iff member `j`
-            // holds `start + offsets[j]`.
+            // holds `start + position_offsets[j]`.
             let mut w = 0usize;
             for r in 0..self.verify_scratch.len() {
                 let start = self.verify_scratch[r];

--- a/src/superfile/fts/reader/phrase.rs
+++ b/src/superfile/fts/reader/phrase.rs
@@ -165,8 +165,8 @@ impl PhraseMember {
 
 /// Doc-at-a-time cursor over an exact phrase: the members'
 /// intersection drives doc alignment, and a doc matches only when the
-/// members' positions verify adjacency (member `i` at `p + i` for
-/// some anchor `p`). Scores as one BM25 atom with `tf` = the number
+/// members' positions verify the phrase's spacing (member `i` at
+/// `p + offsets[i]` for some anchor `p`). Scores as one BM25 atom with `tf` = the number
 /// of verified anchors and `idf` = Σ member idf. Exposes the same
 /// notion of term- and block-level upper bounds as [`TermCursor`], so
 /// the atom walks can prune with it:
@@ -175,6 +175,17 @@ impl PhraseMember {
 /// the BM25 tf-factor is monotone in tf.
 pub(super) struct PhraseCursor {
     pub(super) members: Vec<PhraseMember>,
+    /// Each member's token-position offset from the phrase's first
+    /// member, in `members` (query) order — strictly ascending, first
+    /// entry `0`.
+    ///
+    /// Plain `0..n` for a phrase whose words were adjacent in the
+    /// query, which is every phrase on a column with no analysis
+    /// chain. A column whose stopword set removed a word from the
+    /// middle of the phrase gets a gap here, so the verification asks
+    /// for the members exactly as far apart as the same chain put them
+    /// at index time — see `Phrase` in `fts::tokenize`.
+    pub(super) offsets: Vec<u32>,
     /// Member indices in ascending posting-list length (rarest first).
     /// The doc-alignment in [`Self::seek_match`] is a set intersection —
     /// order-independent — so it probes members rarest-first: the short
@@ -212,11 +223,18 @@ impl PhraseCursor {
         cursors: Vec<TermCursor>,
         positions: Vec<Bytes>,
         positional: Vec<(Option<TermMeta>, Option<u32>)>,
+        offsets: Vec<u32>,
         params: bm25::Bm25Params,
     ) -> Result<Self, FtsError> {
         debug_assert!(cursors.len() >= 2, "single-token phrases degrade to terms");
         debug_assert_eq!(cursors.len(), positions.len());
         debug_assert_eq!(cursors.len(), positional.len());
+        debug_assert_eq!(cursors.len(), offsets.len());
+        debug_assert_eq!(offsets.first(), Some(&0), "offsets are normalized");
+        debug_assert!(
+            offsets.windows(2).all(|w| w[0] < w[1]),
+            "offsets are strictly ascending"
+        );
         let mut idf_sum = 0.0f32;
         let mut min_scaled_bound = f32::INFINITY;
         let members: Vec<PhraseMember> = cursors
@@ -254,6 +272,7 @@ impl PhraseCursor {
             idf_sum,
             term_max_bm25: idf_sum * min_scaled_bound,
             members,
+            offsets,
             align_order,
             current_doc: 0,
             current_tf: 0,
@@ -468,7 +487,8 @@ impl PhraseCursor {
     /// probe is a binary search over a per-doc-tf-sized slice.
     pub(super) fn verify_at_aligned(&mut self, aligned: u32) -> Result<u32, FtsError> {
         // Staged, rarest-first, lazy-decode verification. A phrase match
-        // starting at position `s` has member `j` at `s + j`, so any
+        // starting at position `s` has member `j` at `s + offsets[j]`,
+        // so any
         // member can seed the candidate starts: the rarest member (by
         // posting length — `align_order[0]`) seeds them, then each
         // remaining member filters the survivors *in rarest-first order*.
@@ -488,7 +508,7 @@ impl PhraseCursor {
         // bit-test and its block is not yet decoded; on the ranked path it
         // was already decoded by `skip_to`, so this is a no-op there.
         let anchor = self.align_order[0];
-        let anchor_off = anchor as u32;
+        let anchor_off = self.offsets[anchor];
         self.members[anchor].cursor.materialize_at(aligned);
         self.members[anchor].decode_current_positions()?;
         self.verify_scratch.clear();
@@ -505,9 +525,9 @@ impl PhraseCursor {
             self.members[j].cursor.materialize_at(aligned);
             self.members[j].decode_current_positions()?;
             let plist = &self.members[j].pos_scratch;
-            let off = j as u32;
+            let off = self.offsets[j];
             // Compact the survivors in place: keep a start iff member `j`
-            // holds `start + j`.
+            // holds `start + offsets[j]`.
             let mut w = 0usize;
             for r in 0..self.verify_scratch.len() {
                 let start = self.verify_scratch[r];
@@ -676,10 +696,15 @@ impl AnyCursor {
 #[cfg(test)]
 mod tests {
     use super::{super::test_util::*, *};
-    use crate::superfile::fts::reader::{FtsReader, core::ClauseLists};
+    use crate::superfile::fts::{
+        reader::{FtsReader, core::ClauseLists},
+        tokenize::Phrase,
+    };
 
-    fn phrase(terms: &[&str]) -> Vec<Vec<String>> {
-        vec![terms.iter().map(|t| t.to_string()).collect()]
+    fn phrase(terms: &[&str]) -> Vec<Phrase<String>> {
+        vec![Phrase::adjacent(
+            terms.iter().map(|t| t.to_string()).collect(),
+        )]
     }
 
     #[tokio::test]

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -232,8 +232,16 @@ pub trait Tokenizer: Send + Sync + std::fmt::Debug + 'static {
             };
             self.parse_unquoted_segment(&query[seg_start..unquoted_end], &mut parsed);
             let mut phrase: Phrase<Cow<'q, str>> = Phrase::default();
+            // Offsets are relative to the first *surviving* term. A
+            // leading token the analysis chain removed is unobservable
+            // — there is nothing before it to space it from — and
+            // normalizing here is what lets the verifier subtract an
+            // offset from a position without underflowing near the
+            // start of a document.
+            let mut first_position: Option<u64> = None;
             self.tokenize_each_query_positioned(&query[i + 1..close], &mut |t, position| {
-                phrase.push(t, position)
+                let first = *first_position.get_or_insert(position);
+                phrase.push(t, position.saturating_sub(first));
             });
             match (phrase.len(), sigil) {
                 // Empty quotes contribute nothing.
@@ -550,9 +558,6 @@ pub struct Phrase<T> {
     /// `offsets[i]` is `terms[i]`'s distance from `terms[0]`. Strictly
     /// ascending, and `offsets[0] == 0`.
     pub offsets: Vec<u32>,
-    /// Position of the first kept term, subtracted from every offset
-    /// pushed after it. Only meaningful while building.
-    first_position: Option<u64>,
 }
 
 impl<T> Default for Phrase<T> {
@@ -560,7 +565,6 @@ impl<T> Default for Phrase<T> {
         Self {
             terms: Vec::new(),
             offsets: Vec::new(),
-            first_position: None,
         }
     }
 }
@@ -570,23 +574,21 @@ impl<T> Phrase<T> {
     /// every phrase has on a column with no analysis chain.
     pub fn adjacent(terms: Vec<T>) -> Self {
         let offsets = (0..terms.len() as u32).collect();
-        Self {
-            terms,
-            offsets,
-            first_position: None,
-        }
+        Self { terms, offsets }
     }
 
-    /// Append `term`, which the tokenizer reported at gap-inclusive
-    /// `position`, normalizing the offset against the first term
-    /// appended.
-    fn push(&mut self, term: T, position: u64) {
-        let first = *self.first_position.get_or_insert(position);
-        // Saturating rather than panicking on a non-ascending position:
-        // a tokenizer is an extension point, and a misbehaving one
-        // should cost recall on its own column, not abort a query.
-        self.offsets
-            .push(position.saturating_sub(first).min(u32::MAX as u64) as u32);
+    /// Append `term` at `offset` from the phrase's first term. The
+    /// caller normalizes, so nothing about how the phrase was built
+    /// survives into the value — two phrases with the same terms and
+    /// the same spacing are the same phrase, however each was
+    /// assembled.
+    ///
+    /// `offset` saturates rather than panicking on a position a
+    /// tokenizer reported out of order: a tokenizer is an extension
+    /// point, and a misbehaving one should cost recall on its own
+    /// column, not abort a query.
+    fn push(&mut self, term: T, offset: u64) {
+        self.offsets.push(offset.min(u32::MAX as u64) as u32);
         self.terms.push(term);
     }
 
@@ -614,7 +616,6 @@ impl<T> Phrase<T> {
         Phrase {
             terms: self.terms.iter().map(f).collect(),
             offsets: self.offsets.clone(),
-            first_position: self.first_position,
         }
     }
 }
@@ -749,8 +750,31 @@ impl Tokenizer for AsciiLowerTokenizer {
     /// Zero-copy override: an already-lowercase token borrows from
     /// `text`; only a token that needs lowercasing is copied.
     fn tokenize_each_query<'q>(&self, text: &'q str, f: &mut dyn FnMut(Cow<'q, str>)) {
+        // One scan implementation — delegate and discard the position,
+        // so the two query entry points cannot disagree about which
+        // tokens a query has.
+        self.tokenize_each_query_positioned(text, &mut |t, _position| f(t));
+    }
+
+    /// Zero-copy *and* gap-aware: the same borrowed-where-possible
+    /// tokens as [`Self::tokenize_each_query`], each with the
+    /// gap-inclusive ordinal a dropped non-ASCII run leaves behind.
+    ///
+    /// The gap is why this is overridden rather than left to the
+    /// trait's consecutive default. A phrase query is verified against
+    /// the positions the *index* recorded, and the index has always
+    /// left a hole for a dropped run — so numbering the query's
+    /// surviving tokens consecutively asks for them closer together
+    /// than they were indexed, and `"new café york"` could never match
+    /// the text it was copied from.
+    fn tokenize_each_query_positioned<'q>(
+        &self,
+        text: &'q str,
+        f: &mut dyn FnMut(Cow<'q, str>, u64),
+    ) {
         let bytes = text.as_bytes();
         let mut pos = 0;
+        let mut position: u64 = 0;
         while pos < bytes.len() {
             pos = simd_skip_non_token(bytes, pos);
             if pos >= bytes.len() {
@@ -759,14 +783,22 @@ impl Tokenizer for AsciiLowerTokenizer {
             let start = pos;
             let (end, had_upper, had_non_ascii) = simd_scan_token_run(bytes, pos);
             pos = end;
-            if had_non_ascii || start == pos {
+            if start == pos {
+                continue;
+            }
+            // Every scanned run occupies one ordinal, dropped or not —
+            // the same rule `tokenize_each_inline_positioned` follows,
+            // so query and index agree on the spacing.
+            let this_position = position;
+            position += 1;
+            if had_non_ascii {
                 continue;
             }
             let s = from_utf8(&bytes[start..end]).expect("ASCII-only by construction");
             if had_upper {
-                f(Cow::Owned(s.to_ascii_lowercase()));
+                f(Cow::Owned(s.to_ascii_lowercase()), this_position);
             } else {
-                f(Cow::Borrowed(s));
+                f(Cow::Borrowed(s), this_position);
             }
         }
     }
@@ -1827,6 +1859,42 @@ mod tests {
         // trait object, confirming the right impl is wired.
         let tok = tokenizer_for_name(STANDARD_TOKENIZER).expect("standard");
         assert_eq!(tok.tokenize("Café").collect::<Vec<_>>(), vec!["café"]);
+    }
+
+    /// A phrase's offsets on a chainless tokenizer are its terms'
+    /// indices, and the parsed value equals the `adjacent` fixture the
+    /// tests build — nothing about *how* a phrase was assembled
+    /// survives into it, so two phrases with the same terms and the
+    /// same spacing are the same phrase.
+    #[test]
+    fn a_chainless_phrase_is_adjacent_and_compares_equal_to_the_fixture() {
+        let p = StandardTokenizer.parse("\"new york city\"");
+        let want = Phrase::adjacent(vec![
+            Cow::Borrowed("new"),
+            Cow::Borrowed("york"),
+            Cow::Borrowed("city"),
+        ]);
+        assert_eq!(p.positive_phrases, vec![want]);
+        assert_eq!(p.positive_phrases[0].offsets(), &[0, 1, 2]);
+    }
+
+    /// A tokenizer that drops tokens reports holes, and the parser
+    /// turns them into offsets normalized to the first surviving term.
+    /// `ascii_lower` drops non-ASCII runs, which is a hole with no
+    /// analysis chain involved — so the offset plumbing is exercised
+    /// by the tokenizer that has always left gaps.
+    #[test]
+    fn a_phrase_carries_the_holes_its_tokenizer_left() {
+        // `café` is dropped whole and consumes one ordinal, so `york`
+        // sits two positions after `new`.
+        let p = AsciiLowerTokenizer.parse("\"new café york\"");
+        assert_eq!(phrase_terms(&p.positive_phrases), vec![vec!["new", "york"]]);
+        assert_eq!(p.positive_phrases[0].offsets(), &[0, 2]);
+        // A *leading* dropped run is unobservable: there is nothing
+        // before it to space the phrase from, so the offsets still
+        // start at 0.
+        let p = AsciiLowerTokenizer.parse("\"café new york\"");
+        assert_eq!(p.positive_phrases[0].offsets(), &[0, 1]);
     }
 
     #[test]

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -39,6 +39,7 @@ use std::{
     any::Any,
     borrow::Cow,
     collections::BTreeSet,
+    ops::Deref,
     str::{from_utf8, from_utf8_unchecked},
     sync::Arc,
 };
@@ -46,7 +47,10 @@ use std::{
 use unicode_segmentation::UnicodeSegmentation;
 use wide::u8x16;
 
-use super::reader::BoolMode;
+use super::{
+    analysis::{chain_tokenizer, parse_chain_name},
+    reader::BoolMode,
+};
 
 /// Smallest byte value that is non-ASCII (has the high bit set). The
 /// v1 ASCII-only rule drops any token containing a byte `>= this`.
@@ -101,18 +105,14 @@ pub trait Tokenizer: Send + Sync + std::fmt::Debug + 'static {
     ///
     /// ## Phrase positions and dropped tokens
     ///
-    /// The positional index numbers tokens by the order this trait
-    /// yields them, and exact-phrase matching checks those numbers for
+    /// The positional index numbers tokens by the position this trait
+    /// reports, and exact-phrase matching checks those numbers for
     /// adjacency. A tokenizer that *drops* an input token (a stopword
-    /// filter, a non-ASCII skip, etc.) without otherwise signalling it
-    /// makes the tokens on either side of the dropped one look
-    /// adjacent — so a phrase can match text that isn't actually
-    /// contiguous. The built-in [`AsciiLowerTokenizer`] avoids this on
-    /// its positional build path by leaving a position gap for each
-    /// dropped run; a custom tokenizer that drops tokens and needs
-    /// exact phrase semantics must not rely on this trait to preserve
-    /// gaps (position increments through the trait are a planned
-    /// extension, not yet available).
+    /// filter, a non-ASCII skip) must leave the dropped token's
+    /// ordinal behind as a hole, or the tokens on either side of it
+    /// look adjacent and a phrase matches text that is not contiguous.
+    /// [`Tokenizer::tokenize_each_positioned`] is that channel; a
+    /// tokenizer that drops tokens overrides it.
     fn tokenize<'a>(&'a self, text: &'a str) -> Box<dyn Iterator<Item = String> + 'a>;
 
     /// Call `f(&token)` for each token. The `&str` passed to `f` is
@@ -128,6 +128,28 @@ pub trait Tokenizer: Send + Sync + std::fmt::Debug + 'static {
         }
     }
 
+    /// Call `f(&token, position)` for each token, where `position` is
+    /// the token's **gap-inclusive** ordinal: every input token the
+    /// scan considers consumes one, including the ones this tokenizer
+    /// drops. The positional index build reads positions from here, so
+    /// a dropped token's skipped ordinal is the phrase hole that keeps
+    /// its neighbours non-adjacent (see the note on
+    /// [`Tokenizer::tokenize`]).
+    ///
+    /// The `&str` lifetime rule is [`Tokenizer::tokenize_each`]'s.
+    ///
+    /// Default impl numbers the emitted tokens consecutively, which is
+    /// correct for any tokenizer that drops nothing. A tokenizer that
+    /// drops tokens **must** override this, or it silently reports no
+    /// holes.
+    fn tokenize_each_positioned(&self, text: &str, f: &mut dyn FnMut(&str, u64)) {
+        let mut position = 0u64;
+        self.tokenize_each(text, &mut |t| {
+            f(t, position);
+            position += 1;
+        });
+    }
+
     /// Downcast hatch for the FTS build hot path. Default impl
     /// returns `self` cast to `&dyn Any`; concrete impls should
     /// not override unless they wrap another tokenizer.
@@ -137,6 +159,29 @@ pub trait Tokenizer: Send + Sync + std::fmt::Debug + 'static {
     /// as long as `text` (the query) is alive.
     fn tokenize_each_query<'q>(&self, text: &'q str, f: &mut dyn FnMut(Cow<'q, str>)) {
         self.tokenize_each(text, &mut |t| f(Cow::Owned(t.to_owned())));
+    }
+
+    /// [`Tokenizer::tokenize_each_query`] plus each token's
+    /// gap-inclusive position — the query-side counterpart of
+    /// [`Tokenizer::tokenize_each_positioned`], and what lets a quoted
+    /// phrase keep the holes this tokenizer left in it.
+    ///
+    /// Default impl numbers the emitted tokens consecutively, keeping
+    /// the borrowing `tokenize_each_query` override a tokenizer may
+    /// have. A tokenizer that drops tokens **must** override this, for
+    /// the same reason it must override the indexing counterpart: a
+    /// phrase whose holes are not reported matches text where the words
+    /// are not that far apart.
+    fn tokenize_each_query_positioned<'q>(
+        &self,
+        text: &'q str,
+        f: &mut dyn FnMut(Cow<'q, str>, u64),
+    ) {
+        let mut position = 0u64;
+        self.tokenize_each_query(text, &mut |t| {
+            f(t, position);
+            position += 1;
+        });
     }
 
     /// Used to parse a query into its clauses by leading sigil:
@@ -186,19 +231,23 @@ pub trait Tokenizer: Send + Sync + std::fmt::Debug + 'static {
                 None => i,
             };
             self.parse_unquoted_segment(&query[seg_start..unquoted_end], &mut parsed);
-            let mut terms: Vec<Cow<'q, str>> = Vec::new();
-            self.tokenize_each_query(&query[i + 1..close], &mut |t| terms.push(t));
-            match (terms.len(), sigil) {
+            let mut phrase: Phrase<Cow<'q, str>> = Phrase::default();
+            self.tokenize_each_query_positioned(&query[i + 1..close], &mut |t, position| {
+                phrase.push(t, position)
+            });
+            match (phrase.len(), sigil) {
                 // Empty quotes contribute nothing.
                 (0, _) => {}
                 // A single-token phrase is just that term — degrade to
-                // the term list of the same polarity.
-                (1, Some(b'-')) => parsed.negatives.push(terms.pop().expect("one term")),
-                (1, Some(b'+')) => parsed.musts.push(terms.pop().expect("one term")),
-                (1, _) => parsed.positives.push(terms.pop().expect("one term")),
-                (_, Some(b'-')) => parsed.negative_phrases.push(terms),
-                (_, Some(b'+')) => parsed.must_phrases.push(terms),
-                (_, _) => parsed.positive_phrases.push(terms),
+                // the term list of the same polarity. Its offset is
+                // necessarily 0 and carries no information: a lone
+                // token has nothing to be spaced from.
+                (1, Some(b'-')) => parsed.negatives.push(phrase.pop_term()),
+                (1, Some(b'+')) => parsed.musts.push(phrase.pop_term()),
+                (1, _) => parsed.positives.push(phrase.pop_term()),
+                (_, Some(b'-')) => parsed.negative_phrases.push(phrase),
+                (_, Some(b'+')) => parsed.must_phrases.push(phrase),
+                (_, _) => parsed.positive_phrases.push(phrase),
             }
             i = close + 1;
             seg_start = i;
@@ -473,6 +522,113 @@ fn simd_scan_token_run(bytes: &[u8], mut pos: usize) -> (usize, bool, bool) {
     (pos, had_upper, had_non_ascii)
 }
 
+/// One quoted phrase: its terms in query order, plus each term's
+/// **offset** — how far that term sits from the phrase's first term in
+/// token positions.
+///
+/// Offsets exist because an analysis chain can remove a token from the
+/// middle of a phrase. `"end of the world"` on a column whose stopword
+/// set drops `of` and `the` keeps two terms that were *four* positions
+/// apart in the query, so requiring them adjacent would match nothing
+/// and requiring them merely co-present would match `end world`.
+/// Carrying the offsets keeps the phrase meaning what it says: the
+/// index must hold `end` and `world` three positions apart, which is
+/// exactly where the same chain put them at index time.
+///
+/// Offsets are relative to the first *kept* term, so they always start
+/// at 0. A leading token the chain removed is unobservable — there is
+/// nothing before it to space it from — and normalizing here is what
+/// lets the verifier subtract an offset from a position without
+/// underflowing near the start of a document.
+///
+/// Without a chain every offset is its term's index, so a phrase
+/// behaves exactly as it did before offsets existed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Phrase<T> {
+    /// The phrase's terms, in query order.
+    pub terms: Vec<T>,
+    /// `offsets[i]` is `terms[i]`'s distance from `terms[0]`. Strictly
+    /// ascending, and `offsets[0] == 0`.
+    pub offsets: Vec<u32>,
+    /// Position of the first kept term, subtracted from every offset
+    /// pushed after it. Only meaningful while building.
+    first_position: Option<u64>,
+}
+
+impl<T> Default for Phrase<T> {
+    fn default() -> Self {
+        Self {
+            terms: Vec::new(),
+            offsets: Vec::new(),
+            first_position: None,
+        }
+    }
+}
+
+impl<T> Phrase<T> {
+    /// A phrase whose terms are adjacent — offsets `0..n`. The shape
+    /// every phrase has on a column with no analysis chain.
+    pub fn adjacent(terms: Vec<T>) -> Self {
+        let offsets = (0..terms.len() as u32).collect();
+        Self {
+            terms,
+            offsets,
+            first_position: None,
+        }
+    }
+
+    /// Append `term`, which the tokenizer reported at gap-inclusive
+    /// `position`, normalizing the offset against the first term
+    /// appended.
+    fn push(&mut self, term: T, position: u64) {
+        let first = *self.first_position.get_or_insert(position);
+        // Saturating rather than panicking on a non-ascending position:
+        // a tokenizer is an extension point, and a misbehaving one
+        // should cost recall on its own column, not abort a query.
+        self.offsets
+            .push(position.saturating_sub(first).min(u32::MAX as u64) as u32);
+        self.terms.push(term);
+    }
+
+    /// Take the sole term of a one-term phrase, which degrades to a
+    /// plain term clause.
+    fn pop_term(&mut self) -> T {
+        self.terms.pop().expect("one term")
+    }
+
+    pub fn len(&self) -> usize {
+        self.terms.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    /// The offsets, for the positional verification.
+    pub fn offsets(&self) -> &[u32] {
+        &self.offsets
+    }
+
+    /// Rebuild the phrase over owned terms, preserving the offsets.
+    pub fn map<U>(&self, f: impl FnMut(&T) -> U) -> Phrase<U> {
+        Phrase {
+            terms: self.terms.iter().map(f).collect(),
+            offsets: self.offsets.clone(),
+            first_position: self.first_position,
+        }
+    }
+}
+
+impl<T> Deref for Phrase<T> {
+    type Target = [T];
+
+    /// Derefs to the term slice so a phrase reads as its terms
+    /// wherever the offsets are not the point.
+    fn deref(&self) -> &[T] {
+        &self.terms
+    }
+}
+
 /// A parsed BM25 query, split into its clause lists by leading sigil:
 /// `+term` → `musts`, bare `term` → `positives`, `-term` →
 /// `negatives`. Tokens may borrow the query string, so this can't
@@ -491,13 +647,13 @@ pub struct ParsedQuery<'q> {
     /// `+"…"`-quoted runs of two or more tokens: the doc must contain
     /// the exact token sequence. (Single-token phrases degrade into
     /// `musts`.)
-    pub must_phrases: Vec<Vec<Cow<'q, str>>>,
+    pub must_phrases: Vec<Phrase<Cow<'q, str>>>,
     /// Bare-quoted multi-token runs; polarity resolved from the
     /// default operator like bare terms.
-    pub positive_phrases: Vec<Vec<Cow<'q, str>>>,
+    pub positive_phrases: Vec<Phrase<Cow<'q, str>>>,
     /// `-"…"`-quoted multi-token runs: any doc containing the exact
     /// sequence is excluded.
-    pub negative_phrases: Vec<Vec<Cow<'q, str>>>,
+    pub negative_phrases: Vec<Phrase<Cow<'q, str>>>,
 }
 
 /// A query's clause lists with the default operator already applied —
@@ -513,12 +669,12 @@ pub struct QueryClauses<'q> {
     /// Docs containing any of these are excluded.
     pub negatives: Vec<Cow<'q, str>>,
     /// Multi-token phrases every doc in the result must contain.
-    pub must_phrases: Vec<Vec<Cow<'q, str>>>,
+    pub must_phrases: Vec<Phrase<Cow<'q, str>>>,
     /// Scoring-only phrases when `musts`/`must_phrases` is non-empty;
     /// otherwise part of the union match.
-    pub should_phrases: Vec<Vec<Cow<'q, str>>>,
+    pub should_phrases: Vec<Phrase<Cow<'q, str>>>,
     /// Docs containing any of these exact sequences are excluded.
-    pub negative_phrases: Vec<Vec<Cow<'q, str>>>,
+    pub negative_phrases: Vec<Phrase<Cow<'q, str>>>,
 }
 
 impl<'q> ParsedQuery<'q> {
@@ -577,6 +733,13 @@ impl Tokenizer for AsciiLowerTokenizer {
     /// `&mut dyn FnMut(&str)` indirection.
     fn tokenize_each(&self, text: &str, f: &mut dyn FnMut(&str)) {
         self.tokenize_each_inline(text, |s| f(s));
+    }
+
+    /// Overridden because this tokenizer drops non-ASCII runs: the
+    /// default consecutive numbering would report no hole where one
+    /// was left.
+    fn tokenize_each_positioned(&self, text: &str, f: &mut dyn FnMut(&str, u64)) {
+        self.tokenize_each_inline_positioned(text, |s, position| f(s, position));
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -688,19 +851,25 @@ pub const ASCII_LOWER_TOKENIZER: &str = "ascii_lower";
 /// config, and the analyzer a column gets when none is named.
 pub const STANDARD_TOKENIZER: &str = "standard";
 
-/// Resolve a tokenizer name to an instance, or `None` for an
-/// unrecognized name. The single routing point shared by the build
-/// path (mapping a chosen analyzer to the tokenizer used at index
-/// time) and the read path (reconstructing a column's tokenizer from
-/// the name recorded in its stored config). Callers translate `None`
-/// into their own error — a malformed-superfile read error, or an
-/// invalid-argument error at table-create time.
+/// Resolve an analyzer name to a tokenizer instance, or `None` for a
+/// name this engine cannot reproduce. The single routing point shared
+/// by the build path (mapping a chosen analyzer to the tokenizer used
+/// at index time) and the read path (reconstructing a column's
+/// tokenizer from the name recorded in its stored config). Callers
+/// translate `None` into their own error — a malformed-superfile read
+/// error, or an invalid-argument error at table-create time.
+///
+/// Accepts a bare base name (`"standard"`, `"ascii_lower"`) and the
+/// composite names of the analysis chain
+/// (`"standard+stop=english+stem=english"`), which is why this
+/// function is the format's fail-loud channel for analysis semantics:
+/// an engine that predates a filter does not know the composite name
+/// and refuses the file here, rather than tokenizing queries with a
+/// chain that is missing a filter and answering wrongly. See
+/// [`crate::superfile::fts::analysis`].
 pub fn tokenizer_for_name(name: &str) -> Option<Arc<dyn Tokenizer>> {
-    match name {
-        ASCII_LOWER_TOKENIZER => Some(Arc::new(AsciiLowerTokenizer)),
-        STANDARD_TOKENIZER => Some(Arc::new(StandardTokenizer)),
-        _ => None,
-    }
+    let (base, stopwords, stemmer) = parse_chain_name(name)?;
+    Some(chain_tokenizer(base, stopwords, stemmer))
 }
 
 // ── UAX #29 word breaks, restricted to ASCII ─────────────────────────
@@ -1125,6 +1294,17 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+
+    /// A parsed query's phrases as plain term lists. `Phrase`'s own
+    /// equality includes the offsets; these assertions are about which
+    /// terms a phrase parsed to, and the offsets of a phrase with no
+    /// analysis chain are always `0..n` (covered on its own below).
+    fn phrase_terms<'q>(phrases: &'q [Phrase<Cow<'q, str>>]) -> Vec<Vec<&'q str>> {
+        phrases
+            .iter()
+            .map(|p| p.iter().map(|t| &**t).collect())
+            .collect()
+    }
 
     fn tokens(text: &str) -> Vec<String> {
         AsciiLowerTokenizer.tokenize(text).collect()
@@ -1975,7 +2155,10 @@ mod tests {
     #[test]
     fn parse_pure_phrase() {
         let p = parse(r#""griffith observatory""#);
-        assert_eq!(p.positive_phrases, vec![vec!["griffith", "observatory"]]);
+        assert_eq!(
+            phrase_terms(&p.positive_phrases),
+            vec![vec!["griffith", "observatory"]]
+        );
         assert!(p.positives.is_empty());
         assert!(p.musts.is_empty());
     }
@@ -1983,15 +2166,18 @@ mod tests {
     #[test]
     fn parse_phrase_polarities() {
         let p = parse(r#"+"the who" -"memory unsafe" "new york""#);
-        assert_eq!(p.must_phrases, vec![vec!["the", "who"]]);
-        assert_eq!(p.negative_phrases, vec![vec!["memory", "unsafe"]]);
-        assert_eq!(p.positive_phrases, vec![vec!["new", "york"]]);
+        assert_eq!(phrase_terms(&p.must_phrases), vec![vec!["the", "who"]]);
+        assert_eq!(
+            phrase_terms(&p.negative_phrases),
+            vec![vec!["memory", "unsafe"]]
+        );
+        assert_eq!(phrase_terms(&p.positive_phrases), vec![vec!["new", "york"]]);
     }
 
     #[test]
     fn parse_phrase_mixes_with_terms() {
         let p = parse(r#"+"the who" +uk rust -python"#);
-        assert_eq!(p.must_phrases, vec![vec!["the", "who"]]);
+        assert_eq!(phrase_terms(&p.must_phrases), vec![vec!["the", "who"]]);
         assert_eq!(p.musts, vec!["uk"]);
         assert_eq!(p.positives, vec!["rust"]);
         assert_eq!(p.negatives, vec!["python"]);
@@ -2029,7 +2215,10 @@ mod tests {
         // Phrase innards run through the same tokenizer: lowercased,
         // punctuation split.
         let p = parse(r#""New-York City""#);
-        assert_eq!(p.positive_phrases, vec![vec!["new", "york", "city"]]);
+        assert_eq!(
+            phrase_terms(&p.positive_phrases),
+            vec![vec!["new", "york", "city"]]
+        );
     }
 
     #[test]
@@ -2039,26 +2228,29 @@ mod tests {
         // unquoted segment (its trailing `+` strips as punctuation).
         let p = parse(r#"abc+"x y""#);
         assert_eq!(p.positives, vec!["abc"]);
-        assert_eq!(p.positive_phrases, vec![vec!["x", "y"]]);
+        assert_eq!(phrase_terms(&p.positive_phrases), vec![vec!["x", "y"]]);
         assert!(p.must_phrases.is_empty());
     }
 
     #[test]
     fn parse_adjacent_phrases() {
         let p = parse(r#""a b""c d""#);
-        assert_eq!(p.positive_phrases, vec![vec!["a", "b"], vec!["c", "d"]]);
+        assert_eq!(
+            phrase_terms(&p.positive_phrases),
+            vec![vec!["a", "b"], vec!["c", "d"]]
+        );
     }
 
     #[test]
     fn into_clauses_resolves_phrase_polarity_by_mode() {
         let c = parse(r#""new york" +"the who" -"bad seq" rust"#).into_clauses(BoolMode::Or);
-        assert_eq!(c.should_phrases, vec![vec!["new", "york"]]);
-        assert_eq!(c.must_phrases, vec![vec!["the", "who"]]);
-        assert_eq!(c.negative_phrases, vec![vec!["bad", "seq"]]);
+        assert_eq!(phrase_terms(&c.should_phrases), vec![vec!["new", "york"]]);
+        assert_eq!(phrase_terms(&c.must_phrases), vec![vec!["the", "who"]]);
+        assert_eq!(phrase_terms(&c.negative_phrases), vec![vec!["bad", "seq"]]);
         assert_eq!(c.shoulds, vec!["rust"]);
 
         let c = parse(r#""new york" rust"#).into_clauses(BoolMode::And);
-        assert_eq!(c.must_phrases, vec![vec!["new", "york"]]);
+        assert_eq!(phrase_terms(&c.must_phrases), vec![vec!["new", "york"]]);
         assert!(c.should_phrases.is_empty());
         assert_eq!(c.musts, vec!["rust"]);
     }

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -891,7 +891,7 @@ pub const STANDARD_TOKENIZER: &str = "standard";
 /// translate `None` into their own error — a malformed-superfile read
 /// error, or an invalid-argument error at table-create time.
 ///
-/// Resolves a **base** analyzer name only. A column's stopword set and
+/// Resolves a **base tokenizer** name only. A column's stopword set and
 /// stemmer are separate persisted fields, so a chained column's
 /// tokenizer is built by [`chain_tokenizer`] from all three rather than
 /// resolved from a single string here — see

--- a/src/superfile/fts/tokenize.rs
+++ b/src/superfile/fts/tokenize.rs
@@ -48,7 +48,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use wide::u8x16;
 
 use super::{
-    analysis::{chain_tokenizer, parse_chain_name},
+    analysis::{Base, Stemmer, Stopwords, chain_tokenizer},
     reader::BoolMode,
 };
 
@@ -891,17 +891,14 @@ pub const STANDARD_TOKENIZER: &str = "standard";
 /// translate `None` into their own error — a malformed-superfile read
 /// error, or an invalid-argument error at table-create time.
 ///
-/// Accepts a bare base name (`"standard"`, `"ascii_lower"`) and the
-/// composite names of the analysis chain
-/// (`"standard+stop=english+stem=english"`), which is why this
-/// function is the format's fail-loud channel for analysis semantics:
-/// an engine that predates a filter does not know the composite name
-/// and refuses the file here, rather than tokenizing queries with a
-/// chain that is missing a filter and answering wrongly. See
+/// Resolves a **base** analyzer name only. A column's stopword set and
+/// stemmer are separate persisted fields, so a chained column's
+/// tokenizer is built by [`chain_tokenizer`] from all three rather than
+/// resolved from a single string here — see
 /// [`crate::superfile::fts::analysis`].
 pub fn tokenizer_for_name(name: &str) -> Option<Arc<dyn Tokenizer>> {
-    let (base, stopwords, stemmer) = parse_chain_name(name)?;
-    Some(chain_tokenizer(base, stopwords, stemmer))
+    let base = Base::from_name(name)?;
+    Some(chain_tokenizer(base, Stopwords::None, Stemmer::None))
 }
 
 // ── UAX #29 word breaks, restricted to ASCII ─────────────────────────

--- a/src/superfile/reader.rs
+++ b/src/superfile/reader.rs
@@ -57,7 +57,7 @@ use crate::{
                 self as fts_reader, BoolMode, ClauseLists, FtsReader, MatchWork, OrCursorSet,
                 PreparedClauses, TermPattern,
             },
-            tokenize::Tokenizer,
+            tokenize::{Phrase, Tokenizer},
         },
         vector::{
             layout::VectorLayout,
@@ -1113,11 +1113,11 @@ impl SuperfileReader {
         let musts: Vec<&str> = clauses.musts.iter().map(|t| &**t).collect();
         let shoulds: Vec<&str> = clauses.shoulds.iter().map(|t| &**t).collect();
         let negatives: Vec<&str> = clauses.negatives.iter().map(|t| &**t).collect();
-        let own = |phrases: Vec<Vec<Cow<'_, str>>>| -> Vec<Vec<String>> {
-            phrases
-                .into_iter()
-                .map(|p| p.into_iter().map(Cow::into_owned).collect())
-                .collect()
+        // `Phrase::map` keeps each term's offset, which is what a
+        // phrase on a stopworded column needs: its terms were not
+        // adjacent in the query and must not be required adjacent here.
+        let own = |phrases: Vec<Phrase<Cow<'_, str>>>| -> Vec<Phrase<String>> {
+            phrases.iter().map(|p| p.map(|t| t.to_string())).collect()
         };
         let must_phrases = own(clauses.must_phrases);
         let should_phrases = own(clauses.should_phrases);
@@ -1250,7 +1250,7 @@ impl SuperfileReader {
         &self,
         column: &str,
         terms: &[&str],
-        phrases: &[Vec<String>],
+        phrases: &[Phrase<String>],
         mode: BoolMode,
     ) -> Result<(Vec<u32>, MatchWork), ReadError> {
         let fts = self
@@ -1268,10 +1268,10 @@ impl SuperfileReader {
         &self,
         column: &str,
         terms: &[&str],
-        phrases: &[Vec<String>],
+        phrases: &[Phrase<String>],
         mode: BoolMode,
         neg_terms: &[&str],
-        neg_phrases: &[Vec<String>],
+        neg_phrases: &[Phrase<String>],
     ) -> Result<(u64, MatchWork), ReadError> {
         let fts = self
             .fts()

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -340,6 +340,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        Stemmer, Stopwords,
         superfile::{
             builder::{FtsConfig, VectorConfig},
             vector::{distance::Metric, rerank_codec::RerankCodec},
@@ -894,6 +895,63 @@ mod tests {
         assert!(rendered.contains(&expected.to_hex()), "got: {rendered}");
         // 32 bytes of 0x02 → 64-char hex string.
         assert!(rendered.contains(&"02".repeat(32)), "got: {rendered}");
+    }
+
+    /// A column's analysis filters join the table's identity, and a
+    /// filterless table's identity does not move.
+    ///
+    /// Both halves matter. The first: two tables differing only in a
+    /// stopword set hold different terms, so reopening one with the
+    /// other's options must mismatch rather than silently query a
+    /// differently-analyzed index. The second: the filters ride the
+    /// *derived* analyzer identity rather than a block of their own, and
+    /// a column with no filter derives to its plain tokenizer name — so
+    /// the byte stream for every table that predates the filters is
+    /// unchanged and its stored hash still verifies.
+    #[test]
+    fn analysis_filters_join_the_hash_and_a_filterless_table_is_unchanged() {
+        let strategy = time_range();
+        let hash_of = |fts: FtsConfig| {
+            let opts =
+                SupertableOptions::new(schema_title_only(), vec![fts], vec![]).expect("options");
+            compute_options_hash(&opts, &strategy)
+        };
+
+        let plain = hash_of(FtsConfig::new("title"));
+        let stopped = hash_of(FtsConfig::new("title").stopwords(Stopwords::English));
+        let stemmed = hash_of(FtsConfig::new("title").stemmer(Stemmer::English));
+        let both = hash_of(
+            FtsConfig::new("title")
+                .stopwords(Stopwords::English)
+                .stemmer(Stemmer::English),
+        );
+        for (label, h) in [
+            ("stopwords", &stopped),
+            ("stemmer", &stemmed),
+            ("both", &both),
+        ] {
+            assert_ne!(
+                &plain, h,
+                "{label}: a filtered column must not hash like an unfiltered one"
+            );
+        }
+        assert_ne!(&stopped, &stemmed, "the two filters are distinguishable");
+        assert_ne!(&stopped, &both);
+        assert_ne!(&stemmed, &both);
+
+        // Declaring the filters off explicitly is the same table as not
+        // mentioning them, so an existing table's stored hash still
+        // verifies after this feature ships.
+        assert_eq!(
+            plain,
+            hash_of(
+                FtsConfig::new("title")
+                    .stopwords(Stopwords::None)
+                    .stemmer(Stemmer::None)
+            ),
+            "a filterless column must hash exactly as it did before \
+             filters existed"
+        );
     }
 
     #[test]

--- a/src/supertable/manifest/options_hash.rs
+++ b/src/supertable/manifest/options_hash.rs
@@ -172,7 +172,14 @@ fn compute(
     if emit_analyzers {
         push_tag(&mut buf, b"fts_analyzers");
         for c in &opts.fts_columns {
-            push_str(&mut buf, &c.analyzer);
+            // The column's whole analysis as one derived string, not
+            // just its base name: two columns sharing a base but
+            // differing in a stopword set or stemmer are tokenized
+            // differently, so they must not hash alike. A column with
+            // no filter derives to its plain base name, keeping the
+            // stream byte-identical to hashes stamped before filters
+            // existed.
+            push_str(&mut buf, c.chain_name().unwrap_or(c.analyzer.as_str()));
         }
     }
     // 3d. stored flags — same only-when-non-default rule: an all-stored

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -66,7 +66,10 @@ use crate::{
     superfile::{
         OpenOptions,
         builder::{BuilderOptions, FtsConfig, VectorConfig},
-        fts::tokenize::{Tokenizer, tokenizer_for_name},
+        fts::{
+            analysis::{Base, chain_tokenizer},
+            tokenize::{Tokenizer, tokenizer_for_name},
+        },
         vector::layout::VectorLayout,
     },
     supertable::{
@@ -730,9 +733,13 @@ impl SupertableOptions {
             }
         }
 
-        // 5. Each FTS column's analyzer name must resolve. Validating
-        //    here surfaces a typo at construction with a typed error,
-        //    instead of at the first commit's builder construction.
+        // 5. Each FTS column's base analyzer name must resolve.
+        //    Validating here surfaces a typo at construction with a
+        //    typed error, instead of at the first commit's builder
+        //    construction. The stopword set and stemmer need no check:
+        //    they arrive as enums, so an unrepresentable one cannot be
+        //    constructed. (A *persisted* filter name is different and is
+        //    validated where it is read.)
         for fc in &fts_columns {
             if tokenizer_for_name(&fc.analyzer).is_none() {
                 return Err(BuildError::UnknownAnalyzer {
@@ -900,10 +907,13 @@ impl SupertableOptions {
     /// resolution cannot fail for a registered column). The lookup is a
     /// single pass over `fts_columns`.
     pub fn try_fts_tokenizer_for(&self, column: &str) -> Option<Arc<dyn Tokenizer>> {
-        self.fts_columns
-            .iter()
-            .find(|c| c.column == column)
-            .and_then(|c| tokenizer_for_name(&c.analyzer))
+        let cfg = self.fts_columns.iter().find(|c| c.column == column)?;
+        // The whole chain, not the base: every caller here tokenizes
+        // query-side text — search terms, an equality literal, a `LIKE`
+        // fragment — and must produce the forms the column was indexed
+        // under.
+        let base = Base::from_name(&cfg.analyzer)?;
+        Some(chain_tokenizer(base, cfg.stopwords, cfg.stemmer))
     }
 
     /// Attach a disk cache for storage-backed reads.

--- a/src/supertable/options.rs
+++ b/src/supertable/options.rs
@@ -733,7 +733,7 @@ impl SupertableOptions {
             }
         }
 
-        // 5. Each FTS column's base analyzer name must resolve.
+        // 5. Each FTS column's base tokenizer name must resolve.
         //    Validating here surfaces a typo at construction with a
         //    typed error, instead of at the first commit's builder
         //    construction. The stopword set and stemmer need no check:

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -1037,8 +1037,9 @@ mod tests {
     };
 
     use super::*;
-    use crate::superfile::fts::tokenize::{
-        AsciiLowerTokenizer, StandardTokenizer, tokenizer_for_name,
+    use crate::superfile::fts::{
+        analysis::{Base, Stemmer, Stopwords, chain_tokenizer},
+        tokenize::{AsciiLowerTokenizer, STANDARD_TOKENIZER, StandardTokenizer},
     };
 
     fn fts_cols() -> HashSet<&'static str> {
@@ -1056,7 +1057,46 @@ mod tests {
     /// Resolver whose column carries an analysis chain — the case the
     /// `LIKE` lowering must refuse to bound.
     fn stemming_resolver(_col: &str) -> Option<Arc<dyn Tokenizer>> {
-        tokenizer_for_name("standard+stem=english")
+        Some(chain_tokenizer(
+            Base::Standard,
+            Stopwords::None,
+            Stemmer::English,
+        ))
+    }
+
+    /// Resolver for a stopworded column.
+    fn stopping_resolver(_col: &str) -> Option<Arc<dyn Tokenizer>> {
+        Some(chain_tokenizer(
+            Base::Standard,
+            Stopwords::English,
+            Stemmer::None,
+        ))
+    }
+
+    /// The guard is that a chain's *derived name* matches no arm of
+    /// `Analyzer::of`. Asserted directly, because every `LIKE` test
+    /// below would also pass if the resolver simply returned no
+    /// tokenizer at all — a false pass that would hide the guard
+    /// disappearing.
+    #[test]
+    fn a_chains_name_is_recognized_by_no_analyzer_arm() {
+        let plain = chain_tokenizer(Base::Standard, Stopwords::None, Stemmer::None);
+        assert_eq!(plain.name(), STANDARD_TOKENIZER);
+        assert!(
+            Analyzer::of(plain.as_ref()).is_some(),
+            "a plain column must still be bounded"
+        );
+        for chained in [
+            chain_tokenizer(Base::Standard, Stopwords::English, Stemmer::None),
+            chain_tokenizer(Base::Standard, Stopwords::None, Stemmer::English),
+            chain_tokenizer(Base::AsciiLower, Stopwords::English, Stemmer::English),
+        ] {
+            assert!(
+                Analyzer::of(chained.as_ref()).is_none(),
+                "{:?} must not be recognized as a bare analyzer",
+                chained.name()
+            );
+        }
     }
 
     /// A stemmed column gets **no** `LIKE` constraint, in any fragment
@@ -1101,9 +1141,12 @@ mod tests {
         // Every token removed by the chain's stopword set: there is no
         // term left to require, so the predicate bounds nothing rather
         // than bounding it with an empty conjunction.
-        let stopping = |_col: &str| tokenizer_for_name("standard+stop=english");
         assert_eq!(
-            CandidatePlan::from_filters(&[col("title").eq(lit("of the"))], &fts_cols(), &stopping),
+            CandidatePlan::from_filters(
+                &[col("title").eq(lit("of the"))],
+                &fts_cols(),
+                &stopping_resolver
+            ),
             CandidatePlan::Unbounded
         );
     }

--- a/src/supertable/query/candidate.rs
+++ b/src/supertable/query/candidate.rs
@@ -847,6 +847,19 @@ enum Analyzer {
 }
 
 impl Analyzer {
+    /// Recognize a column's analyzer, or `None` for one whose token
+    /// rules this lowering cannot reason about — which drops the `LIKE`
+    /// constraint entirely and keeps every superfile.
+    ///
+    /// A column carrying an **analysis chain** lands in that `None`,
+    /// and must. The lowering bounds a `LIKE` fragment by the terms it
+    /// tokenizes to, which is only sound while a term in the index is a
+    /// substring-preserving image of the text: with a stemmer it is
+    /// not. `LIKE '%runni%'` matches the text `running`, whose indexed
+    /// term is `run` — so a prefix walk for `runni` finds nothing and
+    /// would drop a superfile that really matches. Nothing else here
+    /// needs to know about chains, because they never reach this
+    /// `match`: a chain's name is a composite one and no arm claims it.
     fn of(tok: &dyn Tokenizer) -> Option<Analyzer> {
         match tok.name() {
             ASCII_LOWER_TOKENIZER => Some(Analyzer::AsciiLower),
@@ -1024,7 +1037,9 @@ mod tests {
     };
 
     use super::*;
-    use crate::superfile::fts::tokenize::{AsciiLowerTokenizer, StandardTokenizer};
+    use crate::superfile::fts::tokenize::{
+        AsciiLowerTokenizer, StandardTokenizer, tokenizer_for_name,
+    };
 
     fn fts_cols() -> HashSet<&'static str> {
         let mut s = HashSet::new();
@@ -1036,6 +1051,61 @@ mod tests {
     /// ASCII-lower analyzer.
     fn ascii_resolver(_col: &str) -> Option<Arc<dyn Tokenizer>> {
         Some(Arc::new(AsciiLowerTokenizer))
+    }
+
+    /// Resolver whose column carries an analysis chain — the case the
+    /// `LIKE` lowering must refuse to bound.
+    fn stemming_resolver(_col: &str) -> Option<Arc<dyn Tokenizer>> {
+        tokenizer_for_name("standard+stem=english")
+    }
+
+    /// A stemmed column gets **no** `LIKE` constraint, in any fragment
+    /// shape. The lowering bounds a fragment by the terms it tokenizes
+    /// to, and stemming breaks the substring relationship that makes
+    /// that sound: `%runni%` matches the text `running`, which is
+    /// indexed as `run`, so a term or prefix bound built from `runni`
+    /// would drop a superfile that genuinely matches. Dropping the
+    /// constraint keeps a superset, which is always allowed; keeping a
+    /// wrong one is not.
+    #[test]
+    fn like_on_a_chained_column_is_unbounded() {
+        for pattern in ["running", "%runni%", "runn%", "%running", "run_ing"] {
+            let expr = col("title").like(lit(pattern));
+            assert_eq!(
+                CandidatePlan::from_filters(&[expr], &fts_cols(), &stemming_resolver),
+                CandidatePlan::Unbounded,
+                "LIKE {pattern:?} on a stemmed column must not be bounded"
+            );
+        }
+    }
+
+    /// Equality still lowers on a chained column, and soundly: the
+    /// literal runs through the *same* chain the postings did, so the
+    /// terms it yields are terms the index really holds, and requiring
+    /// them keeps a superset of the rows that actually compare equal.
+    /// A literal the chain reduces to nothing bounds nothing.
+    #[test]
+    fn equality_on_a_chained_column_lowers_to_the_chain_s_terms() {
+        let plan = CandidatePlan::from_filters(
+            &[col("title").eq(lit("running studies"))],
+            &fts_cols(),
+            &stemming_resolver,
+        );
+        assert_eq!(
+            plan,
+            CandidatePlan::TermsAll {
+                column: "title".to_string(),
+                tokens: vec!["run".to_string(), "studi".to_string()],
+            }
+        );
+        // Every token removed by the chain's stopword set: there is no
+        // term left to require, so the predicate bounds nothing rather
+        // than bounding it with an empty conjunction.
+        let stopping = |_col: &str| tokenizer_for_name("standard+stop=english");
+        assert_eq!(
+            CandidatePlan::from_filters(&[col("title").eq(lit("of the"))], &fts_cols(), &stopping),
+            CandidatePlan::Unbounded
+        );
     }
 
     fn plan(expr: Expr) -> CandidatePlan {

--- a/src/supertable/query/fts.rs
+++ b/src/supertable/query/fts.rs
@@ -128,6 +128,7 @@ use crate::{
                 Bm25SearchOptions, Bm25Stats, ClauseLists, FetchedTermMemo, GlobalTermIdf,
                 LiveFloor, OR_WINDOW_MIN_TERMS, OrCursorSet, PreparedClauses,
             },
+            tokenize::Phrase,
         },
     },
     supertable::{
@@ -242,7 +243,7 @@ impl GlobalIdfCache {
 /// side under the default operator otherwise.
 struct UnrankedMatchSet {
     terms: Vec<String>,
-    phrases: Vec<Vec<String>>,
+    phrases: Vec<Phrase<String>>,
     mode: BoolMode,
 }
 
@@ -267,7 +268,7 @@ impl UnrankedMatchSet {
 #[derive(Default)]
 struct UnrankedNegatives {
     terms: Vec<String>,
-    phrases: Vec<Vec<String>>,
+    phrases: Vec<Phrase<String>>,
 }
 
 impl UnrankedNegatives {
@@ -481,11 +482,11 @@ impl SupertableReader {
         let musts: Vec<String> = clauses.musts.into_iter().map(Cow::into_owned).collect();
         let shoulds: Vec<String> = clauses.shoulds.into_iter().map(Cow::into_owned).collect();
         let negatives: Vec<String> = clauses.negatives.into_iter().map(Cow::into_owned).collect();
-        let own_phrases = |phrases: Vec<Vec<Cow<'_, str>>>| -> Vec<Vec<String>> {
-            phrases
-                .into_iter()
-                .map(|p| p.into_iter().map(Cow::into_owned).collect())
-                .collect()
+        // `Phrase::map` keeps each term's offset, which is what a
+        // phrase on a stopworded column needs: its terms were not
+        // adjacent in the query and must not be required adjacent here.
+        let own_phrases = |phrases: Vec<Phrase<Cow<'_, str>>>| -> Vec<Phrase<String>> {
+            phrases.iter().map(|p| p.map(|t| t.to_string())).collect()
         };
         let must_phrases = own_phrases(clauses.must_phrases);
         let should_phrases = own_phrases(clauses.should_phrases);
@@ -569,7 +570,7 @@ impl SupertableReader {
                     add(t);
                 }
                 for phrase in must_phrases.iter().chain(should_phrases.iter()) {
-                    for member in phrase {
+                    for member in phrase.iter() {
                         add(member);
                     }
                 }
@@ -610,9 +611,9 @@ impl SupertableReader {
         let must_arc: Arc<Vec<String>> = Arc::new(musts);
         let should_arc: Arc<Vec<String>> = Arc::new(shoulds);
         let neg_arc: Arc<Vec<String>> = Arc::new(negatives);
-        let must_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(must_phrases);
-        let should_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(should_phrases);
-        let neg_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(negative_phrases);
+        let must_ph_arc: Arc<Vec<Phrase<String>>> = Arc::new(must_phrases);
+        let should_ph_arc: Arc<Vec<Phrase<String>>> = Arc::new(should_phrases);
+        let neg_ph_arc: Arc<Vec<Phrase<String>>> = Arc::new(negative_phrases);
         let column_arc = Arc::new(column_owned);
 
         // Cross-segment threshold sharing: each unit reads the global
@@ -1280,11 +1281,11 @@ impl SupertableReader {
         let musts: Vec<String> = dedup(clauses.musts);
         let shoulds: Vec<String> = dedup(clauses.shoulds);
         let negatives: Vec<String> = dedup(clauses.negatives);
-        let own_phrases = |phrases: Vec<Vec<Cow<'_, str>>>| -> Vec<Vec<String>> {
-            phrases
-                .into_iter()
-                .map(|p| p.into_iter().map(Cow::into_owned).collect())
-                .collect()
+        // `Phrase::map` keeps each term's offset, which is what a
+        // phrase on a stopworded column needs: its terms were not
+        // adjacent in the query and must not be required adjacent here.
+        let own_phrases = |phrases: Vec<Phrase<Cow<'_, str>>>| -> Vec<Phrase<String>> {
+            phrases.iter().map(|p| p.map(|t| t.to_string())).collect()
         };
         let must_phrases = own_phrases(clauses.must_phrases);
         let should_phrases = own_phrases(clauses.should_phrases);
@@ -1366,9 +1367,9 @@ impl SupertableReader {
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
         let column_arc = Arc::new(column.to_owned());
         let term_arc: Arc<Vec<String>> = Arc::new(match_set.terms);
-        let phrase_arc: Arc<Vec<Vec<String>>> = Arc::new(match_set.phrases);
+        let phrase_arc: Arc<Vec<Phrase<String>>> = Arc::new(match_set.phrases);
         let neg_arc: Arc<Vec<String>> = Arc::new(negatives.terms);
-        let neg_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(negatives.phrases);
+        let neg_ph_arc: Arc<Vec<Phrase<String>>> = Arc::new(negatives.phrases);
         let op_stats = self.op_stats.clone();
         let kernel = move |r: Arc<SuperfileReader>, _: ()| {
             let column_arc = Arc::clone(&column_arc);
@@ -1472,9 +1473,9 @@ impl SupertableReader {
         let phrase_involved = match_set.has_phrases() || !negatives.phrases.is_empty();
         let column_arc = Arc::new(column.to_owned());
         let term_arc: Arc<Vec<String>> = Arc::new(match_set.terms);
-        let phrase_arc: Arc<Vec<Vec<String>>> = Arc::new(match_set.phrases);
+        let phrase_arc: Arc<Vec<Phrase<String>>> = Arc::new(match_set.phrases);
         let neg_arc: Arc<Vec<String>> = Arc::new(negatives.terms);
-        let neg_ph_arc: Arc<Vec<Vec<String>>> = Arc::new(negatives.phrases);
+        let neg_ph_arc: Arc<Vec<Phrase<String>>> = Arc::new(negatives.phrases);
         let units: Vec<(Arc<SuperfileEntry>, ())> = kept.into_iter().map(|e| (e, ())).collect();
 
         // Shared fan-out (`dispatch::fanout_with`): warms tombstones,

--- a/src/test_helpers/brute_force_bm25.rs
+++ b/src/test_helpers/brute_force_bm25.rs
@@ -26,7 +26,7 @@
 
 use std::{cmp::Ordering, collections::HashMap};
 
-use crate::superfile::fts::tokenize::Tokenizer;
+use crate::superfile::fts::tokenize::{Phrase, Tokenizer};
 
 /// Standard BM25 default parameters. Match the constants used by
 /// the production scoring path.
@@ -52,15 +52,36 @@ impl Default for OracleBm25Params {
     }
 }
 
-/// Number of times `phrase` occurs contiguously (in order) in
-/// `tokens` — the brute-force phrase tf.
-fn phrase_tf(tokens: &[String], phrase: &[String]) -> u32 {
+/// Number of times `phrase` occurs in `tokens` at the spacing its
+/// offsets declare — the brute-force phrase tf.
+///
+/// Walks positions rather than token indices because a doc's tokens are
+/// not necessarily consecutive: an analysis chain that removes a
+/// stopword leaves a hole where it was, and the phrase's own offsets
+/// carry the matching holes from the query side. With no chain both are
+/// dense and this reduces to "the phrase's words occur contiguously in
+/// order", which is what it checked before offsets existed.
+fn phrase_tf(tokens: &[(String, u64)], phrase: &Phrase<String>) -> u32 {
     if phrase.is_empty() || tokens.len() < phrase.len() {
         return 0;
     }
     let mut tf = 0u32;
-    for start in 0..=(tokens.len() - phrase.len()) {
-        if tokens[start..start + phrase.len()] == *phrase {
+    for (anchor, anchor_pos) in tokens {
+        if anchor != &phrase.terms[0] {
+            continue;
+        }
+        // Every later member must sit at the anchor's position plus its
+        // declared offset, carrying the same token.
+        let matched = phrase
+            .terms
+            .iter()
+            .zip(phrase.offsets())
+            .skip(1)
+            .all(|(term, off)| {
+                let want = anchor_pos + *off as u64;
+                tokens.iter().any(|(t, p)| *p == want && t == term)
+            });
+        if matched {
             tf += 1;
         }
     }
@@ -76,8 +97,11 @@ struct DocStats {
     dl: u32,
     /// Term frequencies for this doc: term → count.
     tf: HashMap<String, u32>,
-    /// The doc's token sequence, for phrase adjacency scans.
-    tokens: Vec<String>,
+    /// The doc's tokens with their gap-inclusive positions, for phrase
+    /// scans. Positions are not necessarily `0..n`: an analysis chain
+    /// that drops a token leaves its ordinal behind as a hole, exactly
+    /// as the index does.
+    tokens: Vec<(String, u64)>,
 }
 
 /// Pre-tokenized corpus + per-term df + corpus avgdl. Construct
@@ -105,12 +129,17 @@ impl BruteForceBm25 {
 
         for (doc_id, text) in corpus {
             let mut tf: HashMap<String, u32> = HashMap::new();
-            let mut tokens: Vec<String> = Vec::new();
+            let mut tokens: Vec<(String, u64)> = Vec::new();
             let mut dl: u32 = 0;
-            tokenizer.tokenize_each(text, &mut |tok| {
+            // Positioned, so a chain's stopword holes reach the phrase
+            // scan. Doc length counts *emitted* tokens — what the
+            // engine counts, and what Lucene's norms count — so a
+            // dropped token advances the position without lengthening
+            // the document.
+            tokenizer.tokenize_each_positioned(text, &mut |tok, position| {
                 dl += 1;
                 *tf.entry(tok.to_owned()).or_insert(0) += 1;
-                tokens.push(tok.to_owned());
+                tokens.push((tok.to_owned(), position));
             });
             for term in tf.keys() {
                 *df.entry(term.clone()).or_insert(0) += 1;
@@ -285,11 +314,11 @@ impl BruteForceBm25 {
     pub fn top_k_atoms(
         &self,
         musts: &[String],
-        must_phrases: &[Vec<String>],
+        must_phrases: &[Phrase<String>],
         shoulds: &[String],
-        should_phrases: &[Vec<String>],
+        should_phrases: &[Phrase<String>],
         negatives: &[String],
-        negative_phrases: &[Vec<String>],
+        negative_phrases: &[Phrase<String>],
         k: usize,
     ) -> Vec<(u64, f32)> {
         let no_positive = musts.is_empty()
@@ -308,7 +337,7 @@ impl BruteForceBm25 {
                 false => 0.0,
             }
         };
-        let phrase_idf = |p: &Vec<String>| -> f32 { p.iter().map(idf_of).sum() };
+        let phrase_idf = |p: &Phrase<String>| -> f32 { p.iter().map(idf_of).sum() };
 
         let avgdl = self.avgdl;
         let mut scored: Vec<(u64, f32)> = Vec::with_capacity(self.docs.len());

--- a/tests/superfile/fts/analysis_chain.rs
+++ b/tests/superfile/fts/analysis_chain.rs
@@ -29,21 +29,17 @@ use std::{
     sync::Arc,
 };
 
-use arrow_array::{LargeStringArray, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
-use bytes::Bytes;
 use infino::{
     Stemmer, Stopwords,
     superfile::{
         SuperfileReader,
-        builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
-        fts::{
-            reader::BoolMode,
-            tokenize::{Phrase, Tokenizer},
-        },
+        builder::FtsConfig,
+        fts::{reader::BoolMode, tokenize::Tokenizer},
     },
-    test_helpers::{brute_force_bm25::BruteForceBm25, decimal128_ids},
+    test_helpers::brute_force_bm25::BruteForceBm25,
 };
+
+use crate::fts::brute_force_oracle::{build_infino_superfile_with_fts, oracle_top_k_atoms};
 
 /// k large enough to capture every match on the corpus below.
 const K_ALL: usize = 64;
@@ -78,33 +74,17 @@ fn corpus() -> Vec<(u64, &'static str)> {
 fn build(
     stopwords: Stopwords,
     stemmer: Stemmer,
-    analyzer: &str,
+    tokenizer: &str,
 ) -> (SuperfileReader, BruteForceBm25, Arc<dyn Tokenizer>) {
     let corp = corpus();
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("doc_id", DataType::Decimal128(38, 0), false),
-        Field::new("title", DataType::LargeUtf8, false),
-    ]));
-    let opts = BuilderOptions::new(
-        schema.clone(),
-        "doc_id",
-        vec![
-            FtsConfig::new("title")
-                .analyzer(analyzer)
-                .stopwords(stopwords)
-                .stemmer(stemmer)
-                .positions(true),
-        ],
-        vec![],
+    let reader = build_infino_superfile_with_fts(
+        &corp,
+        FtsConfig::new("title")
+            .analyzer(tokenizer)
+            .stopwords(stopwords)
+            .stemmer(stemmer)
+            .positions(true),
     );
-    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
-    let ids = decimal128_ids(corp.iter().map(|(i, _)| *i));
-    let titles = LargeStringArray::from(corp.iter().map(|(_, t)| *t).collect::<Vec<_>>());
-    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
-        .expect("build RecordBatch");
-    b.add_batch(&batch, &[]).expect("add_batch");
-    let bytes = Bytes::from(b.finish().expect("finish builder"));
-    let reader = SuperfileReader::open(bytes).expect("open superfile");
     // Take the tokenizer back off the *reader*, not from a name: it is
     // the one the reader will tokenize queries with, so the oracle is
     // graded against the engine's own analysis rather than a
@@ -173,22 +153,7 @@ async fn assert_matches_oracle(
     query: &str,
     mode: BoolMode,
 ) {
-    let clauses = tok.parse(query).into_clauses(mode);
-    let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
-        v.into_iter().map(|t| t.into_owned()).collect()
-    };
-    let own_ph = |v: Vec<Phrase<std::borrow::Cow<'_, str>>>| -> Vec<Phrase<String>> {
-        v.iter().map(|p| p.map(|t| t.to_string())).collect()
-    };
-    let want = oracle.top_k_atoms(
-        &own(clauses.musts),
-        &own_ph(clauses.must_phrases),
-        &own(clauses.shoulds),
-        &own_ph(clauses.should_phrases),
-        &own(clauses.negatives),
-        &own_ph(clauses.negative_phrases),
-        K_ALL,
-    );
+    let want = oracle_top_k_atoms(oracle, tok, query, mode, K_ALL);
     let got: Vec<(u64, f32)> = reader
         .bm25_hits_async("title", query, K_ALL, mode)
         .await

--- a/tests/superfile/fts/analysis_chain.rs
+++ b/tests/superfile/fts/analysis_chain.rs
@@ -33,12 +33,13 @@ use arrow_array::{LargeStringArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use infino::{
+    Stemmer, Stopwords,
     superfile::{
         SuperfileReader,
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
         fts::{
             reader::BoolMode,
-            tokenize::{Phrase, Tokenizer, tokenizer_for_name},
+            tokenize::{Phrase, Tokenizer},
         },
     },
     test_helpers::{brute_force_bm25::BruteForceBm25, decimal128_ids},
@@ -74,7 +75,11 @@ fn corpus() -> Vec<(u64, &'static str)> {
     ]
 }
 
-fn build(analyzer: &str) -> (SuperfileReader, BruteForceBm25, Arc<dyn Tokenizer>) {
+fn build(
+    stopwords: Stopwords,
+    stemmer: Stemmer,
+    analyzer: &str,
+) -> (SuperfileReader, BruteForceBm25, Arc<dyn Tokenizer>) {
     let corp = corpus();
     let schema = Arc::new(Schema::new(vec![
         Field::new("doc_id", DataType::Decimal128(38, 0), false),
@@ -83,7 +88,13 @@ fn build(analyzer: &str) -> (SuperfileReader, BruteForceBm25, Arc<dyn Tokenizer>
     let opts = BuilderOptions::new(
         schema.clone(),
         "doc_id",
-        vec![FtsConfig::new("title").analyzer(analyzer).positions(true)],
+        vec![
+            FtsConfig::new("title")
+                .analyzer(analyzer)
+                .stopwords(stopwords)
+                .stemmer(stemmer)
+                .positions(true),
+        ],
         vec![],
     );
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
@@ -94,12 +105,51 @@ fn build(analyzer: &str) -> (SuperfileReader, BruteForceBm25, Arc<dyn Tokenizer>
     b.add_batch(&batch, &[]).expect("add_batch");
     let bytes = Bytes::from(b.finish().expect("finish builder"));
     let reader = SuperfileReader::open(bytes).expect("open superfile");
-    // The oracle indexes the same corpus through the same chain, which
-    // is the whole point: grading a chained column against the base
-    // tokenizer would compare two different formulas and pass nothing.
-    let tok = tokenizer_for_name(analyzer).expect("known analyzer");
+    // Take the tokenizer back off the *reader*, not from a name: it is
+    // the one the reader will tokenize queries with, so the oracle is
+    // graded against the engine's own analysis rather than a
+    // reconstruction of it that could drift.
+    let tok = Arc::clone(
+        &reader
+            .fts()
+            .expect("fts index")
+            .fts_columns_config()
+            .next()
+            .expect("has column")
+            .tokenizer,
+    );
     let oracle = BruteForceBm25::index(&corp, tok.as_ref());
     (reader, oracle, tok)
+}
+
+/// The chains under test, with the label used in assertion messages.
+fn chains() -> Vec<(&'static str, Stopwords, Stemmer, &'static str)> {
+    vec![
+        (
+            "standard+stop",
+            Stopwords::English,
+            Stemmer::None,
+            "standard",
+        ),
+        (
+            "standard+stem",
+            Stopwords::None,
+            Stemmer::English,
+            "standard",
+        ),
+        (
+            "standard+stop+stem",
+            Stopwords::English,
+            Stemmer::English,
+            "standard",
+        ),
+        (
+            "ascii_lower+stop+stem",
+            Stopwords::English,
+            Stemmer::English,
+            "ascii_lower",
+        ),
+    ]
 }
 
 /// Doc-ids a query matches, as a set.
@@ -189,13 +239,20 @@ async fn chained_columns_match_the_textbook_scorer() {
         // disagreement.
         "the and of",
     ];
-    for analyzer in [
-        "standard+stop=english",
-        "standard+stem=english",
-        "standard+stop=english+stem=english",
-        "ascii_lower+stop=english+stem=english",
-    ] {
-        let (reader, oracle, tok) = build(analyzer);
+    for (label, stopwords, stemmer, base) in chains() {
+        let (reader, oracle, tok) = build(stopwords, stemmer, base);
+        assert_eq!(
+            tok.name(),
+            reader
+                .fts()
+                .expect("fts index")
+                .fts_columns_config()
+                .next()
+                .expect("has column")
+                .tokenizer
+                .name(),
+            "{label}: fixture drift"
+        );
         for query in queries {
             for mode in [BoolMode::Or, BoolMode::And] {
                 assert_matches_oracle(&reader, &oracle, tok.as_ref(), query, mode).await;
@@ -211,7 +268,7 @@ async fn chained_columns_match_the_textbook_scorer() {
 /// implementations the same way still fails here.
 #[tokio::test]
 async fn phrase_holes_separate_documents_that_differ_only_by_a_stopword() {
-    let (reader, _, _) = build("standard+stop=english");
+    let (reader, _, _) = build(Stopwords::English, Stemmer::None, "standard");
     // Doc 2 is "new york city", doc 3 is "new the york city". Only the
     // first has the two words adjacent.
     assert_eq!(matching(&reader, "\"new york\"").await, HashSet::from([2]));
@@ -236,7 +293,7 @@ async fn phrase_holes_separate_documents_that_differ_only_by_a_stopword() {
 /// other spelling of it.
 #[tokio::test]
 async fn stemming_is_symmetric_across_inflections() {
-    let (reader, _, _) = build("standard+stem=english");
+    let (reader, _, _) = build(Stopwords::None, Stemmer::English, "standard");
     // "walking walked walks walk" (doc 10) is reachable by all four.
     for spelling in ["walking", "walked", "walks", "walk"] {
         let hits = matching(&reader, spelling).await;

--- a/tests/superfile/fts/analysis_chain.rs
+++ b/tests/superfile/fts/analysis_chain.rs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Infino Authors
+
+//! BM25 correctness oracle for a column carrying an **analysis chain**
+//! — a stopword set, a stemmer, or both, on top of a base tokenizer.
+//!
+//! Same discipline as `brute_force_oracle`: the optimized walks are
+//! graded against the textbook scorer in
+//! [`infino::test_helpers::brute_force_bm25`], which shares no code
+//! with them. The chain adds two things that could disagree silently,
+//! so both are graded here rather than only asserted against planted
+//! truth:
+//!
+//! * **Doc length.** Removing a stopword shortens the document, which
+//!   moves *every* score in the column through the BM25 length
+//!   normalizer. If the engine and the oracle counted length
+//!   differently — one counting the tokens the chain emitted, the other
+//!   the tokens it saw — the ranking would still look plausible and be
+//!   wrong. Both count emitted tokens, which is what Lucene's norms
+//!   count and what a merge's carried postings preserve.
+//! * **Phrase spacing.** A removed token leaves a position hole on both
+//!   sides: the index skips its ordinal, and a quoted query carries the
+//!   matching offsets. The phrase oracle walks positions for the same
+//!   reason, so a hole the engine left and one the query asked for have
+//!   to line up exactly.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use arrow_array::{LargeStringArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use bytes::Bytes;
+use infino::{
+    superfile::{
+        SuperfileReader,
+        builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
+        fts::{
+            reader::BoolMode,
+            tokenize::{Phrase, Tokenizer, tokenizer_for_name},
+        },
+    },
+    test_helpers::{brute_force_bm25::BruteForceBm25, decimal128_ids},
+};
+
+/// k large enough to capture every match on the corpus below.
+const K_ALL: usize = 64;
+/// Score-equality tolerance between the two BM25 implementations.
+const SCORE_ABS_TOLERANCE: f32 = 1e-3;
+
+/// Prose corpus: stopwords in every position (leading, interior,
+/// trailing, consecutive), inflections that stem together, and
+/// documents that differ *only* in the stopwords between two content
+/// words — which is what makes the phrase holes observable.
+fn corpus() -> Vec<(u64, &'static str)> {
+    vec![
+        (0, "the end of the world is nigh"),
+        (1, "end world"),
+        (2, "new york city"),
+        (3, "new the york city"),
+        (4, "running the studies of the mind"),
+        (5, "she runs and he ran"),
+        (6, "a runner runs the race"),
+        (7, "the studies are not conclusive"),
+        (8, "study the world"),
+        (9, "of the and to be it is"),
+        (10, "walking walked walks walk"),
+        (11, "the quick brown fox jumps over the lazy dog"),
+        (12, "fox and hound"),
+        (13, "cities and their studies"),
+        (14, "the city studies running"),
+        (15, "nothing here at all"),
+    ]
+}
+
+fn build(analyzer: &str) -> (SuperfileReader, BruteForceBm25, Arc<dyn Tokenizer>) {
+    let corp = corpus();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("doc_id", DataType::Decimal128(38, 0), false),
+        Field::new("title", DataType::LargeUtf8, false),
+    ]));
+    let opts = BuilderOptions::new(
+        schema.clone(),
+        "doc_id",
+        vec![FtsConfig::new("title").analyzer(analyzer).positions(true)],
+        vec![],
+    );
+    let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
+    let ids = decimal128_ids(corp.iter().map(|(i, _)| *i));
+    let titles = LargeStringArray::from(corp.iter().map(|(_, t)| *t).collect::<Vec<_>>());
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)])
+        .expect("build RecordBatch");
+    b.add_batch(&batch, &[]).expect("add_batch");
+    let bytes = Bytes::from(b.finish().expect("finish builder"));
+    let reader = SuperfileReader::open(bytes).expect("open superfile");
+    // The oracle indexes the same corpus through the same chain, which
+    // is the whole point: grading a chained column against the base
+    // tokenizer would compare two different formulas and pass nothing.
+    let tok = tokenizer_for_name(analyzer).expect("known analyzer");
+    let oracle = BruteForceBm25::index(&corp, tok.as_ref());
+    (reader, oracle, tok)
+}
+
+/// Doc-ids a query matches, as a set.
+async fn matching(reader: &SuperfileReader, query: &str) -> HashSet<u64> {
+    reader
+        .bm25_hits_async("title", query, K_ALL, BoolMode::Or)
+        .await
+        .expect("query")
+        .into_iter()
+        .map(|(d, _)| d as u64)
+        .collect()
+}
+
+/// Grade one query's match set *and* per-doc scores against the
+/// oracle, through the clause model so phrases in every polarity are
+/// covered.
+async fn assert_matches_oracle(
+    reader: &SuperfileReader,
+    oracle: &BruteForceBm25,
+    tok: &dyn Tokenizer,
+    query: &str,
+    mode: BoolMode,
+) {
+    let clauses = tok.parse(query).into_clauses(mode);
+    let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
+        v.into_iter().map(|t| t.into_owned()).collect()
+    };
+    let own_ph = |v: Vec<Phrase<std::borrow::Cow<'_, str>>>| -> Vec<Phrase<String>> {
+        v.iter().map(|p| p.map(|t| t.to_string())).collect()
+    };
+    let want = oracle.top_k_atoms(
+        &own(clauses.musts),
+        &own_ph(clauses.must_phrases),
+        &own(clauses.shoulds),
+        &own_ph(clauses.should_phrases),
+        &own(clauses.negatives),
+        &own_ph(clauses.negative_phrases),
+        K_ALL,
+    );
+    let got: Vec<(u64, f32)> = reader
+        .bm25_hits_async("title", query, K_ALL, mode)
+        .await
+        .expect("chained-column query")
+        .into_iter()
+        .map(|(d, s)| (d as u64, s))
+        .collect();
+
+    let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();
+    let want_ids: HashSet<u64> = want.iter().map(|(d, _)| *d).collect();
+    assert_eq!(got_ids, want_ids, "query {query:?}: match sets disagree");
+
+    let want_scores: HashMap<u64, f32> = want.into_iter().collect();
+    for (doc, score) in got {
+        let expected = want_scores[&doc];
+        assert!(
+            (score - expected).abs() <= SCORE_ABS_TOLERANCE,
+            "query {query:?} doc {doc}: score {score} vs oracle {expected}"
+        );
+    }
+}
+
+/// Every chain, every clause shape, graded on scores as well as sets.
+/// The scores are the part that pins doc length: a length disagreement
+/// keeps the match sets identical and moves every number.
+#[tokio::test]
+async fn chained_columns_match_the_textbook_scorer() {
+    let queries = [
+        // Single terms, common and rare.
+        "world",
+        "studies",
+        "running",
+        "fox",
+        // Unions and conjunctions.
+        "world studies",
+        "+running +studies",
+        "city studies running",
+        // Negation.
+        "studies -running",
+        // Phrases, adjacent and holed.
+        "\"new york\"",
+        "\"end of the world\"",
+        "\"the studies\"",
+        "+\"new york\" city",
+        "world -\"end of the world\"",
+        // Queries made entirely of words a stopword set removes: no
+        // clause survives, which must be an empty result and not a
+        // disagreement.
+        "the and of",
+    ];
+    for analyzer in [
+        "standard+stop=english",
+        "standard+stem=english",
+        "standard+stop=english+stem=english",
+        "ascii_lower+stop=english+stem=english",
+    ] {
+        let (reader, oracle, tok) = build(analyzer);
+        for query in queries {
+            for mode in [BoolMode::Or, BoolMode::And] {
+                assert_matches_oracle(&reader, &oracle, tok.as_ref(), query, mode).await;
+            }
+        }
+    }
+}
+
+/// The hole is load-bearing, not incidental: on a stopworded column
+/// `"new york"` must separate two documents that differ only by the
+/// stopword between those two words. Asserted against corpus truth
+/// rather than the oracle, so a hole bug that happens to affect both
+/// implementations the same way still fails here.
+#[tokio::test]
+async fn phrase_holes_separate_documents_that_differ_only_by_a_stopword() {
+    let (reader, _, _) = build("standard+stop=english");
+    // Doc 2 is "new york city", doc 3 is "new the york city". Only the
+    // first has the two words adjacent.
+    assert_eq!(matching(&reader, "\"new york\"").await, HashSet::from([2]));
+    // ...and asking for them one apart selects the other one, which is
+    // the same mechanism read in the opposite direction.
+    assert_eq!(
+        matching(&reader, "\"new the york\"").await,
+        HashSet::from([3])
+    );
+    // Doc 0 is "the end of the world is nigh", doc 1 is "end world".
+    // The query's own removed words are the spacing it asks for, so it
+    // selects doc 0 — and the adjacent spelling selects doc 1.
+    assert_eq!(
+        matching(&reader, "\"end of the world\"").await,
+        HashSet::from([0])
+    );
+    assert_eq!(matching(&reader, "\"end world\"").await, HashSet::from([1]));
+}
+
+/// A stemmed column folds inflections onto one term, and the effect is
+/// symmetric: any spelling of a word finds every document holding any
+/// other spelling of it.
+#[tokio::test]
+async fn stemming_is_symmetric_across_inflections() {
+    let (reader, _, _) = build("standard+stem=english");
+    // "walking walked walks walk" (doc 10) is reachable by all four.
+    for spelling in ["walking", "walked", "walks", "walk"] {
+        let hits = matching(&reader, spelling).await;
+        assert!(
+            hits.contains(&10),
+            "{spelling:?} must reach the document holding its inflections"
+        );
+    }
+    // Every spelling of "run" reaches the same set, because they are one
+    // term in the index.
+    let running = matching(&reader, "running").await;
+    assert_eq!(running, matching(&reader, "runs").await);
+    assert_eq!(running, matching(&reader, "run").await);
+    // Porter2 has no rule for the irregular past, so "ran" stays its own
+    // term — a stemmer folds what it has rules for, not everything.
+    assert_ne!(running, matching(&reader, "ran").await);
+}

--- a/tests/superfile/fts/brute_force_oracle.rs
+++ b/tests/superfile/fts/brute_force_oracle.rs
@@ -28,6 +28,7 @@
 //! "ordered equality".
 
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
@@ -39,7 +40,10 @@ use infino::{
     superfile::{
         SuperfileReader,
         builder::{BuilderOptions, FtsConfig, SuperfileBuilder},
-        fts::reader::BoolMode,
+        fts::{
+            reader::BoolMode,
+            tokenize::{Phrase, Tokenizer},
+        },
     },
     test_helpers::{brute_force_bm25::BruteForceBm25, decimal128_ids, default_tokenizer},
 };
@@ -123,16 +127,18 @@ pub fn build_infino_superfile_positional(corpus: &[(u64, &str)]) -> SuperfileRea
 }
 
 fn build_infino_superfile_with(corpus: &[(u64, &str)], positions: bool) -> SuperfileReader {
+    build_infino_superfile_with_fts(corpus, FtsConfig::new("title").positions(positions))
+}
+
+/// Build the same single-superfile fixture under an arbitrary
+/// [`FtsConfig`], for tests that need a non-default analysis (a stopword
+/// set, a stemmer) rather than just positions on or off.
+pub fn build_infino_superfile_with_fts(corpus: &[(u64, &str)], fts: FtsConfig) -> SuperfileReader {
     let schema = Arc::new(Schema::new(vec![
         Field::new("doc_id", DataType::Decimal128(38, 0), false),
         Field::new("title", DataType::LargeUtf8, false),
     ]));
-    let opts = BuilderOptions::new(
-        schema.clone(),
-        "doc_id",
-        vec![FtsConfig::new("title").positions(positions)],
-        vec![],
-    );
+    let opts = BuilderOptions::new(schema.clone(), "doc_id", vec![fts], vec![]);
     let mut b = SuperfileBuilder::new(opts).expect("new SuperfileBuilder");
     let ids = decimal128_ids(corpus.iter().map(|(i, _)| *i));
     let titles = LargeStringArray::from(corpus.iter().map(|(_, t)| *t).collect::<Vec<_>>());
@@ -141,6 +147,38 @@ fn build_infino_superfile_with(corpus: &[(u64, &str)], positions: bool) -> Super
     b.add_batch(&batch, &[]).expect("add_batch");
     let bytes = Bytes::from(b.finish().expect("finish builder"));
     SuperfileReader::open(bytes).expect("open superfile")
+}
+
+/// Oracle top-k for `query` under `mode`, parsed with `tok`.
+///
+/// Parsing here with the *same* tokenizer the reader uses is the point:
+/// it means a difference in how the query was split into clauses can
+/// never masquerade as a difference in scoring. `Phrase::map` carries
+/// each term's offset across, so a phrase is graded at the spacing the
+/// parser derived rather than at adjacency — which is what a stopworded
+/// column needs, and a no-op for every other column.
+pub fn oracle_top_k_atoms(
+    oracle: &BruteForceBm25,
+    tok: &dyn Tokenizer,
+    query: &str,
+    mode: BoolMode,
+    k: usize,
+) -> Vec<(u64, f32)> {
+    let clauses = tok.parse(query).into_clauses(mode);
+    let own =
+        |v: Vec<Cow<'_, str>>| -> Vec<String> { v.into_iter().map(Cow::into_owned).collect() };
+    let own_ph = |v: Vec<Phrase<Cow<'_, str>>>| -> Vec<Phrase<String>> {
+        v.iter().map(|p| p.map(|t| t.to_string())).collect()
+    };
+    oracle.top_k_atoms(
+        &own(clauses.musts),
+        &own_ph(clauses.must_phrases),
+        &own(clauses.shoulds),
+        &own_ph(clauses.should_phrases),
+        &own(clauses.negatives),
+        &own_ph(clauses.negative_phrases),
+        k,
+    )
 }
 
 /// Run infino's BM25 search and return doc_ids in score-descending

--- a/tests/superfile/fts/fuzz_oracle.rs
+++ b/tests/superfile/fts/fuzz_oracle.rs
@@ -53,15 +53,12 @@
 use std::collections::HashSet;
 
 use infino::{
-    superfile::{
-        SuperfileReader,
-        fts::{reader::BoolMode, tokenize::Phrase},
-    },
+    superfile::{SuperfileReader, fts::reader::BoolMode},
     test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer},
 };
 use proptest::{prelude::*, test_runner::TestCaseError};
 
-use crate::fts::brute_force_oracle::build_infino_superfile_positional;
+use crate::fts::brute_force_oracle::{build_infino_superfile_positional, oracle_top_k_atoms};
 
 /// Small shared vocabulary. Kept short so terms co-occur, intersect,
 /// and (across enough docs) form dense bitset blocks — the shapes the
@@ -243,24 +240,7 @@ fn run_case(
 
     // Oracle full match set (k = n) via the same parsed clauses, so the
     // clause interpretation can never diverge from the reader's.
-    let clauses = tok.parse(&query).into_clauses(mode);
-    let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
-        v.into_iter().map(|t| t.into_owned()).collect()
-    };
-    // `Phrase::map` carries each term's offset across, so the oracle
-    // grades the spacing the parser derived rather than adjacency.
-    let own_ph = |v: Vec<Phrase<std::borrow::Cow<'_, str>>>| -> Vec<Phrase<String>> {
-        v.iter().map(|p| p.map(|t| t.to_string())).collect()
-    };
-    let want_full = oracle.top_k_atoms(
-        &own(clauses.musts),
-        &own_ph(clauses.must_phrases),
-        &own(clauses.shoulds),
-        &own_ph(clauses.should_phrases),
-        &own(clauses.negatives),
-        &own_ph(clauses.negative_phrases),
-        owned.len(),
-    );
+    let want_full = oracle_top_k_atoms(&oracle, tok.as_ref(), &query, mode, owned.len());
 
     let want_ids: HashSet<u64> = want_full.iter().map(|(d, _)| *d).collect();
     let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();

--- a/tests/superfile/fts/fuzz_oracle.rs
+++ b/tests/superfile/fts/fuzz_oracle.rs
@@ -53,7 +53,10 @@
 use std::collections::HashSet;
 
 use infino::{
-    superfile::{SuperfileReader, fts::reader::BoolMode},
+    superfile::{
+        SuperfileReader,
+        fts::{reader::BoolMode, tokenize::Phrase},
+    },
     test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer},
 };
 use proptest::{prelude::*, test_runner::TestCaseError};
@@ -244,10 +247,10 @@ fn run_case(
     let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
         v.into_iter().map(|t| t.into_owned()).collect()
     };
-    let own_ph = |v: Vec<Vec<std::borrow::Cow<'_, str>>>| -> Vec<Vec<String>> {
-        v.into_iter()
-            .map(|p| p.into_iter().map(|t| t.into_owned()).collect())
-            .collect()
+    // `Phrase::map` carries each term's offset across, so the oracle
+    // grades the spacing the parser derived rather than adjacency.
+    let own_ph = |v: Vec<Phrase<std::borrow::Cow<'_, str>>>| -> Vec<Phrase<String>> {
+        v.iter().map(|p| p.map(|t| t.to_string())).collect()
     };
     let want_full = oracle.top_k_atoms(
         &own(clauses.musts),

--- a/tests/superfile/fts/mod.rs
+++ b/tests/superfile/fts/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Infino Authors
 
+pub mod analysis_chain;
 pub mod brute_force_oracle;
 pub mod edge_and_unranked;
 pub mod fuzz_oracle;

--- a/tests/superfile/fts/negation.rs
+++ b/tests/superfile/fts/negation.rs
@@ -12,7 +12,10 @@
 
 use std::collections::HashSet;
 
-use infino::superfile::{SuperfileReader, fts::reader::BoolMode};
+use infino::superfile::{
+    SuperfileReader,
+    fts::{reader::BoolMode, tokenize::Phrase},
+};
 
 use crate::fts::brute_force_oracle::{
     build_infino_superfile, build_infino_superfile_positional, build_multi_block_corpus,
@@ -64,9 +67,12 @@ fn docs_with_phrase(corp: &[(u64, &str)], phrase: &[&str]) -> HashSet<u64> {
         .collect()
 }
 
-/// A phrase as the `&[Vec<String>]` the count/search API expects.
-fn phrase(tokens: &[&str]) -> Vec<Vec<String>> {
-    vec![tokens.iter().map(|t| t.to_string()).collect()]
+/// A phrase as the `&[Phrase<String>]` the count/search API expects.
+/// Adjacent, which is every phrase on a column with no analysis chain.
+fn phrase(tokens: &[&str]) -> Vec<Phrase<String>> {
+    vec![Phrase::adjacent(
+        tokens.iter().map(|t| t.to_string()).collect(),
+    )]
 }
 
 /// Run a query and collect the result doc-ids as a set.
@@ -443,10 +449,10 @@ async fn count_negation_over_dense_bitset_corpus() {
     async fn cnt(
         r: &SuperfileReader,
         terms: &[&str],
-        phrases: &[Vec<String>],
+        phrases: &[Phrase<String>],
         mode: BoolMode,
         neg_terms: &[&str],
-        neg_phrases: &[Vec<String>],
+        neg_phrases: &[Phrase<String>],
     ) -> u64 {
         r.atoms_match_count("title", terms, phrases, mode, neg_terms, neg_phrases)
             .await

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -13,7 +13,10 @@
 use std::collections::{HashMap, HashSet};
 
 use infino::{
-    superfile::{SuperfileReader, fts::reader::BoolMode},
+    superfile::{
+        SuperfileReader,
+        fts::{reader::BoolMode, tokenize::Phrase},
+    },
     test_helpers::{brute_force_bm25::BruteForceBm25, default_tokenizer},
 };
 
@@ -57,10 +60,10 @@ async fn assert_matches_oracle(
     let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
         v.into_iter().map(|t| t.into_owned()).collect()
     };
-    let own_ph = |v: Vec<Vec<std::borrow::Cow<'_, str>>>| -> Vec<Vec<String>> {
-        v.into_iter()
-            .map(|p| p.into_iter().map(|t| t.into_owned()).collect())
-            .collect()
+    // `Phrase::map` carries each term's offset across, so the oracle
+    // grades the spacing the parser derived rather than adjacency.
+    let own_ph = |v: Vec<Phrase<std::borrow::Cow<'_, str>>>| -> Vec<Phrase<String>> {
+        v.iter().map(|p| p.map(|t| t.to_string())).collect()
     };
     let want = oracle.top_k_atoms(
         &own(clauses.musts),
@@ -382,16 +385,16 @@ async fn unranked_ids_and_count_agree_with_oracle() {
     let tok = default_tokenizer();
     let oracle = BruteForceBm25::index(&refs, tok.as_ref());
 
-    let alpha_beta = || vec![vec!["alpha".to_string(), "beta".to_string()]];
-    let shapes: Vec<(Vec<&str>, Vec<Vec<String>>)> = vec![
+    let adjacent = |terms: &[&str]| -> Phrase<String> {
+        Phrase::adjacent(terms.iter().map(|t| t.to_string()).collect())
+    };
+    let alpha_beta = || vec![adjacent(&["alpha", "beta"])];
+    let shapes: Vec<(Vec<&str>, Vec<Phrase<String>>)> = vec![
         (vec![], alpha_beta()),
         (vec!["gamma"], alpha_beta()),
         (
             vec![],
-            vec![
-                vec!["alpha".to_string(), "beta".to_string()],
-                vec!["gamma".to_string(), "delta".to_string()],
-            ],
+            vec![adjacent(&["alpha", "beta"]), adjacent(&["gamma", "delta"])],
         ),
     ];
     for (terms, phrases) in shapes {
@@ -457,7 +460,7 @@ async fn phrase_and_rare_term_two_phase_agrees() {
     let oracle = BruteForceBm25::index(&refs, tok.as_ref());
 
     let terms = vec!["uk"];
-    let phrases = vec![vec!["the".to_string(), "who".to_string()]];
+    let phrases = vec![Phrase::adjacent(vec!["the".to_string(), "who".to_string()])];
     let owned_terms: Vec<String> = terms.iter().map(|t| t.to_string()).collect();
 
     let want: HashSet<u64> = oracle
@@ -529,7 +532,7 @@ async fn two_phase_phrase_with_dense_bitset_members_agrees() {
     let oracle = BruteForceBm25::index(&refs, tok.as_ref());
 
     let terms = vec!["uk"];
-    let phrases = vec![vec!["the".to_string(), "who".to_string()]];
+    let phrases = vec![Phrase::adjacent(vec!["the".to_string(), "who".to_string()])];
     let owned_terms: Vec<String> = terms.iter().map(|t| t.to_string()).collect();
 
     let want: HashSet<u64> = oracle

--- a/tests/superfile/fts/phrase.rs
+++ b/tests/superfile/fts/phrase.rs
@@ -21,7 +21,7 @@ use infino::{
 };
 
 use crate::fts::brute_force_oracle::{
-    build_infino_superfile_positional, build_multi_block_corpus, corpus,
+    build_infino_superfile_positional, build_multi_block_corpus, corpus, oracle_top_k_atoms,
 };
 
 /// k large enough to capture every match on the 60-doc corpus.
@@ -56,24 +56,7 @@ async fn assert_matches_oracle(
     k: usize,
 ) {
     let tok = default_tokenizer();
-    let clauses = tok.parse(query).into_clauses(mode);
-    let own = |v: Vec<std::borrow::Cow<'_, str>>| -> Vec<String> {
-        v.into_iter().map(|t| t.into_owned()).collect()
-    };
-    // `Phrase::map` carries each term's offset across, so the oracle
-    // grades the spacing the parser derived rather than adjacency.
-    let own_ph = |v: Vec<Phrase<std::borrow::Cow<'_, str>>>| -> Vec<Phrase<String>> {
-        v.iter().map(|p| p.map(|t| t.to_string())).collect()
-    };
-    let want = oracle.top_k_atoms(
-        &own(clauses.musts),
-        &own_ph(clauses.must_phrases),
-        &own(clauses.shoulds),
-        &own_ph(clauses.should_phrases),
-        &own(clauses.negatives),
-        &own_ph(clauses.negative_phrases),
-        k,
-    );
+    let want = oracle_top_k_atoms(oracle, tok.as_ref(), query, mode, k);
     let got = search_hits(reader, query, k, mode).await;
 
     let got_ids: HashSet<u64> = got.iter().map(|(d, _)| *d).collect();

--- a/tests/supertable/query/brute_force_oracle.rs
+++ b/tests/supertable/query/brute_force_oracle.rs
@@ -40,7 +40,10 @@ use infino::{
     Bm25SearchOptions,
     superfile::{
         builder::FtsConfig,
-        fts::reader::{Bm25Stats, BoolMode},
+        fts::{
+            reader::{Bm25Stats, BoolMode},
+            tokenize::Phrase,
+        },
     },
     supertable::{Supertable, SupertableOptions, query::SuperfileHit},
     test_helpers::{
@@ -452,7 +455,10 @@ impl QueryShape {
             Self::Phrase(terms) => {
                 // A bare quoted run is a *should* phrase, matching how
                 // the engine's clause split reads it with no sigil.
-                let phrase: Vec<String> = terms.iter().map(|t| (*t).to_owned()).collect();
+                // Adjacent, which is every phrase on a column with no
+                // analysis chain.
+                let phrase =
+                    Phrase::adjacent(terms.iter().map(|t| (*t).to_owned()).collect::<Vec<_>>());
                 let all = oracles
                     .iter()
                     .flat_map(|o| o.top_k_atoms(&[], &[], &[], from_ref(&phrase), &[], &[], k))


### PR DESCRIPTION
## What

An FTS column's **analysis** grows from just a tokenizer into a tokenizer plus an optional
stopword set and an optional stemmer, applied in that order. Each is its own option,
declared through the same `FtsField` door as the column's other options, and all three
apply to both sides of a search — so a term is queried in the form it was indexed under.

> **A note on names.** *Tokenizer* here means the thing that splits text (`standard`,
> `ascii_lower`); *analyzer* means the whole chain — that tokenizer plus its filters.
> Before filters existed the two were interchangeable in this engine, and four surfaces
> still say "analyzer" for a value that is a bare tokenizer name: the public
> `.analyzer(...)` option, `FtsConfig`'s field, the wire key, and the catalog record. The
> persisted superfile key says `"tokenizer"` and is the one that has it right. This PR
> **does not rename anything** — that would break three ecosystems plus the hosted spec
> for a cosmetic win — but it does make every doc-comment say tokenizer where the value is
> a tokenizer, and states the vocabulary outright in `analysis.rs`.

**Both filters are opt-in and the default is untouched.** That is deliberate: the default
is the parity surface, and it already matches Lucene's default. `IndexWriterConfig`
defaults to `StandardAnalyzer`, whose no-arg constructor is documented as building "an
analyzer with no stop words" and which never stemmed — so tokenize-and-lowercase, which
is what `standard` does here, is the right default and this PR does not move it. A column
declaring no filter is not wrapped at all: it keeps its plain analyzer name and takes the
same monomorphized ingest scan, so it is byte-identical *and* code-path-identical to one
declared before chains existed. Closing any remaining gap in `standard` itself belongs to
the tokenizer and the scorer, not here.

This PR is scoped to stopwords and stemming only.

```rust
IndexSpec::new().fts(
    FtsField::new("body")
        .stopwords(Stopwords::English)
        .stemmer(Stemmer::English)
        .positions(true),
);
```

Both bindings take the filters by name, matching how they already take `analyzer` and
`metric`:

```python
IndexSpec().fts("body", stopwords="english", stemmer="english", positions=True)
```

## Persistence: two additive fields, and a derived identity

A column persists its base tokenizer name plus, only when set, a `stopwords` and a
`stemmer` field:

```json
{"name":"body","tokenizer":"standard","k1":1.2,"b":0.75,
 "stopwords":"english","stemmer":"english","positions":true}
```

Both are ordinary additive fields. An old file has neither, serde defaults them off, and
that is correct because such a file really was built unfiltered — so the direction this
format promises (**new reader, old file**) needs no special handling. The catalog record
and the create-table request carry them the same way. A column with no filter is
byte-identical everywhere to one declared before filters existed, and there is **no
format-version change**.

The rule at the boundary: an unknown *field* is ignorable, so an engine predating a filter
reads the column as unfiltered and that column's results degrade until it rolls forward.
An unknown *value* of a field the reader does know — `"stopwords":"german"` on an engine
shipping no German list — fails the open, because analyzing without a set the postings
were built with is a different index, not a degraded one.

That split is deliberate and follows a precedent already set here: this codebase declined
to mark these files with a new FTS section version specifically because a lost-recall
regression is recoverable by rolling forward while an unopenable table is an outage.
Encoding the filters into the analyzer name would have made a rollback exactly that
outage, since an older engine cannot parse the name at all.

The chain still *has* an identity string — `"standard+stop=english+stem=english"` from
`chain_name` — but it is derived in memory and never written. It exists because three
places have to treat a column's analysis as one value, and reading three fields at each
would be three chances to forget one:

- the **`LIKE` prune lowering**, which recognizes analyzers by `Tokenizer::name` (see
  below);
- the **merge carry check**, which compares analyzer names to refuse merging
  differently-analyzed superfiles;
- the **options-hash**, which needs analysis in table identity — a one-line change that
  leaves existing hashes byte-identical, since a filterless column derives to its plain
  base name.

Nothing parses a name back, so a chain is only ever built from its components.

## Position holes, on both sides

Removing a token leaves a **hole**: the ordinal it would have occupied is skipped, so
phrase matching still knows the words it matched were not adjacent in the text.
`"new york"` does not match `new the york`.

Holes travel two new channels:

- **Index** — `Tokenizer::tokenize_each_positioned` yields `(token, position)` with
  gap-inclusive ordinals. The trait's default numbers emitted tokens consecutively, which
  is correct for a tokenizer that drops nothing; one that drops tokens overrides it.
- **Query** — a parsed query's phrases carry per-term offsets (`Phrase<T>`), so
  `"end of the world"` asks for its two surviving terms *three positions apart* rather
  than adjacent. `PhraseCursor` verifies `start + offsets[j]` instead of `start + j`.
  Offsets normalize to the first surviving term, which is both what makes them a pure
  relative constraint and what keeps the verifier's `checked_sub` from underflowing near
  the start of a document.

Without the query side the feature is silently wrong in exactly the direction the
fail-loud design exists to prevent: requiring adjacency matches nothing, and requiring
mere co-presence matches `end world`.

Doc length counts the tokens the chain **emits** — what Lucene's norms count
(`IndexingChain.PerField.invert` bumps `invertState.length` inside the `incrementToken`
loop, so a token `StopFilter` dropped never reaches it) and what a merge's carried
postings preserve.

A phrase reduced to one surviving term degrades to a plain term clause; one reduced to
zero contributes nothing. Both match Lucene.

## `LIKE` pruning is dropped for a chained column, not adapted

The `LIKE` lowering bounds a pattern fragment by the terms it tokenizes to, including a
lex-range walk for a prefix token. That is sound only while an indexed term is a
substring-preserving image of the text, and a stemmer breaks it: `LIKE '%runni%'` matches
the text `running`, whose indexed term is `run`, so a prefix walk for `runni` finds
nothing and **drops a superfile that genuinely matches**. Not a pruning inefficiency — a
wrong answer, and the same lowering feeds the vector kNN pre-filter, where an
over-restrictive candidate set costs recall.

The fix was already latent: `Analyzer::of` dispatches on `Tokenizer::name`, a chain's
derived name matches no arm, and `None` there already means `Unbounded`. So the correct
behaviour arrives by construction. It is now documented on `Analyzer::of` as a
*requirement* and pinned by a test that asserts the property **directly** — that a chain's
name is recognized by no arm — rather than by a `LIKE` case that would also pass if the
resolver simply returned no tokenizer at all. That distinction matters: the weaker version
of this test passed for the wrong reason during the refactor.

Equality and value-set pruning **stay**, sound for the opposite reason: the literal runs
through the same chain the postings did, so the terms it yields are terms the index really
holds and requiring them can only widen the candidate set. A literal the chain reduces to
nothing already falls to `Unbounded`.

## Two things found by reading the code this would touch

**`positions` had no public surface at all.** `FtsConfig::positions` existed, but
`IndexSpec::to_configs` never set it and `FtsConfig` is not re-exported — so every table
created through the public API had `positions = false` and answered **every** phrase query
with an error. None of the hole behaviour above was reachable, let alone testable, without
exposing it. Now on `FtsField` and recorded in the catalog record — required, not
optional, because the flag joins the options-hash, so losing it on reopen would fail the
table's own hash check rather than merely forget how to answer a phrase.

**A pre-existing bug in `ascii_lower`, independent of this feature.** Its zero-copy
`tokenize_each_query` override numbered emitted tokens consecutively, but the tokenizer
drops non-ASCII runs and the index side has always left a hole for one. So a phrase query
carrying a non-ASCII word asked for its surviving words closer together than they were
indexed: **`"new café york"` could never match the text it was copied from.** Fixed, and
both query entry points now share one scan so they cannot disagree about which tokens a
query has.

## New dependency

`rust-stemmers` 1.2 — the de-facto Rust Snowball port, dual MIT / BSD-3-Clause, and its
only transitive dependencies are `serde` + `serde_derive`, already direct dependencies
here, so the graph grows by one node rather than a subtree. Vendoring the stemmer tables
instead would put us on the hook for correctness fixes to algorithms we do not own. It is
also what the reference implementations we compare against use, so a stemming
disagreement is a genuine behaviour difference rather than a difference in Snowball ports.

`Stemmer::English` is named `english`, not `porter`, in both the API and the persisted
name, because the two are different algorithms: Snowball's `english` *is* Porter2, whereas
Lucene's `PorterStemFilter` is the original Porter.

## What the built-in filter names resolve to is frozen

A column persists the *name* `english`, not the words or the rules — so what those names
resolve to is on-disk state, and nothing was guarding it. Two silent-corruption paths were
open and are now pinned by golden tests:

- Editing `ENGLISH_STOPWORDS` would re-analyze every column already built under
  `stopwords: "english"` — add a word and queries for it start missing documents that
  contain it. The prior test only checked sortedness, dedup and a length bound, so a word
  could be added or removed and pass CI.
- Worse for the stemmer, whose rules live in `rust-stemmers` under a caret range admitting
  any `1.x`: a routine dependabot bump changing one Porter2 rule would change how an
  existing column *would* tokenize while its postings kept the old stems.

Both failure messages say what the failure means and what to do — never re-record the
expectation; reject the change, or ship a new name (`english2`) with its own frozen list.
The stemmer range stays a caret on purpose: what needs guarding is the crate's output, not
its version number.

## Shared test harness, and one rename for safety

Three test modules had grown identical copies of the closures that own a parsed query's
clauses and hand them to the oracle — twenty-odd lines each, with a fourth copy due with
the next oracle. They now share `oracle_top_k_atoms`, which also puts the "parse with the
same tokenizer the reader uses" invariant in one place instead of three. The chain
oracle's superfile fixture was a copy of the shared builder too; that builder now takes an
`FtsConfig` and the old entry point delegates.

`PhraseCursor::offsets` is renamed `position_offsets`, because it sat two fields from
`run_offsets` and `cached_run_offset` — which are **byte** offsets into the positions
blob. Two meanings of "offset" in one struct family, where confusing them is a correctness
bug rather than a type error.

## Correctness

New oracle (`tests/superfile/fts/analysis_chain.rs`) grades **four chains × fifteen
queries × both default operators** against the textbook BM25 scorer, on **scores as well
as match sets**. Scores are the load-bearing half: removing a stopword shortens the
document and so moves every score in the column through the length normalizer, so an
engine and oracle that counted length differently would keep identical match sets and rank
plausibly and wrongly.

Two more tests: phrase holes asserted against **corpus truth** rather than the oracle, so a
hole bug affecting both implementations alike still fails; and stemming's symmetry across
inflections plus its silence on irregular forms (`ran` stays its own term).

Then the boundaries the field-based persistence introduces, each of which fails silently if
broken:

- absent filter fields mean off, and an unrecognized *value* is refused — asserted on the
  deserializer, since neither case is reachable through our own writer;
- a catalog record naming an unresolvable filter refuses the table;
- the wire emits the filter keys only when set;
- the filters join the options-hash, while a filterless table's hash stays byte-identical
  to what it was before filters existed.

And the paths whose failure would be silent regardless of representation: a rebuild carries
the whole analysis (compaction would otherwise re-tokenize unfiltered), the `positions`
flag round-trips the catalog (it joins the options-hash, so losing it makes a positional
table fail its own hash check), a positionless column rejects a phrase naming the column,
and the three `FtsField` analysis setters commute.

`BruteForceBm25` had to change to grade any of this — it stored a dense `tokens:
Vec<String>` and scanned it for *contiguous* phrase occurrences, so a hole the engine left
would not exist for it. Now `Vec<(String, u64)>` walked by position, which reduces to the
old contiguity check when both sides are dense.

## Verification

Green: `make check` (fmt, both clippy lanes, api-parity, version-sync, doc-check),
`make doctest`, `make test-remote` (17), `cargo test --lib` (2498),
`--test superfile` (193, both fuzz oracles), `--test supertable` (337),
`supertable_concurrent_processes` (5), and the remaining standalone targets.

`public-api.txt` regenerated; the whole diff is additive — two `#[non_exhaustive]` enums
and three `FtsField` setters. The attribute goes on now because a second language is the
obvious next addition and adding an enum variant is otherwise a breaking change; callers
only ever construct these, never match on them.

Not run here: `make coverage`, `make miri` / `make asan`.

**`supertable_commit_crash_localfs` could not be graded on this machine.** The test leaks
its aborting children, so `cargo test` never returns even after assertions pass. Orphan
batches of those same children were already present from 1d21h and 22h before this branch
existed, alongside 21 orphan `rustfs` daemons from unrelated runs, so nothing here can be
attributed to this diff either way. Worth a clean run in CI.

## Performance

Same-host A/B from this PR's benchmark lanes: the PR ref and base `main` are built and run
side by side on one VM, so the comparison is against a `main` arm measured on the same
hardware in the same run. Verdict line:

```
gate=warm p90, 0 blocking, 0 informational, 11 advisory regressions,
8 improvements, 0 failure line(s), baseline=yes
```

### Ingest — flat on default columns

| build (superfile FTS, 1M docs) | main | PR | ratio |
| --- | --- | --- | --- |
| 1 writer | 15.28 s | 15.37 s | 1.006 |
| 7 writers | 3.85 s | 3.84 s | 0.997 |
| 1 writer (positions) | 27.45 s | 28.82 s | **1.050** |
| 7 writers (positions) | 5.69 s | 5.64 s | 0.991 |

The default (unfiltered) path is flat — +0.6% and −0.3% — which is the number that mattered
most here. FTS tokenizer ingest cost on this codebase is architecture-sensitive: a change
has previously measured ~5% on ARM and ~29% on an x86 CI host, so a local reading proves
nothing and this lane is the one that counts.

That is also what the diff predicts. The analysis chain adds one
`else if let Some(chain)` arm *after* the two existing downcast arms in each `add_doc`
path, and it is `None` for any column that declares no filter; the downcast itself is once
per doc per column, not per token.

**The +5.0% row is not claimed as clean.** Single-writer positional ingest sits exactly at
the 5% advisory threshold, and positions is the path this diff touches most. Against it
being systematic: the 7-writer positional build moved the *other* way (−0.9%) on the same
code and host, and each cell is one sample per arm. Worth a second reading rather than an
explanation.

### Warm query p90 — 15 of 23 cells faster, geomean 0.983

Nothing is near the gate. Slowest: `must_rare_should_common` 1.110 (283 → 314 µs),
`three_similar_or` 1.089, `two_term_and` 1.087, `single_df1` 1.080 (a 1 µs cell),
`two_term_or` 1.077 — all sub-millisecond or ~6 ms, inside the ±5–15% within-arm spread
these shapes show on repeated runs of identical code.

**All four phrase cells are at or below parity** — `phrase_two_mixed` 0.874,
`phrase_two_common` 0.935, `phrase_three_common` 0.959, `phrase_plus_must_term` 1.002 —
which is the specific risk in this diff: `PhraseCursor::verify_at_aligned` now reads an
indexed offset where it cast a loop index, once per member per aligned doc rather than per
position. No measurable cost.

### Two honest limits on the above

**The gate is weak, so its green is not the evidence.** It blocks only on warm p90 and only
past **>50% AND >5 ms**; build time is classified advisory and never blocks. A 30%
regression would pass. The numbers above are read from the two arms directly, not inferred
from the verdict. The **11 advisory regressions** are counted but not listed in the job log,
and the summary artifact was not retrievable (empty check-run output, no PR comment posted),
so I could not reconcile my extraction against the tool's own classification.

**An earlier comment on this PR is superseded.** It reported a reproducible 43% improvement
on `two_term_and_small` that I could not explain and explicitly declined to claim. On this
lane that cell is **1.057** — slightly slower. So it was a code-layout artifact of the local
build, not a real effect, and nothing in this PR should be credited with it.

### Cross-engine

A separate same-box cross-engine run put the branch's index within **16 bytes of main's on
4.13 GB**, confirming the byte-identity claim for a column with no filter. Its latency
buckets were mostly unmeasurable — the same-code control drifted 24–44% on COUNT — with one
bucket (TOP_100, +7–12%) clearing its control uniformly across every query shape, phrases
least affected. That shape is inconsistent with the only query-path change here, so it is
being re-run rather than attributed.
