### PR TITLE
vector: make the resident hnsw graph metric-aware (serve l2sq/negdot)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,13 @@
+# nextest configuration.
+#
+# The coverage gate (`make coverage-ci`) runs the suite through
+# `cargo llvm-cov nextest`, which executes each test in its OWN process and many
+# in parallel — a different isolation model than `cargo test`'s single-process
+# threaded run. That parallelism can surface transient cross-process contention
+# on shared external resources (temp dirs, storage paths) that the threaded run
+# never exposed. Retry a failed test a couple of times so such a transient is
+# reported as FLAKY (visible, still investigable) rather than failing the whole
+# coverage run on one non-deterministic hiccup. A test that fails every attempt
+# still fails the run, so real regressions are unaffected.
+[profile.default]
+retries = 2

--- a/src/superfile/vector/hnsw.rs
+++ b/src/superfile/vector/hnsw.rs
@@ -49,9 +49,11 @@ use rayon::prelude::*;
 use crate::superfile::vector::{
     distance::{
         Metric, SQ4_CODE_MAX, SQ4_LOADING_SIGMAS, SQ4_RESIDUAL_CENTER, SQ4_RESIDUAL_DIVISOR,
-        SQ4_ROW_BLOCK, Sq4Kernel, Sq16Kernel, dequantize_sq16_into, distance, encode_sq16_row,
-        quantize_query_i8, sq8_walk_dot,
+        SQ4_ROW_BLOCK, Sq4Kernel, Sq16Kernel, dequantize_sq16_adaptive_into, dequantize_sq16_into,
+        distance, encode_sq16_adaptive_row, encode_sq16_row, quantize_query_i8, sq8_walk_dot,
+        sq16_adaptive_norm_sq,
     },
+    rerank_codec::SQ16_CODE_MAX,
     rotation::RandomRotation,
 };
 
@@ -124,18 +126,56 @@ impl Plane {
     }
 }
 
-/// Sq16 node scorer: one `u16` code per dimension on the fixed cosine
-/// grid, scored with the existing fused-dequant [`Sq16Kernel`] under the
-/// [`Metric::NegDot`] convention (`score = −dot`, so smaller is nearer).
+/// Single-`u16`-plane node scorer: one `u16` code per dimension, scored with
+/// the existing fused-dequant [`Sq16Kernel`]. It carries the column's [`Metric`]
+/// and one of two rulers, so [`Hnsw::build`] / [`Hnsw::search`] grade against
+/// the geometry the column was created with:
 ///
-/// The codes are stored row-major (`dim × 2` bytes per node) and scored
-/// straight from the code bytes — no per-candidate decode buffer.
+/// - **Fixed cosine grid** (`ruler == None`, `metric == NegDot`). The codes are
+///   the flat `[-1, 1]` Sq16 plane; scoring is `−dot`, smaller is nearer. This
+///   is the cosine data graph and the only ruler that existed before the
+///   metric-aware path — every existing constructor produces it, so cosine
+///   behaviour is byte-for-byte unchanged.
+/// - **Fitted global ruler** (`ruler == Some((scale, offset))`). The codes are a
+///   single `u16` plane quantized against ONE per-dim ruler fitted over the
+///   whole graph — the graph-wide counterpart of the IVF rerank path's
+///   per-cluster [`RerankCodec::Sq16Adaptive`](crate::superfile::vector::rerank_codec::RerankCodec::Sq16Adaptive).
+///   (A single ruler, not per-cluster: the plane is node-ordered across every
+///   cell with no cluster to key a ruler on — the same reason [`Sq4Scorer`] fits
+///   a global ruler. 16 bits keeps the intra-cluster resolution a global ruler
+///   spends elsewhere.) Scoring is the column's real `metric` (`L2Sq`/`NegDot`)
+///   via [`Sq16Kernel::new_adaptive`]; `norms` carries per-node `‖x̂‖²` for the
+///   `L2Sq` cross-term (empty for `NegDot`, where the norm cancels).
+///
+/// The codes are stored row-major (`dim × 2` bytes per node) and scored straight
+/// from the code bytes — no per-candidate decode buffer either way.
 pub(crate) struct Sq16Scorer {
     /// `len × dim × 2` little-endian `u16` codes, row-major — owned heap, or a
     /// zero-copy slice of the mapped graph bundle.
     codes: Plane,
     dim: usize,
     len: usize,
+    /// Distance the kernel ranks by. `NegDot` for the fixed cosine grid (its
+    /// `−dot` orders unit vectors the same as cosine); the column's own metric
+    /// for a fitted ruler.
+    metric: Metric,
+    /// `None` = the fixed `[-1, 1]` cosine grid; `Some` = a fitted global ruler.
+    /// Boxed so the cosine scorer — the overwhelming common case, and the one
+    /// embedded in the resident [`HnswIndex`] / `ResidentIndexKind` enum — pays
+    /// only a pointer, not the two ruler vectors plus the norm table inline.
+    adaptive: Option<Box<AdaptiveRuler>>,
+}
+
+/// The fitted-ruler data a metric-aware [`Sq16Scorer`] carries — absent for the
+/// fixed cosine grid.
+struct AdaptiveRuler {
+    /// Per-dim ruler: reconstruction is `x[d] = code[d]·scale[d] + offset[d]`
+    /// (vs the fixed grid's constants). Each `dim` long.
+    scale: Vec<f32>,
+    offset: Vec<f32>,
+    /// Per-node dequantized `‖x̂‖²`, present only for `L2Sq` (the kernel's L2
+    /// cross-term needs it); empty for `NegDot`.
+    norms: Vec<f32>,
 }
 
 impl Sq16Scorer {
@@ -149,11 +189,7 @@ impl Sq16Scorer {
             debug_assert_eq!(v.len(), dim);
             encode_sq16_row(v, &mut codes[i * stride..(i + 1) * stride]);
         }
-        Self {
-            codes: Plane::Owned(codes),
-            dim,
-            len: vectors.len(),
-        }
+        Self::cosine(Plane::Owned(codes), dim, vectors.len())
     }
 
     /// Adopt already-encoded Sq16 code bytes verbatim: `codes` is
