### PR TITLE
vector: anchor the near-tie admit extension to the stamped width

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -414,6 +414,11 @@ const DEFAULT_VECTOR_FINE_NPROBE_PCT: f64 = 0.0;
 /// (0.287–0.294 across the BioASQ diag configs; decisive-geometry
 /// controls cliff shut below it, so they are unaffected by the value).
 const DEFAULT_VECTOR_SERVE_NEAR_TIE_SLACK: f32 = 0.30;
+/// Cap on the #515 admit extension as a multiple of the stamped
+/// `width_for_k`: served cells are bounded to `mult * width` so the serve
+/// stays anchored to the target-aware width instead of the unbounded
+/// near-tie window. `1` = width-only (no extension). Default 3.
+const DEFAULT_VECTOR_ADMIT_EXTENSION_MULT: usize = 3;
 /// Default user superfiles the hidden-index drain materializes per batch.
 const DEFAULT_VECTOR_DRAIN_BATCH_SUPERFILES: i64 = 64;
 /// Default boundary-replication budget (commit + drain). `<= 1.0` disables
@@ -622,6 +627,10 @@ pub struct VectorSettings {
     /// measure real-query slack, the same distribution mismatch that
     /// under-stamped the width law on such corpora.
     pub serve_near_tie_slack: f32,
+    /// Cap on the #515 admit extension as a multiple of the stamped
+    /// `width_for_k` (see [`DEFAULT_VECTOR_ADMIT_EXTENSION_MULT`]). Anchors
+    /// admission to the target-aware width; `1` disables the extension.
+    pub admit_extension_mult: usize,
     /// K-means training points per centroid for the drain's per-cell
     /// sub-builds. Higher trains on more points (slower, tighter
     /// clusters).
@@ -831,6 +840,7 @@ impl Default for VectorSettings {
             target_recall: DEFAULT_VECTOR_TARGET_RECALL,
             fine_nprobe_pct: DEFAULT_VECTOR_FINE_NPROBE_PCT,
             serve_near_tie_slack: DEFAULT_VECTOR_SERVE_NEAR_TIE_SLACK,
+            admit_extension_mult: DEFAULT_VECTOR_ADMIT_EXTENSION_MULT,
             kmeans_pts_per_centroid: DEFAULT_VECTOR_KMEANS_PTS_PER_CENTROID,
             search_mode: VectorSearchMode::Ivf,
             hnsw_plane: VectorHnswPlane::default(),
@@ -1277,6 +1287,12 @@ impl Config {
             return Err(ConfigError::Invalid(format!(
                 "vector.target_recall must be in (0.0, 1.0], got {}",
                 v.target_recall
+            )));
+        }
+        if v.admit_extension_mult < 1 {
+            return Err(ConfigError::Invalid(format!(
+                "vector.admit_extension_mult ({}) must be >= 1 (1 = width-only)",
+                v.admit_extension_mult
             )));
         }
         for (name, floor) in [

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -5220,9 +5220,14 @@ impl SupertableReader {
                     superseded,
                 )
             })?;
+            // Round-0 exact-score shortlist: anchor to the stamped
+            // (target-aware) width when the law is serving; the fixed
+            // fraction/floor is the legacy fallback for unstamped tables.
+            let round0_window =
+                law_width.unwrap_or_else(|| admit_shortlist_window(admit_ranking.len()));
             let mut admitted: HashSet<u32> = admit_ranking
                 .iter()
-                .take(admit_shortlist_window(admit_ranking.len()))
+                .take(round0_window)
                 .map(|(cell, _)| *cell)
                 .collect();
             admitted.extend(must_include.iter().copied());
@@ -5259,8 +5264,24 @@ impl SupertableReader {
             // estimates could plausibly land inside the serve window;
             // admission is evidence-bounded, no query-side fraction.
             let law_default = !filtered && options.nprobe.is_none() && law_width.is_some();
+            // Cap the #515 extension at a target-aware multiple of the stamped
+            // width, so a loose near-tie window cannot balloon the served cell
+            // count far past what the width targets (`mult=1` => width-only).
+            // Floor the cap at the grid cover-k picks so a large `must_include`
+            // (a coarse blended query) never counts against — and starve — the
+            // near-tie extension budget.
+            let admit_cap = law_width
+                .map(|w| {
+                    w.saturating_mul(config::global().vector.admit_extension_mult)
+                        .max(w)
+                        .max(must_include.len())
+                })
+                .unwrap_or(usize::MAX);
             if law_default {
                 loop {
+                    if admitted.len() >= admit_cap {
+                        break;
+                    }
                     let fine_ranked_now = op_stats::timed_kernel(&self.op_stats, || {
                         cells_ranked_by_fine_score(&candidates)
                     });
@@ -5270,12 +5291,19 @@ impl SupertableReader {
                     let serve_threshold = relative_score_window(best_exact, serve_near_tie_slack);
                     let exact_best_by_cell: HashMap<u32, f32> =
                         fine_ranked_now.into_iter().collect();
-                    let round = admit_extension_round(
+                    let mut round = admit_extension_round(
                         &admit_ranking,
                         &admitted,
                         &exact_best_by_cell,
                         serve_threshold,
                     );
+                    if round.is_empty() {
+                        break;
+                    }
+                    // Bound this round to the target-aware cap: a single round
+                    // can qualify many cells at once, so keep only the best
+                    // (admit_ranking is best-first) up to the cap.
+                    round.truncate(admit_cap.saturating_sub(admitted.len()));
                     if round.is_empty() {
                         break;
                     }


### PR DESCRIPTION
## Problem

On the law-served default vector path, the served cell set was decoupled from the drain-stamped `width_for_k`. Round-0 exactly scored a fixed `max(20% of ranked cells, 48)` shortlist, and the near-tie window (`serve_near_tie_slack`) then extended the admitted set **without bound**. In practice a query served far more cells than the width targets — e.g. on Cohere-1M, a table whose width law stamps ~8 cells for a `target_recall` of 0.92 served **~140 cells**.

Two consequences:

- **Throughput** — the coarse 1-bit scan (and its per-cell LUT build + shortlist sort) is proportional to cells served, so over-serving cells is the dominant per-query cost at matched recall.
- **Recall overshoot** — `target_recall` 0.92 served ~0.98; the served recall did not track the target, and lowering the target barely moved served recall.

The stamped `width_for_k` is already the target-aware answer (it is computed per table and per `k`, and even pins the coarse sweep) — the admission path just wasn't using it.

## Change

Anchor admission to the stamped width:

- **Round-0** takes `width_for_k` cells when the law is serving (the `max(20%, 48)` fraction/floor stays as the fallback for unstamped tables).
- **The extension is capped** at `vector.admit_extension_mult` (new config, default **3**) times the width, **truncated within each round** to keep the best-estimate cells, and floored at the grid cover-`k` picks so a coarse blended query never starves the extension.

Explicit-`nprobe`, filtered, and unstamped/legacy queries are unchanged (`law_width = None` ⇒ prior behavior). `admit_extension_mult` is validated `>= 1` (`1` = width-only).

## Validation

Measured native calibrated serve (no per-query overrides) on Cohere-1M/10M, OpenAI-500K, and BioASQ-1M across `target_recall`, sweeping `admit_extension_mult`:

- **Served cells now track `mult × width`** at every scale — no 48-cell floor, no unbounded balloon.
- **Recall tracks the cap monotonically** and the overshoot is gone; on Cohere-1M `target_recall` 0.92 with `mult=2` serves ~0.925 (vs ~0.98 before), and throughput at matched recall rises substantially.
- **BioASQ** (width-bound) reaches its recall ceiling at higher `mult`, as expected — the cap keys off its (legitimately larger) stamped width, so it is not starved; this is the reason the bound is a width multiple rather than a global cell count.

Contract tests pass: `end_to_end_planted_clusters_recovered`, `law_floor_serve_selection_extends_past_the_served_floor`, `admit_extension_round_follows_evidence`, `admit_shortlist_window_scales_with_cell_population`, `shortlisted_assignment_matches_exact_on_planted_cells`.

## Known trade-off

Round-0 now scores `width_for_k` cells rather than a >=48 floor, so on small-width tables the `#515` residual is estimated from a thinner sample. This is the intended anchoring trade; `admit_extension_mult` (and, at the low end, `serve_near_tie_slack`) are the levers if a corpus needs a wider evidence base. The extension itself is unchanged in kind — only bounded.

Draft while CI runs the full suite.