### PR TITLE
refactor disk reader_cache: merge cache entry states into a Residency enum

### DIFF
--- a/src/supertable/reader_cache/block_source.rs
+++ b/src/supertable/reader_cache/block_source.rs
@@ -164,9 +164,10 @@ impl BlockCachedSource {
         }
     }
 
-    /// Identity token installed on the cache entry that owns this source.
-    pub(crate) fn entry_token(&self) -> Arc<()> {
-        Arc::clone(&self.entry_token)
+    /// Whether `token` is this source's own identity token, compared by pointer. Lets the owning
+    /// cache entry check "is this source still current" without cloning the `Arc`.
+    pub(crate) fn owns_token(&self, token: &Arc<()>) -> bool {
+        Arc::ptr_eq(&self.entry_token, token)
     }
 
     /// Shared filled-bytes counter, installed as the cache entry's
@@ -658,7 +659,7 @@ mod tests {
             dir.path().join("t.blocks"),
         );
         // Install the source as current for its (synthetic) entry.
-        store.install_block_entry_for_test(uri, src.filled_bytes_handle(), src.entry_token());
+        store.install_block_entry_for_test(uri, Arc::clone(&src));
 
         // Read spanning blocks 0..=2 (one contiguous missing run → 1 GET).
         let start = 100u64;
@@ -735,7 +736,7 @@ mod tests {
             uri,
             path.clone(),
         );
-        store.install_block_entry_for_test(uri, src1.filled_bytes_handle(), src1.entry_token());
+        store.install_block_entry_for_test(uri, Arc::clone(&src1));
         let start = 100u64;
         let len = 2 * CACHE_BLOCK_BYTES + 500;
         let first = src1.range(start, len).await.expect("gen1 read");
@@ -754,7 +755,7 @@ mod tests {
             uri,
             path.clone(),
         );
-        store.install_block_entry_for_test(uri, src2.filled_bytes_handle(), src2.entry_token());
+        store.install_block_entry_for_test(uri, Arc::clone(&src2));
 
         let again = src2.range(start, len).await.expect("gen2 read");
         assert_eq!(again, first);
@@ -788,7 +789,7 @@ mod tests {
             uri,
             path.clone(),
         );
-        store.install_block_entry_for_test(uri, src1.filled_bytes_handle(), src1.entry_token());
+        store.install_block_entry_for_test(uri, Arc::clone(&src1));
         let _ = src1
             .range(100, 2 * CACHE_BLOCK_BYTES + 500)
             .await
@@ -807,7 +808,7 @@ mod tests {
             uri,
             path.clone(),
         );
-        store.install_block_entry_for_test(uri, src2.filled_bytes_handle(), src2.entry_token());
+        store.install_block_entry_for_test(uri, Arc::clone(&src2));
         let _ = src2
             .range(100, 2 * CACHE_BLOCK_BYTES + 500)
             .await
@@ -879,7 +880,7 @@ mod tests {
             uri,
             path.clone(),
         );
-        store.install_block_entry_for_test(uri, a.filled_bytes_handle(), a.entry_token());
+        store.install_block_entry_for_test(uri, Arc::clone(&a));
         let start = 100u64;
         let len = 2 * CACHE_BLOCK_BYTES + 500;
         let want = inner_a.blob.slice(start as usize..(start + len) as usize);
@@ -901,7 +902,7 @@ mod tests {
             uri,
             path.clone(),
         );
-        store.install_block_entry_for_test(uri, b.filled_bytes_handle(), b.entry_token());
+        store.install_block_entry_for_test(uri, Arc::clone(&b));
         let tail = 3 * CACHE_BLOCK_BYTES + 10;
         let _ = b
             .range(tail, 50)
@@ -931,7 +932,7 @@ mod tests {
             uri,
             dir.path().join("runs.blocks"),
         );
-        store.install_block_entry_for_test(uri, src.filled_bytes_handle(), src.entry_token());
+        store.install_block_entry_for_test(uri, Arc::clone(&src));
 
         // Fill block 2 first.
         let b = CACHE_BLOCK_BYTES;

--- a/src/supertable/reader_cache/disk/budget.rs
+++ b/src/supertable/reader_cache/disk/budget.rs
@@ -45,7 +45,7 @@ impl DiskCacheStore {
             .cached
             .iter()
             .filter_map(|e| {
-                let mmap = e.value().mmap.clone()?;
+                let mmap = e.value().mmap().cloned()?;
                 let last = e.value().last_access_us.load(Ordering::Acquire);
                 Some((*e.key(), mmap, last))
             })
@@ -91,7 +91,7 @@ impl DiskCacheStore {
     pub fn current_mmap_size_bytes(&self) -> u64 {
         self.cached
             .iter()
-            .filter_map(|e| e.value().mmap.as_ref().map(|m| m.len() as u64))
+            .filter_map(|e| e.value().mmap().map(|m| m.len() as u64))
             .sum()
     }
 
@@ -126,7 +126,7 @@ impl DiskCacheStore {
             .cached
             .iter()
             .filter_map(|e| {
-                let mmap = e.value().mmap.clone()?;
+                let mmap = e.value().mmap().cloned()?;
                 Some((
                     *e.key(),
                     mmap,
@@ -280,16 +280,11 @@ impl DiskCacheStore {
         self.current_bytes.fetch_sub(bytes, Ordering::Release);
     }
 
-    /// True when `token` still identifies the live lazy entry for `uri`.
+    /// True when `token` still identifies the live block source for `uri`.
     pub(crate) fn lazy_block_entry_is_current(&self, uri: &SuperfileUri, token: &Arc<()>) -> bool {
         self.cached
             .get(uri)
-            .and_then(|entry| {
-                entry
-                    .block_token
-                    .as_ref()
-                    .map(|current| Arc::ptr_eq(current, token))
-            })
+            .and_then(|entry| entry.block_source().map(|source| source.owns_token(token)))
             .unwrap_or(false)
     }
 
@@ -305,23 +300,23 @@ impl DiskCacheStore {
     pub(crate) fn install_block_entry_for_test(
         &self,
         uri: SuperfileUri,
-        filled: Arc<AtomicU64>,
-        block_token: Arc<()>,
+        block_source: Arc<crate::supertable::reader_cache::block_source::BlockCachedSource>,
     ) {
         let reader = SuperfileReader::open(
             crate::supertable::reader_cache::disk::test_support::tiny_superfile_bytes(),
         )
         .expect("tiny superfile opens");
+        let size_bytes = block_source.filled_bytes_handle();
         self.cached.insert(
             uri,
             Arc::new(CachedEntry {
                 reader: Arc::new(reader),
-                mmap: None,
-                size_bytes: filled,
+                residency: Residency::Paged {
+                    block_source,
+                    fill_spawned: AtomicBool::new(false),
+                },
+                size_bytes,
                 accounting: EntryAccounting::SourceOwned,
-                block_token: Some(block_token),
-                block_source: None,
-                fill_spawned: AtomicBool::new(false),
                 last_access_us: AtomicU64::new(self.now_us()),
             }),
         );

--- a/src/supertable/reader_cache/disk/fetch.rs
+++ b/src/supertable/reader_cache/disk/fetch.rs
@@ -67,30 +67,27 @@ impl DiskCacheStore {
     ) -> Result<Arc<CachedEntry>, DiskCacheError> {
         let (mmap, bytes) = mmap_readonly_with_handle(path).map_err(DiskCacheError::Io)?;
         let reader = SuperfileReader::open_with(bytes, OpenOptions { verify_crc })?;
-        Ok(self.build_mmap_entry(Arc::new(reader), mmap, size, None, None, false))
+        Ok(self.build_mmap_entry(Arc::new(reader), mmap, size, None))
     }
 
-    /// Build a promoted, mmap-backed `CachedEntry`. The single place the whole-file entry shape is
-    /// written: `Eager` accounting (the whole superfile size is store-reserved) and a live mmap.
-    /// `block_token`/`block_source` stay `Some` only when a vector-hole fallback keeps part of the
-    /// object on the block cache after promote.
+    /// Build a promoted [`Residency::Mapped`] entry: the single place the mmap shape is written,
+    /// always `Eager` (the whole superfile size is store-reserved). `vector_source` is `Some` only
+    /// when the vector blob was left out of the mmap and still comes from the block cache.
     pub(crate) fn build_mmap_entry(
         &self,
         reader: Arc<SuperfileReader>,
         mmap: Arc<Mmap>,
         size: u64,
-        block_token: Option<Arc<()>>,
-        block_source: Option<Arc<BlockCachedSource>>,
-        fill_spawned: bool,
+        vector_source: Option<Arc<BlockCachedSource>>,
     ) -> Arc<CachedEntry> {
         Arc::new(CachedEntry {
             reader,
-            mmap: Some(mmap),
+            residency: Residency::Mapped {
+                mmap,
+                vector_source,
+            },
             size_bytes: Arc::new(AtomicU64::new(size)),
             accounting: EntryAccounting::Eager,
-            block_token,
-            block_source,
-            fill_spawned: AtomicBool::new(fill_spawned),
             last_access_us: AtomicU64::new(self.now_us()),
         })
     }
@@ -261,12 +258,10 @@ impl DiskCacheStore {
         //    cache hits serve the mmap reader instead.
         let entry = Arc::new(CachedEntry {
             reader: Arc::clone(&foreground_reader),
-            mmap: None, // hybrid foreground entry is in-memory; finalizer mmaps later
+            // Hybrid foreground: the whole file is in a heap buffer; the finalizer mmaps it later.
+            residency: Residency::Buffered,
             size_bytes: Arc::new(AtomicU64::new(size)),
             accounting: EntryAccounting::Eager,
-            block_token: None,
-            block_source: None,
-            fill_spawned: AtomicBool::new(false),
             last_access_us: AtomicU64::new(self.now_us()),
         });
         self.n_cold_fetches.fetch_add(1, Ordering::AcqRel);
@@ -388,11 +383,14 @@ impl DiskCacheStore {
         entry: &CachedEntry,
         storage: Option<&Arc<dyn StorageProvider>>,
     ) {
-        if skip_background_fill() || entry.mmap.is_some() {
+        if skip_background_fill() || entry.is_mapped() {
             return;
         }
-        if entry
-            .fill_spawned
+        // Only a Paged entry can start a fill, and its latch makes that happen at most once.
+        let Some(fill_spawned) = entry.fill_spawned() else {
+            return;
+        };
+        if fill_spawned
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
@@ -403,8 +401,7 @@ impl DiskCacheStore {
         // block source, and reserve it here — the vector open never did, so the
         // promotion's mmap needs budget reserved before it downloads.
         let size = entry
-            .block_source
-            .as_ref()
+            .block_source()
             .map(|bs| bs.size())
             .filter(|&s| s > 0)
             .unwrap_or_else(|| entry.size_bytes.load(Ordering::Acquire));
@@ -638,7 +635,6 @@ impl DiskCacheStore {
         }
 
         let lazy_reader = Arc::new(lazy_reader);
-        let block_token = block_source_arc.entry_token();
         let (size_bytes, accounting) = if allow_background_fill {
             (Arc::new(AtomicU64::new(size)), EntryAccounting::Eager)
         } else {
@@ -649,14 +645,14 @@ impl DiskCacheStore {
         };
         let entry = Arc::new(CachedEntry {
             reader: Arc::clone(&lazy_reader),
-            mmap: None,
+            // Fill is modality-gated via [`Self::maybe_spawn_background_fill`] after the open
+            // returns, so it starts false here and vector opens never flip it.
+            residency: Residency::Paged {
+                block_source: block_source_arc,
+                fill_spawned: AtomicBool::new(false),
+            },
             size_bytes,
             accounting,
-            block_token: Some(block_token),
-            block_source: Some(block_source_arc),
-            // Fill is modality-gated via [`Self::maybe_spawn_background_fill`]
-            // after the open returns — vector never starts it.
-            fill_spawned: AtomicBool::new(false),
             last_access_us: AtomicU64::new(self.now_us()),
         });
         self.n_cold_fetches.fetch_add(1, Ordering::AcqRel);
@@ -700,7 +696,7 @@ impl DiskCacheStore {
                 verify_crc: self.config.verify_crc_on_open,
             },
         )?;
-        let entry = self.build_mmap_entry(Arc::new(reader), mmap, size, None, None, false);
+        let entry = self.build_mmap_entry(Arc::new(reader), mmap, size, None);
         self.install_promoted_entry(*uri, Arc::clone(&entry), &final_path, InstallMode::Fresh);
         self.n_cold_fetches.fetch_add(1, Ordering::AcqRel);
         reservation.commit();
@@ -833,7 +829,7 @@ async fn finalize_to_mmap(
         // Replace the in-memory-backed entry with the mmap-backed one. `ReplaceIfPresent` drops
         // the file instead of reinstating when a racing reservation evicted the slot mid-finalize
         // (reinstating an evicted, already-released entry would leak its reservation).
-        let entry = store.build_mmap_entry(Arc::new(reader), mmap, size, None, None, false);
+        let entry = store.build_mmap_entry(Arc::new(reader), mmap, size, None);
         store.install_promoted_entry(uri, entry, &final_path, InstallMode::ReplaceIfPresent);
         store.coordinators.remove(&uri);
         Ok::<(), DiskCacheError>(())
@@ -1195,10 +1191,9 @@ async fn lazy_background_fill(
         let prior_block = store
             .cached
             .get(&uri)
-            .and_then(|entry| entry.block_source.clone());
-        let (promoted_reader, block_token, block_source) = match (skip_vec, prior_block) {
+            .and_then(|entry| entry.block_source().cloned());
+        let (promoted_reader, vector_source) = match (skip_vec, prior_block) {
             (Some((vec_off, vec_len)), Some(block_source)) => {
-                let block_token = block_source.entry_token();
                 let local: Arc<dyn LazyByteSource> =
                     Arc::new(BytesLazyByteSource::new(bytes.clone()));
                 let source: Arc<dyn LazyByteSource> = Arc::new(HoleFallbackSource {
@@ -1213,7 +1208,7 @@ async fn lazy_background_fill(
                 // Sync parquet decodes (take / id scans) run off the mmap;
                 // the sparse vector region stays behind the hole source.
                 reader.install_resident_parquet(bytes)?;
-                (reader, Some(block_token), Some(block_source))
+                (reader, Some(block_source))
             }
             (Some((vec_off, vec_len)), None) => {
                 // Evicted mid-fill: fresh block cache over storage for the hole.
@@ -1232,7 +1227,6 @@ async fn lazy_background_fill(
                     // bytes come from the mmap.
                     None,
                 );
-                let block_token = block_source.entry_token();
                 let local: Arc<dyn LazyByteSource> =
                     Arc::new(BytesLazyByteSource::new(bytes.clone()));
                 let source: Arc<dyn LazyByteSource> = Arc::new(HoleFallbackSource {
@@ -1247,7 +1241,7 @@ async fn lazy_background_fill(
                 // Sync parquet decodes (take / id scans) run off the mmap;
                 // the sparse vector region stays behind the hole source.
                 reader.install_resident_parquet(bytes)?;
-                (reader, Some(block_token), Some(block_source))
+                (reader, Some(block_source))
             }
             (None, _) => {
                 let reader = SuperfileReader::open_with(
@@ -1256,19 +1250,13 @@ async fn lazy_background_fill(
                         verify_crc: store.config.verify_crc_on_open,
                     },
                 )?;
-                (reader, None, None)
+                (reader, None)
             }
         };
 
-        let block_source_retained = block_source.is_some();
-        let entry = store.build_mmap_entry(
-            Arc::new(promoted_reader),
-            mmap_arc,
-            size,
-            block_token,
-            block_source,
-            true,
-        );
+        let block_source_retained = vector_source.is_some();
+        let entry =
+            store.build_mmap_entry(Arc::new(promoted_reader), mmap_arc, size, vector_source);
         // Installed (still present) + no retained block source -> the promoted mmap serves every
         // range, so the sparse block sidecar is dead weight; drop it. Evicted mid-fill -> the
         // install dropped the file and we leave the sidecar to normal reclaim.
@@ -1413,10 +1401,7 @@ impl LazyByteSource for HoleFallbackSource {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    };
+    use std::sync::{Arc, atomic::Ordering};
 
     use bytes::Bytes;
     use tempfile::TempDir;
@@ -1445,7 +1430,7 @@ mod tests {
 
         // Seed a cache entry the way a lazy fill would, plus a leftover tmp
         // scratch file for the partial download.
-        store.install_block_entry_for_test(uri, Arc::new(AtomicU64::new(0)), Arc::new(()));
+        store.install_block_entry_for_test(uri, dummy_block_source(&store, uri));
         assert!(
             store.is_cached(&uri),
             "entry must be cached before rollback"
@@ -1521,7 +1506,7 @@ mod tests {
         let reader = Arc::new(
             SuperfileReader::open_with(mapped, OpenOptions { verify_crc: false }).expect("open"),
         );
-        let entry = store.build_mmap_entry(reader, mmap, size, None, None, false);
+        let entry = store.build_mmap_entry(reader, mmap, size, None);
 
         // `cached` is empty (slot evicted): ReplaceIfPresent returns None, removes the file, and
         // touches no budget.
@@ -1714,6 +1699,44 @@ mod tests {
             .await
             .expect("FTS open must start background fill");
         assert!(store.is_mmap_promoted(&uri));
+    }
+
+    /// A vector-opened entry that later gets an FTS open promotes to a Mapped entry that KEEPS its
+    /// block source as the vector hole: parquet and FTS serve from the mmap, the vector blob stays
+    /// on the block cache. Pins the `Residency::Mapped { vector_source: Some }` path and its
+    /// `block_source()` accessor arm, which the scalar fixtures never reach.
+    #[tokio::test]
+    async fn vector_open_promotes_to_mapped_keeping_the_hole() {
+        let (_dir, store) = test_store_with(|cfg| {
+            cfg.cold_fetch_mode = ColdFetchMode::LazyForegroundWithBackgroundFill;
+        });
+        let uri = SuperfileUri::new_v4();
+        put_superfile(&store, &uri, tiny_vector_superfile_bytes()).await;
+
+        // Vector modality: lazy, block-cache only, no fill.
+        let vector_reader = store
+            .reader_with_hints(&uri, None, None, false)
+            .await
+            .expect("vector open");
+        drop(vector_reader);
+
+        // FTS modality starts the fill, which promotes while leaving the vector blob sparse.
+        let fts_reader = store
+            .reader_with_hints(&uri, None, None, true)
+            .await
+            .expect("fts open");
+        drop(fts_reader);
+        store
+            .wait_until_mmap_promoted(&uri, PROMOTE_TIMEOUT)
+            .await
+            .expect("promote");
+
+        let entry = store.cached.get(&uri).expect("entry cached");
+        assert!(entry.is_mapped(), "promoted to a Mapped entry");
+        assert!(
+            entry.block_source().is_some(),
+            "the vector blob stays on the block cache as the retained hole",
+        );
     }
 
     #[tokio::test]

--- a/src/supertable/reader_cache/disk/mod.rs
+++ b/src/supertable/reader_cache/disk/mod.rs
@@ -153,52 +153,77 @@ pub enum DiskCacheError {
     Config(String),
 }
 
-/// Live cache entry. Holds the cached `Arc<SuperfileReader>`
-/// (constructed once on cache fill); the `Bytes` inside the
-/// reader is mmap-backed via `Bytes::from_owner(ArcMmapOwner)`,
-/// so dropping the last `Arc<SuperfileReader>` (cache evict +
-/// no in-flight queries) drops the mmap and unmaps the file.
+/// Live cache entry: the cached [`SuperfileReader`] plus the [`Residency`] that says where its
+/// bytes currently live. Dropping the last `Arc<SuperfileReader>` (evicted, no in-flight query)
+/// releases whatever backs it, whether that is a heap buffer, an mmap, or the block source.
 ///
-/// In-flight queries pin the reader independently — the
-/// cache can evict the entry and unlink the on-disk file
-/// while a query still holds an `Arc<SuperfileReader>` over
-/// the now-unlinked-but-mmap'd bytes. POSIX semantics
-/// (mac/linux): the mmap stays valid until the last
+/// In-flight queries pin the reader independently, so the cache can evict the entry and unlink the
+/// file while a query still reads the mmapped bytes. POSIX keeps the mapping valid until the last
 /// reference drops.
-///
-/// `mmap` is `None` for in-memory-bytes-backed entries
-/// produced by the hybrid cold-fetch path (transient, before
-/// `finalize_to_mmap` runs); `Some` once the entry is
-/// mmap-backed. The idle-threshold sweep thread iterates
-/// entries with `Some(mmap)` and calls
-/// `madvise(MADV_DONTNEED)` on those that haven't been
-/// accessed in `mmap_cold_threshold_secs`.
 pub(crate) struct CachedEntry {
     reader: Arc<SuperfileReader>,
-    /// Separate handle on the mmap for `MADV_DONTNEED`. Same
-    /// `Arc<Mmap>` instance that backs the reader's `Bytes`
-    /// — both share the underlying OS mapping, so `madvise`
-    /// on either path affects the cached entry's resident
-    /// pages.
-    mmap: Option<Arc<Mmap>>,
-    /// Accounted bytes for this entry. For eager entries this is fixed at
-    /// insertion; for block-backed lazy entries this points at the block
-    /// source's live filled-bytes counter.
+    residency: Residency,
+    /// Bytes charged to the budget. Fixed at insertion for [`EntryAccounting::Eager`]; for
+    /// [`EntryAccounting::SourceOwned`] it tracks the block source's live filled-bytes counter.
     size_bytes: Arc<AtomicU64>,
-    /// Who owns accounting release for this entry.
+    /// Who releases `size_bytes` when the entry drops.
     accounting: EntryAccounting,
-    /// Identity of the sparse source currently allowed to grow this lazy
-    /// entry. `None` for eager and fully mmap-backed entries.
-    block_token: Option<Arc<()>>,
-    /// Live block-cache source for lazy (and hybrid mmap+hole) entries.
-    /// Retained across vector-excluding background fill so touched vector
-    /// ranges stay local after parquet/FTS promote to mmap.
-    block_source: Option<Arc<BlockCachedSource>>,
-    /// Whether a background fill task has been spawned for this URI.
-    /// Vector opens leave this false (block-cache only); an later FTS/SQL
-    /// open may flip it and start fill.
-    fill_spawned: AtomicBool,
     last_access_us: AtomicU64,
+}
+
+/// Where a cached entry's bytes currently live. Lines up with the three tiers
+/// [`DiskCacheStore::reader`] checks in order: memory, disk, then object store.
+enum Residency {
+    /// Whole superfile in an anonymous heap buffer, and the only copy. A background task writes it
+    /// to disk and promotes it to [`Residency::Mapped`].
+    Buffered,
+    /// Superfile mmapped from the local cache file. Usually the whole object; `vector_source` is
+    /// `Some` when the vector blob was deliberately left out of the file (vector search reads only
+    /// a few clusters, so downloading the whole blob is wasteful) and is served from the block
+    /// cache instead. Parquet and FTS always come from the mmap.
+    Mapped {
+        mmap: Arc<Mmap>,
+        vector_source: Option<Arc<BlockCachedSource>>,
+    },
+    /// Byte ranges fetched on demand from object storage and cached locally in blocks.
+    /// `fill_spawned` latches the single background download so it starts at most once.
+    Paged {
+        block_source: Arc<BlockCachedSource>,
+        fill_spawned: AtomicBool,
+    },
+}
+
+impl CachedEntry {
+    /// The mmap when this entry is [`Residency::Mapped`], for the idle-page sweep's `madvise`.
+    fn mmap(&self) -> Option<&Arc<Mmap>> {
+        match &self.residency {
+            Residency::Mapped { mmap, .. } => Some(mmap),
+            _ => None,
+        }
+    }
+
+    /// Whether the whole file is mmapped locally, so the hot path never reads object storage.
+    fn is_mapped(&self) -> bool {
+        matches!(self.residency, Residency::Mapped { .. })
+    }
+
+    /// The live block source: a [`Residency::Paged`] entry's source, or the retained vector hole of
+    /// a [`Residency::Mapped`] entry.
+    fn block_source(&self) -> Option<&Arc<BlockCachedSource>> {
+        match &self.residency {
+            Residency::Paged { block_source, .. } => Some(block_source),
+            Residency::Mapped { vector_source, .. } => vector_source.as_ref(),
+            Residency::Buffered => None,
+        }
+    }
+
+    /// The background-fill latch when this entry is [`Residency::Paged`].
+    fn fill_spawned(&self) -> Option<&AtomicBool> {
+        match &self.residency {
+            Residency::Paged { fill_spawned, .. } => Some(fill_spawned),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -451,10 +476,7 @@ impl DiskCacheStore {
     /// `LazyForegroundWithBackgroundFill` still holds the lazy
     /// in-memory reader or the background download is in flight.
     pub fn is_mmap_promoted(&self, uri: &SuperfileUri) -> bool {
-        self.cached
-            .get(uri)
-            .map(|e| e.mmap.is_some())
-            .unwrap_or(false)
+        self.cached.get(uri).map(|e| e.is_mapped()).unwrap_or(false)
     }
 
     /// Snapshot of the cache's load. Cheap; reads atomics +
@@ -615,17 +637,36 @@ mod test_support {
 
     use crate::{
         storage::{LocalFsStorageProvider, StorageProvider},
-        superfile::builder::{BuilderOptions, SuperfileBuilder},
+        superfile::{
+            BytesLazyByteSource, LazyByteSource,
+            builder::{BuilderOptions, SuperfileBuilder},
+        },
         supertable::{
             manifest::SuperfileUri,
             reader_cache::{
-                block_source::{CACHE_BLOCK_BYTES, serialize_index},
+                block_source::{BlockCachedSource, CACHE_BLOCK_BYTES, serialize_index},
                 config::DiskCacheConfig,
                 disk::*,
             },
         },
-        test_helpers::{decimal128_id_field, decimal128_ids},
+        test_helpers::{decimal128_id_field, decimal128_ids, default_vector_config},
     };
+
+    /// A block source over empty storage, for tests that only need a [`Residency::Paged`] entry to
+    /// exist. Does not own budget accounting, so dropping it never touches `current_bytes`.
+    pub(crate) fn dummy_block_source(
+        store: &Arc<DiskCacheStore>,
+        uri: SuperfileUri,
+    ) -> Arc<BlockCachedSource> {
+        let inner: Arc<dyn LazyByteSource> = Arc::new(BytesLazyByteSource::new(Bytes::new()));
+        BlockCachedSource::new_pre_reserved(
+            inner,
+            Arc::downgrade(store),
+            uri,
+            store.blocks_path(&uri),
+            None,
+        )
+    }
 
     pub(crate) fn seed_valid_block_file(
         store: &Arc<DiskCacheStore>,
@@ -687,6 +728,29 @@ mod test_support {
         let batch =
             RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(titles)]).expect("batch");
         b.add_batch(&batch, &[]).expect("add_batch");
+        Bytes::from(b.finish().expect("finish"))
+    }
+
+    /// Like [`tiny_superfile_bytes`] but with a 16-dim vector column, so the reader carries a real
+    /// vector blob. Needed to drive the cold-fetch promote down its vector-hole path, where the
+    /// blob stays on the block cache instead of the mmap.
+    pub(crate) fn tiny_vector_superfile_bytes() -> Bytes {
+        let schema = Arc::new(Schema::new(vec![decimal128_id_field("doc_id")]));
+        let opts = BuilderOptions::new(
+            schema.clone(),
+            "doc_id",
+            vec![],
+            vec![default_vector_config("emb", 7)],
+        );
+        let mut b = SuperfileBuilder::new(opts).expect("builder");
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(decimal128_ids(vec![10u64, 11]))])
+            .expect("batch");
+        // Two rows on distinct axes so IVF clustering has something to place.
+        let mut embeddings = vec![0.0f32; 2 * 16];
+        embeddings[0] = 1.0;
+        embeddings[16 + 1] = 1.0;
+        b.add_batch(&batch, &[embeddings.as_slice()])
+            .expect("add_batch");
         Bytes::from(b.finish().expect("finish"))
     }
 

--- a/src/supertable/reader_cache/disk/read.rs
+++ b/src/supertable/reader_cache/disk/read.rs
@@ -157,7 +157,7 @@ impl DiskCacheStore {
         fetch_storage: Arc<dyn StorageProvider>,
     ) -> Result<Arc<SuperfileReader>, DiskCacheError> {
         if let Some(entry) = self.cached.get(uri) {
-            if entry.mmap.is_some() {
+            if entry.is_mapped() {
                 entry.last_access_us.store(self.now_us(), Ordering::Release);
                 return Ok(Arc::clone(&entry.reader));
             }
@@ -276,7 +276,11 @@ impl DiskCacheStore {
         let start = Instant::now();
         loop {
             let pending = self.cached.iter().any(|entry| {
-                entry.value().fill_spawned.load(Ordering::Acquire) && entry.value().mmap.is_none()
+                // A Paged entry whose fill latched but hasn't promoted to Mapped yet.
+                entry
+                    .value()
+                    .fill_spawned()
+                    .is_some_and(|f| f.load(Ordering::Acquire))
             });
             if !pending {
                 return Ok(());

--- a/src/supertable/reader_cache/disk/store_files.rs
+++ b/src/supertable/reader_cache/disk/store_files.rs
@@ -384,7 +384,7 @@ impl DiskCacheStore {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, atomic::AtomicU64};
+    use std::sync::Arc;
 
     use bytes::Bytes;
     use tempfile::TempDir;
@@ -546,9 +546,11 @@ mod tests {
         // second decrement here would underflow `current_bytes`.
         let (_dir, store) = test_store();
         let uri = SuperfileUri::new_v4();
-        let filled = Arc::new(AtomicU64::new(4096));
-        let token = Arc::new(());
-        store.install_block_entry_for_test(uri, Arc::clone(&filled), Arc::clone(&token));
+        let block_source = dummy_block_source(&store, uri);
+        block_source
+            .filled_bytes_handle()
+            .store(4096, Ordering::Release);
+        store.install_block_entry_for_test(uri, block_source);
         assert_eq!(store.stats().current_bytes, 0, "source owns these bytes");
 
         assert!(store.erase_superfile_local_copy(&uri), "entry was present");


### PR DESCRIPTION
### What does this PR do?

This PR replaces a cache entry's five loosely-coupled state fields with one `Residency` enum, without changing behavior. An entry is now explicitly one of `Buffered`, `Mapped`, or `Paged`, instead of a combination of optional fields. Part of #737.

### Why do we need this change?

The entry's real state, whether its bytes are in a heap buffer, lazily block-backed, or fully mmapped, was never written down. It lived as an implicit combination of `mmap`, `block_source`, `block_token`, and `fill_spawned`. Nothing stopped an illegal combination like a mmapped entry that also claimed to be source-owned, so the set of valid states existed only in people's heads.

### How do we do this change?

- `Residency` names the three states: `Buffered` (whole file in a heap buffer), `Mapped` (whole file mmapped, optionally keeping the large vector blob on the block cache), and `Paged` (byte ranges fetched on demand from object storage). The mmap, block source, and fill latch each move inside the variant they belong to, so an illegal combination no longer type-checks.

### Notes

- Behavior-preserving: the existing `disk_cache` suite is the contract and CI stays green with no assertion edits.