@@ -161,11 +197,7 @@ impl Sq16Scorer {
     /// on-disk `full[]` Sq16 plane. No decode/re-encode round trip.
     pub(crate) fn from_codes(codes: Vec<u8>, dim: usize, len: usize) -> Self {
         debug_assert_eq!(codes.len(), len * dim * 2);
-        Self {
-            codes: Plane::Owned(codes),
-            dim,
-            len,
-        }
+        Self::cosine(Plane::Owned(codes), dim, len)
     }
 
     /// Adopt an already-backed Sq16 code plane verbatim: the plane holds
@@ -174,7 +206,114 @@ impl Sq16Scorer {
     /// decode/re-encode round trip and, for the shared variant, no heap copy.
     pub(crate) fn from_plane(codes: Plane, dim: usize, len: usize) -> Self {
         debug_assert_eq!(codes.len(), len * dim * 2);
-        Self { codes, dim, len }
+        Self::cosine(codes, dim, len)
+    }
+
+    /// The fixed `[-1, 1]` cosine-grid scorer (`metric == NegDot`, no ruler,
+    /// no norms) — the one shape every legacy constructor produces.
+    fn cosine(codes: Plane, dim: usize, len: usize) -> Self {
+        Self {
+            codes,
+            dim,
+            len,
+            metric: Metric::NegDot,
+            adaptive: None,
+        }
+    }
+
+    /// Adopt a single-`u16` plane quantized against a fitted GLOBAL `(scale,
+    /// offset)` ruler (each `dim` long), scored under `metric`. `norms` are the
+    /// per-node dequantized `‖x̂‖²` and are required for `L2Sq` (the kernel's
+    /// cross-term reads them) and empty for `NegDot`. Cosine never takes this
+    /// path — it keeps the fixed grid.
+    pub(crate) fn from_adaptive_plane(
+        codes: Plane,
+        dim: usize,
+        len: usize,
+        metric: Metric,
+        scale: Vec<f32>,
+        offset: Vec<f32>,
+        norms: Vec<f32>,
+    ) -> Self {
+        debug_assert_eq!(codes.len(), len * dim * 2);
+        debug_assert_eq!(scale.len(), dim);
+        debug_assert_eq!(offset.len(), dim);
+        debug_assert!(metric != Metric::Cosine, "cosine keeps the fixed grid");
+        debug_assert_eq!(
+            norms.len(),
+            if metric == Metric::L2Sq { len } else { 0 },
+            "L2Sq needs one per-node norm; NegDot needs none"
+        );
+        Self {
+            codes,
+            dim,
+            len,
+            metric,
+            adaptive: Some(Box::new(AdaptiveRuler {
+                scale,
+                offset,
+                norms,
+            })),
+        }
+    }
+
+    /// Fit ONE global `(scale, offset)` ruler over `flat` (`len × dim` fp32,
+    /// row-major) and encode it to a single-`u16` adaptive plane scored under
+    /// `metric` — the non-cosine counterpart of [`Self::from_unit_vectors`]. The
+    /// ruler is per-dim `[min, max] → (scale = span/65535, offset = min)`, the
+    /// same fit the IVF per-cluster `Sq16Adaptive` uses, but taken once over the
+    /// whole graph (the plane is node-ordered across cells, with no cluster to
+    /// key a ruler on). A degenerate (constant) dim keeps `scale = 1` so decode
+    /// returns the offset exactly. Per-node `‖x̂‖²` is computed for `L2Sq`.
+    ///
+    /// The ruler is always fit fresh over `flat`. (A ruler-INHERITING variant —
+    /// delta rows landing on a prior plane's ruler, the first-input-ruler rule
+    /// the adaptive codecs follow on merge — belongs with the incremental extend
+    /// path, which does not yet support fitted-ruler graphs.)
+    pub(crate) fn from_fp32_metric(flat: &[f32], dim: usize, len: usize, metric: Metric) -> Self {
+        debug_assert_eq!(flat.len(), len * dim);
+        debug_assert_ne!(metric, Metric::Cosine, "cosine keeps the fixed grid");
+        let (scale, offset) = {
+            let mut lo = vec![f32::INFINITY; dim];
+            let mut hi = vec![f32::NEG_INFINITY; dim];
+            for i in 0..len {
+                let row = &flat[i * dim..(i + 1) * dim];
+                for (d, &x) in row.iter().enumerate() {
+                    lo[d] = lo[d].min(x);
+                    hi[d] = hi[d].max(x);
+                }
+            }
+            let mut scale = vec![1.0f32; dim];
+            let mut offset = vec![0.0f32; dim];
+            for d in 0..dim {
+                // A constant (or empty-plane) coordinate keeps unit scale so the
+                // stored ruler stays finite and round-trips; encode maps it to
+                // code 0 and decode returns `offset` exactly.
+                if lo[d].is_finite() && hi[d] > lo[d] {
+                    offset[d] = lo[d];
+                    scale[d] = (hi[d] - lo[d]) / SQ16_CODE_MAX;
+                } else if lo[d].is_finite() {
+                    offset[d] = lo[d];
+                }
+            }
+            (scale, offset)
+        };
+        let stride = dim * 2;
+        let mut codes = vec![0u8; len * stride];
+        let mut norms = if metric == Metric::L2Sq {
+            vec![0.0f32; len]
+        } else {
+            Vec::new()
+        };
+        for i in 0..len {
+            let src = &flat[i * dim..(i + 1) * dim];
+            let row = &mut codes[i * stride..(i + 1) * stride];
+            encode_sq16_adaptive_row(src, &scale, &offset, row);
+            if metric == Metric::L2Sq {
+                norms[i] = sq16_adaptive_norm_sq(row, dim, &scale, &offset);
+            }
+        }
+        Self::from_adaptive_plane(Plane::Owned(codes), dim, len, metric, scale, offset, norms)
     }
 
     /// The raw node-ordered Sq16 code plane — so an incremental build can
@@ -184,11 +323,70 @@ impl Sq16Scorer {
         self.codes.bytes()
     }
 
+    /// The distance the kernel ranks by (`NegDot` for the fixed cosine grid).
+    pub(crate) fn metric(&self) -> Metric {
+        self.metric
+    }
+
+    /// The COLUMN metric this scorer serves: the fixed grid serves `Cosine` (its
+    /// `−dot` orders unit vectors the same way), a fitted ruler serves its own
+    /// `metric`. Distinct from [`Self::metric`] — the serving path compares this
+    /// to the column's declared metric to reject a graph built for another.
+    pub(crate) fn served_metric(&self) -> Metric {
+        if self.adaptive.is_none() {
+            Metric::Cosine
+        } else {
+            self.metric
+        }
+    }
+
+    /// The fitted global ruler `(scale, offset)`, or `None` for the fixed
+    /// cosine grid — so [`encode_hnsw`] can persist it.
+    pub(crate) fn ruler(&self) -> Option<(&[f32], &[f32])> {
+        self.adaptive
+            .as_ref()
+            .map(|a| (a.scale.as_slice(), a.offset.as_slice()))
+    }
+
+    /// Per-node dequantized `‖x̂‖²` (non-empty only for a fitted-ruler `L2Sq`
+    /// scorer) — so [`encode_hnsw`] can persist the norm table.
+    pub(crate) fn node_norms(&self) -> &[f32] {
+        self.adaptive.as_ref().map_or(&[], |a| a.norms.as_slice())
+    }
+
+    /// Whether calibration queries drawn from this plane should be
+    /// unit-normalized: yes for the fixed cosine grid (its geometry is
+    /// unit vectors), no for a fitted ruler (magnitude carries signal under
+    /// `L2Sq`/`NegDot`).
+    pub(crate) fn normalizes_queries(&self) -> bool {
+        self.adaptive.is_none()
+    }
+
+    /// Decode one node to fp32 through whichever ruler this scorer holds — the
+    /// fixed grid or the fitted `(scale, offset)`. Used to synthesize
+    /// calibration queries in the plane's own geometry.
+    pub(crate) fn decode_node_into(&self, node: u32, out: &mut [f32]) {
+        debug_assert_eq!(out.len(), self.dim);
+        match &self.adaptive {
+            None => dequantize_sq16_into(self.row(node), out),
+            Some(a) => dequantize_sq16_adaptive_into(self.row(node), &a.scale, &a.offset, out),
+        }
+    }
+
     #[inline]
     fn row(&self, node: u32) -> &[u8] {
         let stride = self.dim * 2;
         let start = node as usize * stride;
         &self.codes.bytes()[start..start + stride]
+    }
+
+    /// Fold a query into the fused kernel through this scorer's ruler + metric.
+    #[inline]
+    fn kernel_for(&self, query: &[f32]) -> Sq16Kernel {
+        match &self.adaptive {
+            None => Sq16Kernel::new(self.metric, query),
+            Some(a) => Sq16Kernel::new_adaptive(self.metric, query, &a.scale, &a.offset),
+        }
     }
 }
 
@@ -206,7 +404,7 @@ impl NodeScorer for Sq16Scorer {
     }
 
     fn prepare(&self, query: &[f32]) -> Sq16Kernel {
-        Sq16Kernel::new(Metric::NegDot, query)
+        self.kernel_for(query)
     }
 
     fn prepare_node(&self, node: u32) -> Sq16Kernel {
@@ -214,16 +412,20 @@ impl NodeScorer for Sq16Scorer {
         // at build time) so it can act as the query for node-to-node
         // distance; candidate scoring below stays fused-from-codes.
         let mut decoded = vec![0.0f32; self.dim];
-        dequantize_sq16_into(self.row(node), &mut decoded);
-        Sq16Kernel::new(Metric::NegDot, &decoded)
+        self.decode_node_into(node, &mut decoded);
+        self.kernel_for(&decoded)
     }
 
     #[inline]
     fn score(&self, q: &Sq16Kernel, node: u32) -> f32 {
-        // NegDot: `distance_with_norm` returns `−dot`, computed by the
-        // fused `u16 → f32` dequant cross kernel straight off the code
-        // bytes — no per-candidate decode.
-        q.distance_with_norm(self.row(node), None)
+        // Fixed cosine grid / NegDot: `distance_with_norm` returns `−dot` with
+        // no norm term. A fitted-ruler L2Sq scorer feeds the node's stored
+        // `‖x̂‖²`; every case is the fused `u16 → f32` dequant cross kernel
+        // straight off the code bytes — no per-candidate decode.
+        let norm = (self.metric == Metric::L2Sq)
+            .then(|| self.adaptive.as_ref().map(|a| a.norms[node as usize]))
+            .flatten();
+        q.distance_with_norm(self.row(node), norm)
     }
 }
 
@@ -1266,23 +1468,37 @@ pub(crate) fn calibration_queries(
 ) -> Vec<Vec<f32>> {
     let n = scorer.len();
     let dim = scorer.dim();
-    let stride = dim * 2;
     let mut rng = seed ^ SPLITMIX64_INCREMENT;
     let nq = n_queries.min(n);
+    // The fixed cosine grid's geometry is unit vectors: jitter by an absolute
+    // amount and renormalize. A fitted ruler (L2Sq/NegDot) is in the column's
+    // own un-normalized space — an absolute 0.05 nudge is negligible next to a
+    // raw vector's components, so recall would read falsely optimistic; scale
+    // the nudge to the vector's magnitude instead, and DON'T renormalize
+    // (magnitude carries signal).
+    let normalize = scorer.normalizes_queries();
     (0..nq)
         .map(|i| {
-            let node = i.wrapping_mul(CALIB_QUERY_STRIDE_MULT) % n;
+            let node = (i.wrapping_mul(CALIB_QUERY_STRIDE_MULT) % n) as u32;
             let mut v = vec![0.0f32; dim];
-            // Straight from the Sq16 codes: a query derived through a
+            // Decoded through the scorer's own ruler: a query derived through a
             // coarse plane would carry that plane's error into the probe.
-            dequantize_sq16_into(&scorer.codes()[node * stride..(node + 1) * stride], &mut v);
+            scorer.decode_node_into(node, &mut v);
+            let jitter = if normalize {
+                CALIB_QUERY_JITTER
+            } else {
+                let rms = (v.iter().map(|a| a * a).sum::<f32>() / dim as f32).sqrt();
+                CALIB_QUERY_JITTER * rms.max(1e-12)
+            };
             for x in &mut v {
                 let u = (splitmix64(&mut rng) >> 40) as f32 / (1u64 << 24) as f32; // [0,1)
-                *x += (u * 2.0 - 1.0) * CALIB_QUERY_JITTER;
+                *x += (u * 2.0 - 1.0) * jitter;
             }
-            let norm = v.iter().map(|a| a * a).sum::<f32>().sqrt().max(1e-12);
-            for x in &mut v {
-                *x /= norm;
+            if normalize {
+                let norm = v.iter().map(|a| a * a).sum::<f32>().sqrt().max(1e-12);
+                for x in &mut v {
+                    *x /= norm;
+                }
             }
             v
         })
@@ -1815,7 +2031,7 @@ const HNSW_DATA_MAGIC_V3: &[u8; 8] = b"INFDDG03";
 /// `k`) on `v03`/`v02` — today's exact behavior, no forced rebuild.
 const HNSW_DATA_MAGIC_V4: &[u8; 8] = b"INFDDG04";
 /// All magics are 8 bytes; the shared byte width of the leading tag.
-const HNSW_DATA_MAGIC_LEN: usize = HNSW_DATA_MAGIC_V4.len();
+pub(crate) const HNSW_DATA_MAGIC_LEN: usize = HNSW_DATA_MAGIC_V4.len();
 /// Byte size of the fixed frame of a data bundle: magic(8) + n(u64) + dim(u32)
 /// + ef(u32) + col_len(u32) + graph_len(u64). The variable-length column name,
 /// doc-id map, Sq16/SQ8 planes, and graph bytes are added on top; naming it
@@ -1836,6 +2052,42 @@ const HNSW_DATA_FIXED_BYTES: usize = HNSW_DATA_MAGIC_LEN + 8 + 4 + 4 + 4 + 8;
 /// would take the column-name length out of the middle of the header and
 /// mis-slice every section after it.
 const HNSW_DATA_MAGIC_V5: &[u8; 8] = b"INFDDG05";
+
+/// `v06` makes the Sq16 refine plane metric-aware. It appends, after `v05`'s
+/// trailing k→ef curve, a metric byte and — for a non-cosine column — the
+/// single fitted global ruler (`scale[dim]`, `offset[dim]`) the plane was
+/// quantized against plus, for `L2Sq`, the per-node `‖x̂‖²` table. Cosine
+/// columns keep writing `v05` (fixed `[-1, 1]` grid, `−dot`), so every existing
+/// cosine bundle and reader is untouched; only L2Sq/NegDot columns — which
+/// `v05` and earlier declined to build a graph for at all — reach `v06`.
+///
+/// The ruler + norms ride at the END rather than the header so the entire
+/// `v05` sequential read (doc-ids, Sq16/walk planes, graph, curve) is byte-for
+/// -byte unchanged; `v06` reads three extra trailing sections and rebuilds a
+/// metric-aware scorer from them instead of the fixed-grid one.
+pub(crate) const HNSW_DATA_MAGIC_V6: &[u8; 8] = b"INFDDG06";
+
+/// Wire tag for the column metric stamped in a `v06` bundle. Local to the
+/// bundle format so the on-disk mapping cannot drift with an unrelated enum
+/// reorder elsewhere.
+fn metric_tag(metric: Metric) -> u8 {
+    match metric {
+        Metric::Cosine => 0,
+        Metric::L2Sq => 1,
+        Metric::NegDot => 2,
+    }
+}
+
+/// Inverse of [`metric_tag`]; `None` for an unknown tag (a newer build) so the
+/// bundle decodes to `None` and the query serves ivf rather than misreading it.
+fn metric_from_tag(tag: u8) -> Option<Metric> {
+    match tag {
+        0 => Some(Metric::Cosine),
+        1 => Some(Metric::L2Sq),
+        2 => Some(Metric::NegDot),
+        _ => None,
+    }
+}
 
 /// Which resident plane the graph walk scores candidates on.
 ///
@@ -1977,6 +2229,12 @@ pub(crate) struct HnswIndex {
 /// `sq4` must be `Some` exactly when `walk` names a 4-bit codec; the caller
 /// builds it from the same `sq16_codes` written here, so the two cannot
 /// describe different rows.
+///
+/// `ruler` makes the Sq16 refine plane metric-aware: `None` writes a `v05`
+/// bundle (the fixed `[-1, 1]` cosine grid, scored `−dot`); `Some((scale,
+/// offset))` writes a `v06` bundle stamping `metric` plus that single fitted
+/// global ruler and, for `L2Sq`, the per-node `‖x̂‖²` in `norms`. Cosine passes
+/// `None`, so its bytes are unchanged.
 pub(crate) fn encode_hnsw(
     sq16_codes: &[u8],
     doc_ids: &[i128],
@@ -1987,6 +2245,9 @@ pub(crate) fn encode_hnsw(
     column: &str,
     walk: WalkCodec,
     sq4: Option<&Sq4Scorer>,
+    metric: Metric,
+    ruler: Option<(&[f32], &[f32])>,
+    norms: &[f32],
 ) -> Vec<u8> {
     let n = doc_ids.len();
     debug_assert_eq!(sq16_codes.len(), n * dim * 2);
@@ -1994,6 +2255,19 @@ pub(crate) fn encode_hnsw(
         walk.is_sq4(),
         sq4.is_some(),
         "the 4-bit plane must be supplied exactly when the codec names it"
+    );
+    // A fitted ruler makes this a v06 (metric-aware) bundle; its absence is the
+    // fixed-grid cosine v05. Guard the shapes the two trailing sections assume.
+    let v6 = ruler.is_some();
+    if let Some((scale, offset)) = ruler {
+        debug_assert_ne!(metric, Metric::Cosine, "cosine keeps the fixed grid (v05)");
+        debug_assert_eq!(scale.len(), dim, "ruler scale length vs dim");
+        debug_assert_eq!(offset.len(), dim, "ruler offset length vs dim");
+    }
+    debug_assert_eq!(
+        norms.len(),
+        if v6 && metric == Metric::L2Sq { n } else { 0 },
+        "L2Sq stamps one norm per node; every other case stamps none"
     );
     let graph_bytes = graph.to_bytes();
     let col = column.as_bytes();
@@ -2010,6 +2284,13 @@ pub(crate) fn encode_hnsw(
     };
     // The trailing k→ef curve: a u16 count then `(u32 k, u32 ef)` per pair.
     let curve_len = 2 + ef_curve.len() * 8;
+    // v06 metric-aware trailer: metric byte, and for a fitted ruler the two
+    // f32 ruler vectors plus the per-node norm table (L2Sq only).
+    let meta_len = if v6 {
+        1 + dim * 2 * 4 + norms.len() * 4
+    } else {
+        0
+    };
     let mut out = Vec::with_capacity(
         HNSW_DATA_FIXED_BYTES
             + 1
@@ -2018,9 +2299,14 @@ pub(crate) fn encode_hnsw(
             + sq16_codes.len()
             + walk_len
             + graph_bytes.len()
-            + curve_len,
+            + curve_len
+            + meta_len,
     );
-    out.extend_from_slice(HNSW_DATA_MAGIC_V5);
+    out.extend_from_slice(if v6 {
+        HNSW_DATA_MAGIC_V6
+    } else {
+        HNSW_DATA_MAGIC_V5
+    });
     out.extend_from_slice(&(n as u64).to_le_bytes());
     out.extend_from_slice(&(dim as u32).to_le_bytes());
     // Was reserved / alignment; now the stamped recall@10 query beam (u32).
@@ -2081,6 +2367,21 @@ pub(crate) fn encode_hnsw(
         out.extend_from_slice(&k.to_le_bytes());
         out.extend_from_slice(&ef.to_le_bytes());
     }
+    // v06 metric-aware trailer, after the curve so the whole v05 layout above is
+    // untouched: metric byte, then (fitted ruler only) `scale`, `offset`, and
+    // the per-node norm table. Cosine wrote v05 and skips all of this.
+    if let Some((scale, offset)) = ruler {
+        out.push(metric_tag(metric));
+        for &s in scale {
+            out.extend_from_slice(&s.to_le_bytes());
+        }
+        for &o in offset {
+            out.extend_from_slice(&o.to_le_bytes());
+        }
+        for &nsq in norms {
+            out.extend_from_slice(&nsq.to_le_bytes());
+        }
+    }
     out
 }
 
@@ -2124,24 +2425,28 @@ pub(crate) fn decode_hnsw(bundle: &Bytes, want: Option<WalkCodec>) -> Option<Hns
     let bytes: &[u8] = bundle.as_ref();
     let mut c = Cursor::new(bytes);
     let magic = c.take(HNSW_DATA_MAGIC_LEN)?;
-    // Two independent format axes, so three facts per magic:
-    //   - `walk_tag`: does the header carry the walk-codec byte? `v05` only.
+    // Independent format axes, so four facts per magic:
+    //   - `walk_tag`: does the header carry the walk-codec byte? `v05`/`v06`.
     //   - `implied_walk`: for the versions that predate that byte, the codec
     //     their layout implies — `v03`/`v04` always wrote the SQ8 section,
     //     `v02` wrote none, so SQ8 is derived on read.
-    //   - `has_curve`: is the trailing k→ef curve present? `v04`/`v05`. Older
-    //     bundles synthesize a degenerate 1-point curve from the single stamped
-    //     `ef` below.
+    //   - `has_curve`: is the trailing k→ef curve present? `v04`/`v05`/`v06`.
+    //     Older bundles synthesize a degenerate 1-point curve from the single
+    //     stamped `ef` below.
+    //   - `metric_aware`: does a metric + fitted-ruler trailer follow the curve?
+    //     `v06` only; every older bundle is the fixed `[-1, 1]` cosine grid.
     // Any other tag (e.g. a legacy `01`) is unsupported → `None`, and the query
     // serves ivf until the next drain rebuilds.
-    let (walk_tag, implied_walk, has_curve) = if magic == HNSW_DATA_MAGIC_V5 {
-        (true, WalkCodec::Sq16, true)
+    let (walk_tag, implied_walk, has_curve, metric_aware) = if magic == HNSW_DATA_MAGIC_V6 {
+        (true, WalkCodec::Sq16, true, true)
+    } else if magic == HNSW_DATA_MAGIC_V5 {
+        (true, WalkCodec::Sq16, true, false)
     } else if magic == HNSW_DATA_MAGIC_V4 {
-        (false, WalkCodec::Sq8, true)
+        (false, WalkCodec::Sq8, true, false)
     } else if magic == HNSW_DATA_MAGIC_V3 {
-        (false, WalkCodec::Sq8, false)
+        (false, WalkCodec::Sq8, false, false)
     } else if magic == HNSW_DATA_MAGIC_V2 {
-        (false, WalkCodec::Sq16, false)
+        (false, WalkCodec::Sq16, false, false)
     } else {
         return None;
     };
@@ -2198,7 +2503,11 @@ pub(crate) fn decode_hnsw(bundle: &Bytes, want: Option<WalkCodec>) -> Option<Hns
     let mut sq8_plane = Plane::Owned(Vec::new());
     match stored {
         WalkCodec::Sq16 => {
-            if want != WalkCodec::Sq16 {
+            // A metric-aware (fitted-ruler) bundle never serves a derived SQ8
+            // walk: the high byte of a per-dim adaptive code is not a valid
+            // proximity proxy, so the serve path walks the Sq16 plane directly.
+            // Deriving one anyway would just waste `n × dim` bytes.
+            if want != WalkCodec::Sq16 && !metric_aware {
                 sq8_plane = Plane::Owned(derive_sq8_plane(sq16_slice));
             }
         }
@@ -2292,7 +2601,46 @@ pub(crate) fn decode_hnsw(bundle: &Bytes, want: Option<WalkCodec>) -> Option<Hns
     } else {
         ef_curve
     };
-    let scorer = Sq16Scorer::from_plane(Plane::Shared(sq16_plane), dim, n);
+    // The refine scorer: the fixed cosine grid for every pre-`v06` bundle, or
+    // the fitted-ruler metric-aware plane read from the `v06` trailer. The Sq16
+    // plane bytes are identical either way — only the ruler/metric/norms the
+    // scorer scores them through differ.
+    let scorer = if metric_aware {
+        let metric = metric_from_tag(c.u8()?)?;
+        // A cosine tag in a v06 trailer is malformed (cosine writes v05); reject
+        // rather than build a fitted-ruler scorer that will not be exercised.
+        if metric == Metric::Cosine {
+            return None;
+        }
+        // Bound the ruler read (two f32 vectors) before taking it.
+        if dim.checked_mul(2)?.checked_mul(4)? > c.remaining() {
+            return None;
+        }
+        let scale = read_f32_le(c.take(dim.checked_mul(4)?)?);
+        let offset = read_f32_le(c.take(dim.checked_mul(4)?)?);
+        // Per-node norms follow for L2Sq only (the kernel's cross-term needs
+        // them); NegDot stamps none. Bound the read before taking it.
+        let norms = if metric == Metric::L2Sq {
+            let norm_bytes = n.checked_mul(4)?;
+            if norm_bytes > c.remaining() {
+                return None;
+            }
+            read_f32_le(c.take(norm_bytes)?)
+        } else {
+            Vec::new()
+        };
+        Sq16Scorer::from_adaptive_plane(
+            Plane::Shared(sq16_plane),
+            dim,
+            n,
+            metric,
+            scale,
+            offset,
+            norms,
+        )
+    } else {
+        Sq16Scorer::from_plane(Plane::Shared(sq16_plane), dim, n)
+    };
     Some(HnswIndex {
         scorer,
         graph,
@@ -3605,6 +3953,9 @@ mod tests {
             "emb",
             WalkCodec::Sq8,
             None,
+            Metric::Cosine,
+            None,
+            &[],
         );
         assert_eq!(
             &bytes[..HNSW_DATA_MAGIC_LEN],
@@ -3695,6 +4046,9 @@ mod tests {
                 "emb",
                 walk,
                 Some(&sq4),
+                Metric::Cosine,
+                None,
+                &[],
             );
             assert_eq!(
                 &bytes[..HNSW_DATA_MAGIC_LEN],
@@ -3722,6 +4076,78 @@ mod tests {
                     graph.search(original, q, 10, 64),
                     idx.graph.search(restored, q, 10, 64),
                     "restored Sq4 bundle search diverged"
+                );
+            }
+        }
+    }
+
+    /// The metric-aware `v06` bundle round-trips a fitted-ruler plane: the
+    /// metric, the single global `(scale, offset)` ruler, and — for L2Sq — the
+    /// per-node norm table, all recovered so a decoded graph scores exactly the
+    /// distances it was built on. Covers both non-cosine metrics: L2Sq (carries
+    /// norms) and NegDot (no norms).
+    #[test]
+    fn hnsw_bundle_roundtrip_v06_metric_aware() {
+        let dim = 20;
+        let n = 800;
+        for metric in [Metric::L2Sq, Metric::NegDot] {
+            // Non-unit vectors so the ruler spans a real range and, under L2Sq,
+            // the per-node norms actually vary.
+            let flat: Vec<f32> = random_unit_vectors(n, dim, 0xA11CE)
+                .into_iter()
+                .flatten()
+                .enumerate()
+                .map(|(i, x)| x * (1.0 + (i % 5) as f32))
+                .collect();
+            let scorer = Sq16Scorer::from_fp32_metric(&flat, dim, n, metric);
+            assert_eq!(scorer.served_metric(), metric);
+            assert!(scorer.ruler().is_some(), "a fitted ruler must be present");
+            assert_eq!(
+                scorer.node_norms().len(),
+                if metric == Metric::L2Sq { n } else { 0 },
+                "L2Sq stamps one norm per node; NegDot stamps none"
+            );
+            let graph = Hnsw::build(&scorer, HnswParams::default());
+            let doc_ids: Vec<i128> = (0..n as i128).map(|i| 500 + i * 3).collect();
+            let curve: Vec<(u32, u32)> = vec![(10, 128)];
+            let (rscale, roffset) = scorer.ruler().expect("ruler");
+            let bytes = encode_hnsw(
+                scorer.codes(),
+                &doc_ids,
+                &graph,
+                dim,
+                128,
+                &curve,
+                "emb",
+                WalkCodec::Sq16,
+                None,
+                metric,
+                Some((rscale, roffset)),
+                scorer.node_norms(),
+            );
+            assert_eq!(
+                &bytes[..HNSW_DATA_MAGIC_LEN],
+                HNSW_DATA_MAGIC_V6,
+                "a fitted-ruler bundle stamps the v06 magic"
+            );
+            let idx = decode_hnsw(&Bytes::from(bytes), Some(WalkCodec::Sq16)).expect("decode v06");
+            assert_eq!(idx.scorer.served_metric(), metric, "metric round-trips");
+            let (dscale, doffset) = idx.scorer.ruler().expect("ruler round-trips");
+            assert_eq!(dscale, rscale, "ruler scale round-trips");
+            assert_eq!(doffset, roffset, "ruler offset round-trips");
+            assert_eq!(
+                idx.scorer.node_norms(),
+                scorer.node_norms(),
+                "norm table round-trips"
+            );
+            // The decoded graph scores exactly what the built one does — the
+            // whole point of persisting the ruler + norms rather than a plane on
+            // the wrong grid.
+            for q in random_unit_vectors(15, dim, 0xF00D) {
+                assert_eq!(
+                    graph.search(&scorer, &q, 10, 64),
+                    idx.graph.search(&idx.scorer, &q, 10, 64),
+                    "{metric:?}: metric-aware bundle search diverged"
                 );
             }
         }
@@ -3770,6 +4196,9 @@ mod tests {
                 "emb",
                 walk,
                 sq4.as_ref(),
+                Metric::Cosine,
+                None,
+                &[],
             );
             let bundle = Bytes::from(bytes);
 
@@ -3856,6 +4285,9 @@ mod tests {
                 "emb",
                 walk,
                 sq4.as_ref(),
+                Metric::Cosine,
+                None,
+                &[],
             ));
 
             // What maintenance does: hydrate as stored, re-encode on the
@@ -3871,6 +4303,9 @@ mod tests {
                 &prior.column,
                 prior.stored_walk,
                 prior.sq4.as_ref(),
+                Metric::Cosine,
+                None,
+                &[],
             ));
             assert_eq!(
                 first, again,
@@ -3916,6 +4351,9 @@ mod tests {
             column,
             WalkCodec::Sq4,
             Some(&sq4),
+            Metric::Cosine,
+            None,
+            &[],
         );
 
         // Walk the header to the ruler's `step` vector and zero its first
@@ -4142,6 +4580,9 @@ mod tests {
             "emb",
             WalkCodec::Sq8,
             None,
+            Metric::Cosine,
+            None,
+            &[],
         );
         assert_eq!(&v5[..HNSW_DATA_MAGIC_LEN], HNSW_DATA_MAGIC_V5);
 
@@ -4259,6 +4700,9 @@ mod tests {
             "emb",
             WalkCodec::Sq8,
             None,
+            Metric::Cosine,
+            None,
+            &[],
         );
         let idx_off =
             decode_hnsw(&Bytes::from(v5_again), Some(WalkCodec::Sq16)).expect("decode v05 sq8-off");
@@ -4364,6 +4808,9 @@ mod tests {
             "emb",
             WalkCodec::Sq8,
             None,
+            Metric::Cosine,
+            None,
+            &[],
         );
         let idx = decode_hnsw(&Bytes::from(bytes), Some(WalkCodec::Sq8)).expect("decode bundle");
         assert!(

--- a/src/supertable/query/vector.rs
+++ b/src/supertable/query/vector.rs
@@ -108,7 +108,9 @@ use crate::{
         fts::reader::BoolMode,
         vector::{
             cell_posting::EncodedCellRow,
-            distance::{Metric, distance, normalize, relative_score_window},
+            distance::{
+                Metric, dequantize_sq16_adaptive_into, distance, normalize, relative_score_window,
+            },
             flat::Sq4FlatIndex,
             hnsw::{self, HnswParams, Plane, Sq4Scorer, Sq16Scorer, encode_hnsw},
             layout::VectorLayout,
@@ -2714,18 +2716,82 @@ const HNSW_CALIB_SEED: u64 = 0x_C0FF_EE00_CA11_B000;
 /// in the same order). `stride_step = Some(k)` keeps only every k-th row — a
 /// coarse, deterministic, evenly-spread sample that lets the probe bound its
 /// memory to ~`n/k` rows instead of the whole plane; `None` collects every row.
-async fn collect_hnsw_codes(
+/// The node-ordered rerank plane a resident-index build gathers, in the form the
+/// column's ruler needs. Cosine keeps the raw fixed-grid Sq16 codes (used
+/// verbatim); a fitted-ruler metric (`Sq16Adaptive`, whose codes are
+/// per-cluster) is decoded to fp32 so the caller can refit it onto ONE global
+/// ruler. Node ordering is identical either way — the gather iteration is what
+/// defines what node index N means, and the metric only changes the payload.
+enum GatheredPlane {
+    /// `rows × dim × 2` fixed-grid Sq16 code bytes (cosine).
+    Codes(Vec<u8>),
+    /// `rows × dim` decoded fp32, row-major (a fitted-ruler metric).
+    Fp32(Vec<f32>),
+}
+
+impl Default for GatheredPlane {
+    /// An empty cosine plane — the placeholder `std::mem::take` leaves behind
+    /// once the build has consumed the gathered plane.
+    fn default() -> Self {
+        GatheredPlane::Codes(Vec::new())
+    }
+}
+
+impl GatheredPlane {
+    /// Decoded/carried row count implied by the payload length and `dim`.
+    fn rows(&self, dim: usize) -> usize {
+        match self {
+            GatheredPlane::Codes(b) => b.len() / (dim * 2),
+            GatheredPlane::Fp32(f) => f.len() / dim,
+        }
+    }
+
+    /// Build the resident scorer this plane serves: the fixed cosine grid for
+    /// raw codes, or a freshly-fitted global ruler over the decoded fp32.
+    fn into_scorer(self, dim: usize, len: usize, metric: Metric) -> Sq16Scorer {
+        match self {
+            GatheredPlane::Codes(b) => Sq16Scorer::from_codes(b, dim, len),
+            GatheredPlane::Fp32(f) => Sq16Scorer::from_fp32_metric(&f, dim, len, metric),
+        }
+    }
+
+    /// The raw Sq16 code bytes; valid only for the cosine (`Codes`) plane the
+    /// flat arm gathers (it is metric-gated to cosine, so it never sees fp32).
+    fn expect_codes(self) -> Vec<u8> {
+        match self {
+            GatheredPlane::Codes(b) => b,
+            GatheredPlane::Fp32(_) => {
+                unreachable!("flat index build gathers a cosine (Codes) plane")
+            }
+        }
+    }
+}
+
+/// Decode one materialized single-`u16` rerank row (`Sq16Adaptive`) to fp32
+/// through its per-cluster ruler — the reconstruction the metric-aware graph
+/// refits onto one global ruler at drain, the same transient fp32 the IVF merge
+/// transcode already produces. `out.len() == dim`.
+fn decode_adaptive_row_into(enc: &EncodedCellRow, out: &mut [f32]) {
+    dequantize_sq16_adaptive_into(&enc.codes, &enc.scale, &enc.offset, out);
+}
+
+async fn collect_hnsw_plane(
     manifest: &ManifestSnapshot,
     column: &str,
-    stride: usize,
+    dim: usize,
     stride_step: Option<usize>,
-) -> Result<Vec<u8>, QueryError> {
+    metric: Metric,
+) -> Result<GatheredPlane, QueryError> {
+    let stride = dim * 2;
+    let metric_aware = metric != Metric::Cosine;
     let store = Arc::clone(&manifest.options.store);
     let disk_cache = manifest.options.disk_cache.clone();
     let storage = manifest.options.storage.clone();
     let empty_superseded = BTreeMap::new();
     let superseded = manifest.get_superseded_cells().unwrap_or(&empty_superseded);
     let mut codes: Vec<u8> = Vec::new();
+    let mut fp32: Vec<f32> = Vec::new();
+    let mut scratch = vec![0.0f32; dim];
     let mut gi: usize = 0;
     for entry in manifest.get_all_superfiles() {
         let reader =
@@ -2750,12 +2816,21 @@ async fn collect_hnsw_codes(
                 None => true,
             };
             if keep {
-                codes.extend_from_slice(&row.encoded.codes);
+                if metric_aware {
+                    decode_adaptive_row_into(&row.encoded, &mut scratch);
+                    fp32.extend_from_slice(&scratch);
+                } else {
+                    codes.extend_from_slice(&row.encoded.codes);
+                }
             }
             gi += 1;
         }
     }
-    Ok(codes)
+    Ok(if metric_aware {
+        GatheredPlane::Fp32(fp32)
+    } else {
+        GatheredPlane::Codes(codes)
+    })
 }
 
 /// Cheap metadata-only row count for `column` across all superfiles, excluding
@@ -2821,6 +2896,18 @@ pub(crate) enum IndexUnavailable {
     CodecUnsupported { column: String, codec: &'static str },
     /// The column's metric is not the one these scorers rank under.
     MetricUnsupported { column: String, metric: Metric },
+    /// The resident graph was built for a different metric than the column now
+    /// declares (a metric change, or a pre-metric-aware cosine graph on a column
+    /// since re-declared) — serve ivf until the next drain rebuilds it.
+    MetricMismatch {
+        column: String,
+        built: Metric,
+        declared: Metric,
+    },
+    /// Incremental extend of a fitted-ruler (non-cosine) graph is not yet
+    /// supported — the caller does a full rebuild, which refits the global ruler
+    /// over the whole corpus. (Extend inheriting the prior ruler is a follow-up.)
+    IncrementalMetricUnsupported { column: String, metric: Metric },
     /// No rows materialized for the column.
     NoRows { column: String },
     /// The corpus is past the index's document ceiling.
@@ -2873,6 +2960,20 @@ impl std::fmt::Display for IndexUnavailable {
                 f,
                 "column `{column}` uses metric {metric:?}; the resident scorers rank \
                  by inner product, which orders neighbours correctly only under Cosine"
+            ),
+            IndexUnavailable::MetricMismatch {
+                column,
+                built,
+                declared,
+            } => write!(
+                f,
+                "the resident graph for `{column}` was built for metric {built:?}, but \
+                 the column now declares {declared:?}"
+            ),
+            IndexUnavailable::IncrementalMetricUnsupported { column, metric } => write!(
+                f,
+                "column `{column}` uses metric {metric:?}; incremental extend of a \
+                 fitted-ruler graph is not yet supported — rebuilding in full"
             ),
             IndexUnavailable::NoRows { column } => {
                 write!(f, "no rows materialized for column `{column}`")
@@ -3060,8 +3161,14 @@ async fn gather_sq16_rows(
     op_stats: &Option<Arc<OpStatsCollector>>,
     n: usize,
     probe_step: Option<usize>,
-) -> Result<Option<(Vec<i128>, Vec<u8>)>, QueryError> {
+    metric: Metric,
+) -> Result<Option<(Vec<i128>, GatheredPlane)>, QueryError> {
     let stride = dim * 2;
+    // A fitted-ruler metric (Sq16Adaptive) carries per-cluster codes, so the raw
+    // bytes are meaningless as one plane; decode each row to fp32 through its own
+    // ruler and refit onto a single global ruler in the caller. Cosine's fixed
+    // grid is one ruler already, so its codes ride verbatim.
+    let metric_aware = metric != Metric::Cosine;
     let store = Arc::clone(&manifest.options.store);
     let disk_cache = manifest.options.disk_cache.clone();
     let storage = manifest.options.storage.clone();
@@ -3070,6 +3177,8 @@ async fn gather_sq16_rows(
 
     let mut doc_ids: Vec<i128> = Vec::with_capacity(n);
     let mut carried_codes: Vec<u8> = Vec::new();
+    let mut carried_fp32: Vec<f32> = Vec::new();
+    let mut scratch = vec![0.0f32; dim];
     let mut gi: usize = 0;
     for entry in manifest.get_all_superfiles() {
         let reader =
@@ -3099,12 +3208,17 @@ async fn gather_sq16_rows(
                 ))
             })?;
             doc_ids.push(stable_id);
-            match probe_step {
-                Some(step) if gi.is_multiple_of(step) => {
+            let keep = match probe_step {
+                Some(step) => gi.is_multiple_of(step),
+                None => true,
+            };
+            if keep {
+                if metric_aware {
+                    decode_adaptive_row_into(&row.encoded, &mut scratch);
+                    carried_fp32.extend_from_slice(&scratch);
+                } else {
                     carried_codes.extend_from_slice(&row.encoded.codes);
                 }
-                Some(_) => {}
-                None => carried_codes.extend_from_slice(&row.encoded.codes),
             }
             gi += 1;
         }
@@ -3120,7 +3234,12 @@ async fn gather_sq16_rows(
     if doc_ids.is_empty() {
         return Ok(None);
     }
-    Ok(Some((doc_ids, carried_codes)))
+    let plane = if metric_aware {
+        GatheredPlane::Fp32(carried_fp32)
+    } else {
+        GatheredPlane::Codes(carried_codes)
+    };
+    Ok(Some((doc_ids, plane)))
 }
 
 /// Build and encode the flat 4-bit index for `column` — the drain path for
@@ -3193,14 +3312,17 @@ pub(crate) async fn assemble_flat_sections(
     // of a graph build - the calibration sweep - does not exist here; the fit
     // is one pass, and the gate below runs against the real plane rather than
     // a subsample whose recall would be optimistic.
-    let Some((doc_ids, sq16_codes)) =
-        gather_sq16_rows(manifest, column, dim, op_stats, n, None).await?
+    // The flat arm is metric-gated to cosine above, so the gather always yields
+    // the raw fixed-grid Sq16 codes this build fits from.
+    let Some((doc_ids, plane)) =
+        gather_sq16_rows(manifest, column, dim, op_stats, n, None, Metric::Cosine).await?
     else {
         return Ok(IndexOutcome::Unavailable(IndexUnavailable::GatherEmpty {
             column: column.to_string(),
             pre_count: n,
         }));
     };
+    let sq16_codes = plane.expect_codes();
     // The bare 4-bit plane, always. The 1.0 B/dim residual rung was carved out
     // pending a matched-bytes comparison against a single 8-bit plane — the
     // Sq16-vs-Sq8Residual theorem says a uniform plane beats coarse+residual
@@ -3277,7 +3399,20 @@ pub(crate) async fn assemble_hnsw_sections(
                 .collect(),
         }));
     };
-    if !vc.rerank_codec.is_sq16() {
+    let metric = vc.metric;
+    // The graph serves the fixed cosine grid (`Sq16`) and, via one fitted global
+    // ruler, the per-cluster `Sq16Adaptive` plane that L2Sq/NegDot columns store.
+    // Cosine keeps the fixed grid; every other metric requires the fitted-ruler
+    // single-u16 codec (a fixed-grid `Sq16` carries no per-cluster ruler to
+    // decode its rows through, and its `[-1, 1]` grid is cosine-only anyway).
+    // (The flat arm and centroid router stay cosine-only via `metric_supported`
+    // — this arm's own scorer is metric-aware, so it does not gate on it.)
+    let codec_ok = if metric == Metric::Cosine {
+        vc.rerank_codec.is_sq16()
+    } else {
+        vc.rerank_codec.writes_single_u16_plane() && vc.rerank_codec.fits_per_cluster_ruler()
+    };
+    if !codec_ok {
         return Ok(IndexOutcome::Unavailable(
             IndexUnavailable::CodecUnsupported {
                 column: column.to_string(),
@@ -3285,11 +3420,7 @@ pub(crate) async fn assemble_hnsw_sections(
             },
         ));
     }
-    if let Some(reason) = metric_supported(manifest, column) {
-        return Ok(IndexOutcome::Unavailable(reason));
-    }
     let dim = vc.dim;
-    let stride = dim * 2;
 
     // Gather the stable doc-ids (cheap: 16 B/row) and the row count first. The
     // Sq16 code plane itself (dim*2 B/row — GBs at scale) is gathered LATER: a
@@ -3335,8 +3466,8 @@ pub(crate) async fn assemble_hnsw_sections(
     // the sample is ~probe_cap rows. `None` = small corpus, no probe.
     let probe_step: Option<usize> = (n > probe_cap).then(|| (n / probe_cap).max(1));
 
-    let Some((doc_ids, mut carried_codes)) =
-        gather_sq16_rows(manifest, column, dim, op_stats, n, probe_step).await?
+    let Some((doc_ids, mut carried_plane)) =
+        gather_sq16_rows(manifest, column, dim, op_stats, n, probe_step, metric).await?
     else {
         return Ok(IndexOutcome::Unavailable(IndexUnavailable::GatherEmpty {
             column: column.to_string(),
@@ -3346,10 +3477,12 @@ pub(crate) async fn assemble_hnsw_sections(
 
     if probe_step.is_some() {
         // Reuse the strided sample gathered in the merged pass above — no second
-        // decode. (Byte-identical to the prior `collect_hnsw_codes(Some(step))`.)
-        let pcodes = std::mem::take(&mut carried_codes);
-        let pn = pcodes.len() / stride;
-        let pscorer = Sq16Scorer::from_codes(pcodes, dim, pn);
+        // decode. For a fitted-ruler metric the sample fits its OWN ruler (the
+        // probe only sizes `m0` against scale, so a sample ruler is fine here);
+        // the full-corpus pass below fits the authoritative one.
+        let psample = std::mem::take(&mut carried_plane);
+        let pn = psample.rows(dim);
+        let pscorer = psample.into_scorer(dim, pn, metric);
         // The calibrate build is pure CPU; run it on the reader pool (not the
         // global rayon pool, and not inline on the tokio worker) per the
         // concurrency contract. The candidate grids are tiny, so clone them
@@ -3422,10 +3555,10 @@ pub(crate) async fn assemble_hnsw_sections(
     // above (no probe was taken from `carried_codes`); the probe path re-reads
     // the plane here, having kept it out of RAM through the probe to bound peak
     // memory at scale.
-    let codes = if probe_step.is_none() {
-        std::mem::take(&mut carried_codes)
+    let full_plane = if probe_step.is_none() {
+        std::mem::take(&mut carried_plane)
     } else {
-        collect_hnsw_codes(manifest, column, stride, None).await?
+        collect_hnsw_plane(manifest, column, dim, None, metric).await?
     };
     // Size the scorer from the DECODED plane, not the metadata pre-count `n`
     // (which only sizes the probe step). The decode can skip a superfile the
@@ -3435,7 +3568,7 @@ pub(crate) async fn assemble_hnsw_sections(
     // plane and the doc-id pass disagree, a transient fault desynced the two
     // reads and a graph built now would mismap nodes to ids: skip it and serve
     // ivf; the next drain rebuilds.
-    let decoded_rows = codes.len() / stride;
+    let decoded_rows = full_plane.rows(dim);
     if decoded_rows != doc_ids.len() {
         tracing::warn!(
             column,
@@ -3450,7 +3583,10 @@ pub(crate) async fn assemble_hnsw_sections(
             },
         ));
     }
-    let scorer = Sq16Scorer::from_codes(codes, dim, decoded_rows);
+    // For a fitted-ruler metric this fits the authoritative global ruler over
+    // the full corpus and re-encodes the single-u16 plane; cosine adopts the raw
+    // codes verbatim.
+    let scorer = full_plane.into_scorer(dim, decoded_rows, metric);
     // Calibrate (m0, ef) to the table's recall bar on the FULL corpus (build
     // once at m0_max, prune down, sweep ef by re-search — free). The m0
     // requirement is scale-dependent, so this full-corpus pass is authoritative
@@ -3474,7 +3610,21 @@ pub(crate) async fn assemble_hnsw_sections(
         vcfg.hnsw_register_floor,
         vcfg.hnsw_ef_construction,
     );
-    let walk = hnsw::WalkCodec::from_config(vcfg.hnsw_plane);
+    let mut walk = hnsw::WalkCodec::from_config(vcfg.hnsw_plane);
+    // The SQ8 / 4-bit walk planes are code-space proxies fitted to the uniform
+    // fixed cosine grid; they do not carry the per-dim fitted ruler, so on a
+    // metric-aware plane their navigation is wrong. Walk the metric-aware Sq16
+    // plane directly for non-cosine columns (the refine is Sq16 regardless, so
+    // only per-candidate walk cost changes, never the order returned). A
+    // ruler-aware coarse walk is a follow-up.
+    if metric != Metric::Cosine && walk != hnsw::WalkCodec::Sq16 {
+        tracing::debug!(
+            column,
+            ?walk,
+            "hnsw: non-cosine column walks the ruler-aware Sq16 plane (coarse walk planes are not ruler-aware yet)"
+        );
+        walk = hnsw::WalkCodec::Sq16;
+    }
     let n_rows = doc_ids.len();
     let (scorer, sq4, choice, ef_curve, graph) = run_on_pool(
         Some(&manifest.options.reader_pool),
@@ -3573,6 +3723,9 @@ pub(crate) async fn assemble_hnsw_sections(
         column,
         walk,
         sq4.as_ref(),
+        scorer.metric(),
+        scorer.ruler(),
+        scorer.node_norms(),
     )))
 }
 
@@ -3613,7 +3766,13 @@ pub(crate) async fn assemble_hnsw_incremental(
         }));
     };
     let dim = prior.dim;
-    if !vc.rerank_codec.is_sq16() {
+    let metric = vc.metric;
+    let codec_ok = if metric == Metric::Cosine {
+        vc.rerank_codec.is_sq16()
+    } else {
+        vc.rerank_codec.writes_single_u16_plane() && vc.rerank_codec.fits_per_cluster_ruler()
+    };
+    if !codec_ok {
         return Ok(IndexOutcome::Unavailable(
             IndexUnavailable::CodecUnsupported {
                 column: column.to_string(),
@@ -3626,6 +3785,18 @@ pub(crate) async fn assemble_hnsw_incremental(
             queried: vc.dim,
             index: dim,
         }));
+    }
+    // A fitted-ruler (non-cosine) delta must re-encode onto the prior global
+    // ruler, and the recall re-check below grades on the fixed grid — neither is
+    // wired yet. Decline to a full rebuild, which refits the ruler over the whole
+    // corpus and is correct; the cosine incremental path is unchanged.
+    if metric != Metric::Cosine {
+        return Ok(IndexOutcome::Unavailable(
+            IndexUnavailable::IncrementalMetricUnsupported {
+                column: column.to_string(),
+                metric,
+            },
+        ));
     }
     let stride = dim * 2;
     let store = Arc::clone(&manifest.options.store);
@@ -3912,6 +4083,9 @@ pub(crate) async fn assemble_hnsw_incremental(
             column,
             inherited_walk,
             sq4.as_ref(),
+            scorer.metric(),
+            scorer.ruler(),
+            scorer.node_norms(),
         ),
         new_high_water,
         inserted,
@@ -4089,11 +4263,21 @@ impl SupertableReader {
         if data.doc_ids.is_empty() {
             return Ok(IndexOutcome::Unavailable(IndexUnavailable::IndexEmpty));
         }
-        // A graph published before the build-side metric gate existed can still
-        // be resident, and it ranks by inner product regardless of what the
-        // column's metric says.
-        if let Some(reason) = metric_supported(self.manifest(), column) {
-            return Ok(IndexOutcome::Unavailable(reason));
+        // Reject a graph built for a different metric than the column now
+        // declares — a metric change, or a pre-metric-aware cosine graph on a
+        // column since re-declared — rather than serve the wrong geometry at the
+        // right latency. The resident scorer knows which metric it serves (the
+        // fixed grid serves Cosine; a fitted ruler serves its own metric).
+        let served = data.scorer.served_metric();
+        let declared = column_metric(&self.manifest().options.vector_columns, column);
+        if declared != Some(served) {
+            return Ok(IndexOutcome::Unavailable(
+                IndexUnavailable::MetricMismatch {
+                    column: column.to_string(),
+                    built: served,
+                    declared: declared.unwrap_or(served),
+                },
+            ));
         }
         let k_fetch = replica_fetch_width(k);
         // The calibrated per-`k` beam from the stamped k→ef curve drives the
@@ -4142,7 +4326,18 @@ impl SupertableReader {
                 // monomorphized walk. A coarse plane re-ranks its beam on Sq16
                 // (`refine_k`), so the plane changes which candidates are
                 // considered, never the order returned.
-                let walked = if let Some(sq4) = &data.sq4 {
+                //
+                // A fitted-ruler (non-cosine) graph MUST walk the metric-aware
+                // Sq16 plane directly: the SQ8 / 4-bit walk planes are code-space
+                // `−dot` proxies that assume the UNIFORM fixed cosine grid (one
+                // scale/offset for every dim), so on a per-dim ruler their
+                // navigation is meaningless and the beam that reaches the refine
+                // is wrong. (`decode_hnsw` may still have derived an SQ8 plane
+                // because the running `hnsw_plane` config asked for it; ignore it
+                // here rather than mis-navigate.)
+                let walked = if served != Metric::Cosine {
+                    data.graph.search(&data.scorer, &query_owned, k_fetch, ef)
+                } else if let Some(sq4) = &data.sq4 {
                     data.search_walk_refine(sq4, &query_owned, k_fetch, ef, refine_k)
                 } else if !data.sq8_plane.is_empty() {
                     data.search_sq8_refine(&query_owned, k_fetch, ef, refine_k)
@@ -4152,15 +4347,21 @@ impl SupertableReader {
                 walked
                     .into_iter()
                     .filter_map(|(node, dist)| {
-                        // Shift the graph's `−dot` onto the ivf/scan arm's
-                        // `1 − dot` cosine scale so the cross-arm merge
-                        // (top_k_ascending) compares like with like. Monotonic
-                        // in `dist`, so intra-arm order is unchanged; the public
-                        // `score` column stays non-negative.
+                        // Publish the metric's own distance so the cross-arm
+                        // merge (top_k_ascending) compares like with like: the
+                        // cosine grid walks `−dot` and shifts onto the scan arm's
+                        // `1 − dot` scale (monotonic, non-negative), while L2Sq /
+                        // NegDot already score the exact distance the scan emits
+                        // (squared distance, `−dot`) and pass it straight through.
+                        let score = if served == Metric::Cosine {
+                            1.0 + dist
+                        } else {
+                            dist
+                        };
                         Some(SuperfileHit {
                             superfile: SuperfileUri(Uuid::nil()),
                             local_doc_id: 0,
-                            score: 1.0 + dist,
+                            score,
                             stable_id: Some(*data.doc_ids.get(node as usize)?),
                         })
                     })
@@ -11344,6 +11545,32 @@ mod tests {
         options_one_col_sq16_metric(dim, Metric::Cosine)
     }
 
+    /// A one-column table under a non-cosine metric, whose rerank codec is the
+    /// per-cluster-fitted `Sq16Adaptive` the engine picks for L2Sq/NegDot (the
+    /// fixed-grid `Sq16` is cosine-only and config validation rejects it here).
+    fn options_one_col_adaptive_metric(dim: usize, metric: Metric) -> SupertableOptions {
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        SupertableOptions::new(
+            schema_with_vector(dim),
+            vec![FtsConfig::new("title")],
+            vec![VectorConfig {
+                column: "emb".into(),
+                dim,
+                rot_seed: 7,
+                metric,
+                rerank_codec: RerankCodec::Sq16Adaptive,
+                provided_centroids: None,
+            }],
+        )
+        .expect("valid options")
+        .with_writer_pool(pool)
+    }
+
     fn options_one_col_sq16_metric(dim: usize, metric: Metric) -> SupertableOptions {
         let pool = Arc::new(
             rayon::ThreadPoolBuilder::new()
@@ -11412,6 +11639,129 @@ mod tests {
             hits[0].score < 0.05,
             "an exact match is distance ~0 on the cosine scale, got {}",
             hits[0].score
+        );
+    }
+
+    /// A drained L2Sq table (rerank codec `Sq16Adaptive`) with a GRAPH published
+    /// and stamped — the l2sq peer of [`drained_graph_fixture`], used to pin that
+    /// `hnsw_ivf` now serves the resident graph for non-cosine metrics instead of
+    /// declining every one to the ivf scan.
+    fn drained_l2sq_graph_fixture() -> (Supertable, TempDir, Arc<Supertable>) {
+        let schema = schema_with_vector(GRAPH_FIXTURE_DIM);
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("storage"));
+        let opts =
+            options_one_col_adaptive_metric(GRAPH_FIXTURE_DIM, Metric::L2Sq).with_storage(storage);
+        let st = Supertable::create(opts).expect("create");
+        let mut w = st.writer().expect("writer");
+        w.append(&build_vector_batch(
+            0,
+            GRAPH_FIXTURE_ROWS,
+            GRAPH_FIXTURE_DIM,
+            schema,
+        ))
+        .expect("append");
+        w.commit().expect("commit");
+        drop(w);
+        st.drain_vectors_to_cells_sync().expect("drain");
+
+        let hidden = hidden_index_of(&st);
+        let reader = hidden.reader().expect("hidden reader");
+        let manifest = reader.manifest();
+        // The build fix: an L2Sq column no longer declines the graph at the codec
+        // gate (`Sq16Adaptive` is not `is_sq16`) or the cosine-only metric gate —
+        // before it, this `expect_ready` panicked with `CodecUnsupported`.
+        let graph = expect_ready(
+            block_on(assemble_hnsw_sections(manifest, "emb", &None)).expect("assemble ok"),
+            "a drained L2Sq corpus",
+        );
+        // The metric-aware plane is stamped in the v06 bundle.
+        use crate::superfile::vector::hnsw::{HNSW_DATA_MAGIC_LEN, HNSW_DATA_MAGIC_V6};
+        assert_eq!(
+            &graph[..HNSW_DATA_MAGIC_LEN],
+            HNSW_DATA_MAGIC_V6,
+            "a fitted-ruler (non-cosine) graph stamps the v06 metric-aware magic"
+        );
+        let storage = manifest.options.storage.clone().expect("storage");
+        let blob = encode_resident_envelope(0, 0, &[], Some((PayloadKind::Graph, &graph)));
+        let reference =
+            block_on(write_resident_index_blob(storage.as_ref(), blob)).expect("publish");
+        let stamped = manifest.with_slow_vector_state_graphs(Some(reference));
+        drop(reader);
+        hidden.inner().manifest.store(Arc::new(stamped));
+        (st, dir, hidden)
+    }
+
+    /// The metric-aware graph fix (infino-ai/infino#757): under `hnsw_ivf` an
+    /// L2Sq column now BUILDS and SERVES the resident graph, where before the
+    /// build declined it (the `Sq16Adaptive` codec fails `is_sq16`, and the
+    /// serve/build metric gate was cosine-only) and every query fell back to the
+    /// ivf scan. The regression is twofold: the graph must answer, and it must
+    /// answer on the L2Sq distance scale (squared distance, ~0 for an exact
+    /// match) rather than the cosine `1 − dot` the old publish shifted onto.
+    #[test]
+    fn hnsw_ivf_serves_the_graph_for_l2sq() {
+        let (_st, _dir, hidden) = drained_l2sq_graph_fixture();
+        let served = hidden.reader().expect("hidden reader after publish");
+
+        // The resident graph is metric-aware: it serves the column's own L2Sq,
+        // not the fixed-grid cosine every pre-fix graph carried.
+        let resident = block_on(served.resident_vector_index()).expect("the ref must hydrate");
+        let data = resident
+            .data
+            .as_ref()
+            .and_then(ResidentIndexKind::graph)
+            .expect("the fixture publishes a decodable graph");
+        assert_eq!(
+            data.scorer.served_metric(),
+            Metric::L2Sq,
+            "the resident graph must serve the column's L2Sq metric"
+        );
+        // A fitted-ruler graph must carry NO coarse walk plane: the SQ8 / 4-bit
+        // walks are code-space `−dot` proxies for the uniform cosine grid and
+        // mis-navigate a per-dim ruler, so decode derives none and the serve
+        // path walks the metric-aware Sq16 plane directly. Before this, decode
+        // derived an SQ8 plane (config default `hnsw_plane = sq8`) and the walk
+        // returned near-random neighbours (recall collapsed to ~0 at scale).
+        assert!(
+            data.sq8_plane.is_empty() && data.sq4.is_none(),
+            "a metric-aware graph must serve the Sq16 walk, not a coarse proxy plane"
+        );
+
+        // An exact one-hot match (direction 5) is L2Sq distance ~0. Before the
+        // fix, hnsw_search declined L2Sq outright and this was `Unavailable`.
+        let mut q = vec![0.0f32; GRAPH_FIXTURE_DIM];
+        q[5] = 1.0;
+        let hits = expect_ready(
+            block_on(served.hnsw_search("emb", &q, 5, None)).expect("hnsw search"),
+            "the published L2Sq graph",
+        );
+        assert!(!hits.is_empty(), "the graph must answer its own generation");
+        assert!(
+            hits.windows(2).all(|w| w[0].score <= w[1].score),
+            "hits must be ascending by distance"
+        );
+        assert!(
+            hits[0].score < 0.05,
+            "an exact match is L2Sq distance ~0, got {}",
+            hits[0].score
+        );
+
+        // L2Sq scale, not the cosine `1 − dot`: scaling the query to magnitude 2
+        // leaves the nearest one-hot row PARALLEL (cosine distance 0) but at L2Sq
+        // distance ‖2·e5 − e5‖² = 1. A score near 1 proves the graph publishes the
+        // metric's own distance; the pre-fix cosine shift would report ~0.
+        let q2: Vec<f32> = q.iter().map(|x| x * 2.0).collect();
+        let hits2 = expect_ready(
+            block_on(served.hnsw_search("emb", &q2, 5, None)).expect("hnsw search x2"),
+            "the published L2Sq graph",
+        );
+        assert!(
+            (hits2[0].score - 1.0).abs() < 0.1,
+            "a magnitude-2 query is L2Sq distance ~1 from a parallel unit row \
+             (cosine would report ~0), got {}",
+            hits2[0].score
         );
     }
 
@@ -11676,11 +12026,15 @@ mod tests {
             other => panic!("expected CodecUnsupported, got {}", describe(other)),
         }
 
-        // A non-cosine column. Both resident index types rank by `-dot`, which
-        // is the column's own ordering only under Cosine — and the register
-        // gate cannot catch it, because `probe_recall` grades a `-dot` scan
-        // against a `-dot` exhaustive scan and so measures a mis-metriced
-        // index as perfect. Declined at build, for BOTH arms.
+        // A non-cosine column stored under the fixed-grid `Sq16` codec. The
+        // FLAT arm is cosine-only: it ranks by `-dot` mapped onto `1 - dot`,
+        // which is the column's own ordering only under Cosine, so it declines
+        // as MetricUnsupported. The HNSW arm is metric-aware, but a fitted-ruler
+        // graph needs the fitted-ruler codec — the fixed `[-1, 1]` grid carries
+        // no per-cluster ruler to decode these rows through — so it declines the
+        // fixed-grid codec as CodecUnsupported (a real L2Sq table stores the
+        // `Sq16Adaptive` codec and builds the graph; see
+        // `hnsw_ivf_serves_the_graph_for_l2sq`).
         for metric in [Metric::L2Sq, Metric::NegDot] {
             let metric_dir = TempDir::new().expect("tempdir");
             let metric_storage: Arc<dyn StorageProvider> =
@@ -11690,29 +12044,29 @@ mod tests {
             )
             .expect("create non-cosine table");
             let reader = table.reader().expect("reader");
-            for (arm, outcome) in [
-                (
-                    "flat",
-                    block_on(assemble_flat_sections(reader.manifest(), "emb", &None)),
-                ),
-                (
-                    "hnsw",
-                    block_on(assemble_hnsw_sections(reader.manifest(), "emb", &None)),
-                ),
-            ] {
-                match outcome.expect("ok") {
-                    IndexOutcome::Unavailable(IndexUnavailable::MetricUnsupported {
-                        column,
-                        metric: named,
-                    }) => {
-                        assert_eq!(column, "emb");
-                        assert_eq!(named, metric);
-                    }
-                    other => panic!(
-                        "the {arm} arm must decline {metric:?} as MetricUnsupported, got {}",
-                        describe(other)
-                    ),
+            match block_on(assemble_flat_sections(reader.manifest(), "emb", &None)).expect("ok") {
+                IndexOutcome::Unavailable(IndexUnavailable::MetricUnsupported {
+                    column,
+                    metric: named,
+                }) => {
+                    assert_eq!(column, "emb");
+                    assert_eq!(named, metric);
                 }
+                other => panic!(
+                    "the flat arm must decline {metric:?} as MetricUnsupported, got {}",
+                    describe(other)
+                ),
+            }
+            match block_on(assemble_hnsw_sections(reader.manifest(), "emb", &None)).expect("ok") {
+                IndexOutcome::Unavailable(IndexUnavailable::CodecUnsupported { column, codec }) => {
+                    assert_eq!(column, "emb");
+                    assert_eq!(codec, RerankCodec::Sq16.name());
+                }
+                other => panic!(
+                    "the hnsw arm must decline the fixed-grid codec under {metric:?} as \
+                     CodecUnsupported, got {}",
+                    describe(other)
+                ),
             }
         }
 


### PR DESCRIPTION
## Summary

Under `search_mode = hnsw_ivf` the resident HNSW graph was built and served only for **cosine** columns. `l2sq` and `negdot` columns were declined up front — the fitted-ruler `Sq16Adaptive` codec they store fails the graph's `is_sq16` gate, and both the build and serve paths carried a cosine-only metric gate — so every query on those metrics silently fell back to the IVF scan and got its latency/throughput, never the graph's.

This makes the graph metric-aware end to end. It closes #757.

## What changes

The single resident scorer now carries the column `Metric` and, for non-cosine, a fitted GLOBAL `(scale, offset)` ruler plus per-node `‖x̂‖²`, scored through the existing adaptive `Sq16Kernel`. The fixed `[-1, 1]` cosine grid stays the default (no ruler, scored `−dot`) and is byte-for-byte unchanged.

- **Build.** A non-cosine column decodes its per-cluster `Sq16Adaptive` rows to fp32 at drain (the same transient transcode the IVF merge already performs — no fp32 in the served path), fits ONE global ruler over the whole graph, re-encodes to a single-`u16` plane, and computes the norm table. The codec gate is relaxed to the fitted-ruler single-`u16` codec for non-cosine; the cosine-only `metric_supported` gate stays in place for the flat-IVF arm and the centroid router (out of scope here).
- **Calibration.** Calibration queries are synthesized in the plane's own geometry — decoded through the ruler, normalized only for cosine, with the off-node jitter scaled to the vector's magnitude for non-cosine so recall is not falsely optimistic.
- **Walk / refine.** The graph keeps its SQ8-walk / Sq16-refine shape for cosine. A fitted-ruler graph walks the metric-aware Sq16 plane directly: the SQ8 / 4-bit walk planes are code-space `−dot` proxies that assume the uniform fixed grid (one scale/offset for every dim), so on a per-dim ruler they mis-navigate — decode derives none and the serve path skips them. (A ruler-aware coarse walk is a follow-up.)
- **Serve.** The serve path rejects a graph built for a different metric than the column now declares, and publishes the metric's own distance (cosine `1 − dot`, `l2sq` squared distance, `negdot` `−dot`) so a cross-generation merge compares like with like.
- **Persistence.** A new bundle version stamps the metric, the ruler, and (l2sq) the per-node norm table after the existing sections. Cosine keeps writing the current version, so existing cosine bundles and `public-api.txt` are untouched.
- **Extend.** Incremental extend of a fitted-ruler graph is not yet wired, so a non-cosine drain rebuilds in full (correct, just not incremental); a ruler-inheriting extend is a follow-up.

## Validation (gist-960-euclidean, l2sq, 1M × 960)

Before, an `l2sq` table showed the signature of no graph being walked — **flat recall and flat rps across every `ef`**. After, recall rises monotonically with `ef` and the served latency is the graph's:

| ef | recall@10 | rps | p95 (ms) |
|----:|----:|----:|----:|
| 128 | 0.8319 | 3752 | 2.44 |
| 256 | 0.9183 | 2487 | 4.12 |
| 512 | 0.9645 | 1519 | 7.19 |
| 1024 | 0.9860 | 944 | 12.4 |
| 1536 | 0.9920 | 726 | 16.0 |
| 2048 | 0.9944 | 431 | 19.7 |

The broken baseline served the IVF scan: recall flat at 0.9872 across every `ef`, ~410 rps. The graph now clears the recall@10 ≥ 0.99 bar and is walked (thousands of rps at low `ef`). Cosine columns (including 1536-dim) are unchanged.

## Testing

- New regression tests: an `l2sq` table whose `hnsw_ivf` recall rises with `ef` (and which carries no coarse walk plane, so it walks the metric-aware Sq16 plane), and a metric-aware bundle round-trip covering `l2sq` (norm table) and `negdot`. Both fail before and pass after.
- The obsolete "hnsw declines non-cosine" assertion was updated: the hnsw arm now declines only the fixed-grid codec under a non-cosine metric (`CodecUnsupported`), while the flat arm keeps its cosine-only decline.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the full library test suite pass locally; cosine behavior is byte-for-byte unchanged.

## CI note (second commit)

A second, self-contained commit adds `.config/nextest.toml` with `[profile.default] retries = 2`. It is unrelated to the vector change and can be split out, but it rides here because it unblocks this PR's own coverage job: the `Tests & coverage` gate recently moved to `cargo llvm-cov nextest` (process-per-test parallelism) with no nextest config, so transient cross-process contention on shared FS/storage resources — a different test each run, all in disk-cache / concurrent-writer code untouched here — was failing the whole coverage run non-deterministically. The retries report such a transient as flaky rather than failing the run; a test that fails every attempt still fails. No `test-groups` serialization for now.
