### PR TITLE
chore: add split check logic in optimizer

### DIFF
--- a/src/supertable/gc/mod.rs
+++ b/src/supertable/gc/mod.rs
@@ -430,6 +430,7 @@ mod tests {
             Some(Manifest {
                 tombstone_seqs: Default::default(),
                 superseded_cells: Default::default(),
+                split_checks: Default::default(),
                 format_version: FORMAT_VERSION.into(),
                 manifest_id: TEST_MANIFEST_ID,
                 options_hash: ContentHash::of(b"options"),
@@ -503,6 +504,7 @@ mod tests {
             Some(Manifest {
                 tombstone_seqs: Default::default(),
                 superseded_cells: Default::default(),
+                split_checks: Default::default(),
                 format_version: FORMAT_VERSION.into(),
                 manifest_id: TEST_MANIFEST_ID,
                 options_hash: ContentHash::of(b"options"),
@@ -571,6 +573,7 @@ mod tests {
             Some(Manifest {
                 tombstone_seqs: Default::default(),
                 superseded_cells: Default::default(),
+                split_checks: Default::default(),
                 format_version: FORMAT_VERSION.into(),
                 manifest_id: TEST_MANIFEST_ID,
                 options_hash: ContentHash::of(b"options"),

--- a/src/supertable/handle.rs
+++ b/src/supertable/handle.rs
@@ -6124,6 +6124,7 @@ mod tests {
             drained_ranges: None,
             global_vector_index: None,
             superseded_cells_additions: None,
+            split_checks_additions: None,
             graph_ref: None,
         };
         let no_removals = Vec::new();
@@ -6323,6 +6324,7 @@ mod tests {
             drained_ranges: None,
             global_vector_index: None,
             superseded_cells_additions: None,
+            split_checks_additions: None,
             graph_ref: None,
         };
         let no_removals = Vec::new();
@@ -6399,6 +6401,7 @@ mod tests {
             drained_ranges: None,
             global_vector_index: None,
             superseded_cells_additions: None,
+            split_checks_additions: None,
             graph_ref: None,
         };
         let zero_manifest = hidden
@@ -6600,6 +6603,7 @@ mod tests {
             drained_ranges: None,
             global_vector_index: None,
             superseded_cells_additions: None,
+            split_checks_additions: None,
             graph_ref: None,
         };
         let no_removals = Vec::new();
@@ -6965,6 +6969,125 @@ mod tests {
             }
             other => panic!("hidden stays VectorCell after optimize, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn optimize_memoizes_a_whole_cell_and_skips_re_checking_it() {
+        // A single unimodal blob big enough to reach the modality trigger but
+        // NOT multimodal: `optimize` downloads and checks it once, leaves it
+        // whole, and records the verdict. A second `optimize` finds the cell's
+        // contents unchanged and must not re-record it.
+        const DIM: usize = 16;
+        const N: usize = (MODALITY_MIN_CELL_DOCS as usize) + 32;
+
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("title", DataType::LargeUtf8, false),
+            Field::new(
+                "emb",
+                DataType::FixedSizeList(item_field.clone(), DIM as i32),
+                false,
+            ),
+        ]));
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("pool"),
+        );
+        let dir = TempDir::new().expect("tempdir");
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(LocalFsStorageProvider::new(dir.path()).expect("provider"));
+        let options = SupertableOptions::new(
+            schema.clone(),
+            vec![FtsConfig::new("title")],
+            vec![VectorConfig {
+                column: "emb".into(),
+                dim: DIM,
+                rot_seed: 7,
+                metric: Metric::Cosine,
+                rerank_codec: RerankCodec::Sq8Residual,
+                provided_centroids: None,
+            }],
+        )
+        .expect("valid options")
+        .with_storage(storage)
+        .with_writer_pool(pool)
+        .with_vector_cell_counts(1, 1);
+        let st = Supertable::create(options).expect("create");
+
+        let titles = LargeStringArray::from((0..N).map(|i| format!("doc-{i}")).collect::<Vec<_>>());
+        // One tight blob around e_0 with tiny per-row jitter — unimodal, so the
+        // shape check leaves the cell whole.
+        let mut flat = vec![0.0f32; N * DIM];
+        for r in 0..N {
+            flat[r * DIM] = 1.0;
+            flat[r * DIM + 1] = ((r % 7) as f32 - 3.0) * 1e-3;
+        }
+        let fsl = FixedSizeListArray::new(
+            item_field,
+            DIM as i32,
+            Arc::new(Float32Array::from(flat)),
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(titles) as Arc<dyn Array>,
+                Arc::new(fsl) as Arc<dyn Array>,
+            ],
+        )
+        .expect("batch");
+        let mut w = st.writer().expect("writer");
+        w.append(&batch).expect("append");
+        w.commit().expect("commit");
+        st.drain_vectors_to_cells_sync().expect("drain to cells");
+
+        let hidden = st
+            .reader()
+            .expect("reader")
+            .vector_index_table()
+            .expect("hidden index")
+            .clone();
+
+        st.optimize(&OptimizeOptions::default()).expect("optimize");
+
+        // The whole cell stayed whole, and its verdict was recorded.
+        let after_first = hidden.reader().expect("reader");
+        let manifest = after_first.manifest();
+        match manifest.get_partition_strategy() {
+            PartitionStrategy::VectorCell { clusters, .. } => {
+                assert_eq!(clusters.n_cent, 1, "unimodal cell must not split");
+            }
+            other => panic!("hidden stays VectorCell, got {other:?}"),
+        }
+        let checks = manifest
+            .get_split_checks()
+            .expect("hidden manifest has a list")
+            .clone();
+        assert!(
+            checks.contains_key(&0),
+            "the checked whole cell records a verdict, got {checks:?}"
+        );
+        assert_eq!(
+            checks[&0].version,
+            crate::supertable::writer::CELL_SPLIT_CHECK_VERSION,
+            "verdict is stamped with the current check version"
+        );
+
+        // A second optimize sees the same contents: the verdict is unchanged
+        // (the memo hit re-checks nothing).
+        st.optimize(&OptimizeOptions::default()).expect("optimize");
+        let after_second = hidden.reader().expect("reader");
+        assert_eq!(
+            after_second
+                .manifest()
+                .get_split_checks()
+                .expect("list")
+                .get(&0),
+            checks.get(&0),
+            "an unchanged cell keeps its recorded verdict"
+        );
     }
 
     /// The centroid-router graph is cached stamped with the hidden manifest

--- a/src/supertable/manifest/commit.rs
+++ b/src/supertable/manifest/commit.rs
@@ -827,6 +827,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: LIST_FORMAT_VERSION.into(),
             manifest_id: 1,
             options_hash: ContentHash([0u8; 32]),

--- a/src/supertable/manifest/list.rs
+++ b/src/supertable/manifest/list.rs
@@ -213,6 +213,21 @@ pub struct Manifest {
     /// blocks and merge drops them; the entry leaves the manifest when
     /// its superfile is merged away (mirrors [`Self::tombstone_seqs`]).
     pub superseded_cells: BTreeMap<Uuid, BTreeSet<u32>>,
+    /// Per cell, the last split-check verdict and a fingerprint of the
+    /// contents it ran against. Lets maintenance skip re-checking a cell whose
+    /// contents are unchanged. Self-invalidating: a cell's fingerprint moves
+    /// when its superfiles change, and an unknown cell is simply re-checked.
+    pub split_checks: BTreeMap<u32, CellSplitCheck>,
+}
+
+/// A cached split-check result for one cell. `fingerprint` identifies the
+/// contents the check ran on; a mismatch — or a `version` bump when the check
+/// logic changes — re-checks the cell. Only "left whole" verdicts are stored;
+/// a split replaces the cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CellSplitCheck {
+    pub fingerprint: u64,
+    pub version: u32,
 }
 
 /// Content-addressed reference to a sibling object of a manifest
@@ -1330,6 +1345,8 @@ struct ManifestDto {
     parts: Vec<ManifestPartEntryDto>,
     tombstone_seqs: BTreeMap<String, u64>,        // UUID keys
     superseded_cells: BTreeMap<String, Vec<u32>>, // UUID keys
+    #[serde(default)]
+    split_checks: BTreeMap<u32, CellSplitCheck>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -1919,6 +1936,7 @@ fn list_to_dto(l: &Manifest) -> Result<ManifestDto, ListEncodeError> {
             .iter()
             .map(|(id, cells)| (id.to_string(), cells.iter().copied().collect()))
             .collect(),
+        split_checks: l.split_checks.clone(),
     })
 }
 
@@ -2060,6 +2078,7 @@ fn list_from_dto(d: ManifestDto) -> Result<Manifest, ListParseError> {
                     .map_err(|_| ListParseError::BadFieldValue("superseded_cells", id))
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?,
+        split_checks: d.split_checks,
     })
 }
 
@@ -2632,6 +2651,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -2835,6 +2855,44 @@ mod tests {
         let bytes = encode(&list).expect("encode");
         let decoded = decode(&bytes).expect("decode");
         assert_eq!(decoded.superseded_cells, list.superseded_cells);
+    }
+
+    #[test]
+    fn split_checks_roundtrip() {
+        let mut list = empty_list();
+        list.split_checks.insert(
+            3,
+            CellSplitCheck {
+                fingerprint: 0xABCD_1234_5678_9F01,
+                version: 2,
+            },
+        );
+        list.split_checks.insert(
+            7,
+            CellSplitCheck {
+                fingerprint: 1,
+                version: 1,
+            },
+        );
+        let bytes = encode(&list).expect("encode");
+        let decoded = decode(&bytes).expect("decode");
+        assert_eq!(decoded.split_checks, list.split_checks);
+    }
+
+    #[test]
+    fn split_checks_absent_decodes_empty() {
+        // A manifest written before the field existed carries no `split_checks`
+        // key; `#[serde(default)]` must decode it to an empty memo, not fail.
+        let list = empty_list();
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&encode(&list).expect("encode")).expect("parse");
+        value
+            .as_object_mut()
+            .expect("object")
+            .remove("split_checks");
+        let bytes = serde_json::to_vec(&value).expect("reserialize");
+        let decoded = decode(&bytes).expect("decode legacy manifest");
+        assert!(decoded.split_checks.is_empty());
     }
 
     #[test]

--- a/src/supertable/manifest/list_prune.rs
+++ b/src/supertable/manifest/list_prune.rs
@@ -296,6 +296,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: FORMAT_VERSION.into(),
             manifest_id: 1,
             options_hash: ContentHash([0u8; 32]),

--- a/src/supertable/manifest/mod.rs
+++ b/src/supertable/manifest/mod.rs
@@ -466,6 +466,7 @@ impl ManifestSnapshot {
             parts,
             tombstone_seqs,
             superseded_cells,
+            split_checks: BTreeMap::new(),
         }
     }
 
@@ -1529,6 +1530,34 @@ impl ManifestSnapshot {
         }
     }
 
+    /// Overlay `additions` onto the split-check memo, replacing any prior
+    /// verdict for the same cell. In-process-only manifests pass through
+    /// unchanged. See [`list::Manifest::split_checks`].
+    pub fn with_split_checks_added(&self, additions: &BTreeMap<u32, list::CellSplitCheck>) -> Self {
+        let new_list = self.list.as_ref().map(|list| {
+            let mut list = list.clone();
+            list.split_checks
+                .extend(additions.iter().map(|(&c, &v)| (c, v)));
+            list
+        });
+        Self {
+            superfile_list: self.superfile_list.clone(),
+            list: new_list.or_else(|| self.list.clone()),
+            parts: self.parts.clone(),
+            loader: self.loader.clone(),
+            stamped_partition_strategy: self.stamped_partition_strategy.clone(),
+            stamped_global_vector_index: self.stamped_global_vector_index.clone(),
+            stamped_drained_ranges: self.stamped_drained_ranges.clone(),
+        }
+    }
+
+    /// The persisted list's split-check memo: per cell, the verdict of the
+    /// last split check and the content fingerprint it ran against. `None`
+    /// for in-process-only manifests (no persisted list).
+    pub fn get_split_checks(&self) -> Option<&BTreeMap<u32, list::CellSplitCheck>> {
+        self.list.as_ref().map(|l| &l.split_checks)
+    }
+
     /// The persisted list's per-superfile tombstone-seq map. `None`
     /// for in-process-only manifests (no persisted list ⇒ no sidecars
     /// can exist).
@@ -1944,6 +1973,14 @@ impl ManifestSnapshot {
             .map(|list| list.superseded_cells.clone())
             .unwrap_or_default();
         superseded_cells.retain(|id, _| !ids_to_remove.contains(id));
+        // Verdicts carry forward unchanged: each is keyed to a content
+        // fingerprint, so a cell that changed no longer matches and re-checks
+        // itself — nothing to prune here.
+        let split_checks = self
+            .list
+            .as_ref()
+            .map(|list| list.split_checks.clone())
+            .unwrap_or_default();
 
         let opts_hash = options_hash::compute_options_hash(opts.as_ref(), &strategy);
         let vector_columns: Vec<list::VectorColumnInfo> = opts
@@ -1963,6 +2000,7 @@ impl ManifestSnapshot {
             drained_ranges: self.get_drained_ranges(),
             tombstone_seqs,
             superseded_cells,
+            split_checks,
             format_version: LIST_FORMAT_VERSION.into(),
             manifest_id: self.get_next_manifest_id(),
             options_hash: opts_hash,
@@ -4643,6 +4681,7 @@ mod tests {
                 global_vector_index: None,
                 tombstone_seqs: Default::default(),
                 superseded_cells: Default::default(),
+                split_checks: Default::default(),
                 format_version: LIST_FORMAT_VERSION.into(),
                 manifest_id: 1,
                 options_hash: ContentHash([0u8; 32]),
@@ -4689,6 +4728,48 @@ mod tests {
                 stamped_global_vector_index: None,
                 stamped_drained_ranges: None,
             }
+        }
+
+        #[test]
+        fn split_checks_added_are_readable_and_replace_per_cell() {
+            let storage = Arc::new(CountingMockStorage::new(HashMap::new()));
+            let snapshot = build_manifest_with_loader(fresh_list(vec![]), storage);
+            assert!(snapshot.get_split_checks().expect("list").is_empty());
+
+            let mut additions = BTreeMap::new();
+            additions.insert(
+                5,
+                list::CellSplitCheck {
+                    fingerprint: 111,
+                    version: 1,
+                },
+            );
+            let with_five = snapshot.with_split_checks_added(&additions);
+            assert_eq!(
+                with_five.get_split_checks().expect("list").get(&5),
+                Some(&list::CellSplitCheck {
+                    fingerprint: 111,
+                    version: 1,
+                })
+            );
+
+            // A later verdict for the same cell replaces the earlier one.
+            let mut replace = BTreeMap::new();
+            replace.insert(
+                5,
+                list::CellSplitCheck {
+                    fingerprint: 222,
+                    version: 2,
+                },
+            );
+            let replaced = with_five.with_split_checks_added(&replace);
+            assert_eq!(
+                replaced.get_split_checks().expect("list").get(&5),
+                Some(&list::CellSplitCheck {
+                    fingerprint: 222,
+                    version: 2,
+                })
+            );
         }
 
         #[tokio::test]
@@ -4951,6 +5032,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 1,
             options_hash: part::ContentHash([0u8; 32]),
@@ -5131,6 +5213,7 @@ mod tests {
                 global_vector_index: None,
                 tombstone_seqs: Default::default(),
                 superseded_cells: Default::default(),
+                split_checks: Default::default(),
                 format_version: list::FORMAT_VERSION.into(),
                 manifest_id: 0,
                 options_hash: ContentHash([0u8; 32]),
@@ -5270,6 +5353,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -5347,6 +5431,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 1,
             options_hash: ContentHash([0u8; 32]),
@@ -5475,6 +5560,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 1,
             options_hash: ContentHash([0u8; 32]),
@@ -5687,6 +5773,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 1,
             options_hash: ContentHash([0u8; 32]),
@@ -5949,6 +6036,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -6104,6 +6192,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -6317,6 +6406,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -6422,6 +6512,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -6554,6 +6645,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -6676,6 +6768,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -6814,6 +6907,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -6962,6 +7056,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -7124,6 +7219,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -7348,6 +7444,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -7450,6 +7547,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -7568,6 +7666,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -7709,6 +7808,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -7847,6 +7947,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -7939,6 +8040,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -8050,6 +8152,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 0,
             options_hash: ContentHash([0u8; 32]),
@@ -8184,6 +8287,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: list::FORMAT_VERSION.into(),
             manifest_id: 1,
             options_hash: part::ContentHash([0u8; 32]),

--- a/src/supertable/query/prune.rs
+++ b/src/supertable/query/prune.rs
@@ -332,6 +332,7 @@ mod tests {
             global_vector_index: None,
             tombstone_seqs: Default::default(),
             superseded_cells: Default::default(),
+            split_checks: Default::default(),
             format_version: FORMAT_VERSION.into(),
             manifest_id: 1,
             options_hash: ContentHash([0u8; 32]),

--- a/src/supertable/writer.rs
+++ b/src/supertable/writer.rs
@@ -171,8 +171,8 @@ use crate::{
             ClusterCentroids, RabitqAdmitContext,
             commit::{get_current_manifest_etag, manifest_uri},
             list::{
-                CellRoutingParams, DrainedVersionRanges, GlobalVectorIndex, PartitionStrategy,
-                WIDTH_LAW_KS,
+                CellRoutingParams, CellSplitCheck, DrainedVersionRanges, GlobalVectorIndex,
+                PartitionStrategy, WIDTH_LAW_KS,
             },
             options_hash,
             part::{self as part_mod, ContentHash, PartId},
@@ -1903,6 +1903,7 @@ impl SupertableWriter {
             global_vector_index: pending_gvi.clone(),
             drained_ranges: None,
             superseded_cells_additions: None,
+            split_checks_additions: None,
             graph_ref: None,
         };
 
@@ -4788,6 +4789,7 @@ pub(in crate::supertable) async fn drain_user_superfiles_to_hidden_cells(
             drained_ranges: Some(new_drained),
             global_vector_index: None,
             superseded_cells_additions: None,
+            split_checks_additions: None,
             graph_ref: None,
         };
         let no_removals: Vec<Arc<SuperfileEntry>> = Vec::new();
@@ -6510,6 +6512,49 @@ pub(in crate::supertable) async fn scan_cell_parents(
     Ok((cell_counts, parents_by_cell))
 }
 
+/// Version of the split-check logic. Folded into every fingerprint, so
+/// bumping it invalidates all stored verdicts at once.
+pub(in crate::supertable) const CELL_SPLIT_CHECK_VERSION: u32 = 1;
+
+/// Hashes a cell's identity: its live (non-superseded) superfile ids, the
+/// modality threshold, and the check version. Read straight from the
+/// manifest, so it costs no I/O — two cells with the same fingerprint hold
+/// the same rows.
+///
+/// The id set alone is a complete key because the check reads physical rows:
+/// a delete doesn't rewrite a superfile (its rows drop only at query time),
+/// so only a rewrite — which changes the id set — alters the check's input.
+/// A change that makes the check honor deletes must bump the version above.
+fn cell_content_fingerprint(
+    parents: &[Arc<SuperfileEntry>],
+    superseded_map: Option<&BTreeMap<Uuid, BTreeSet<u32>>>,
+    cell: u32,
+    modality_d: f64,
+) -> u64 {
+    let mut ids: Vec<Uuid> = parents
+        .iter()
+        .filter(|entry| {
+            !superseded_map
+                .and_then(|m| m.get(&entry.superfile_id))
+                .is_some_and(|s| s.contains(&cell))
+        })
+        .map(|entry| entry.superfile_id)
+        .collect();
+    ids.sort_unstable();
+    let mut hasher = Blake3Hasher::new();
+    hasher.update(&CELL_SPLIT_CHECK_VERSION.to_le_bytes());
+    hasher.update(&modality_d.to_bits().to_le_bytes());
+    for id in ids {
+        hasher.update(id.as_bytes());
+    }
+    let hash = hasher.finalize();
+    u64::from_le_bytes(
+        hash.as_bytes()[..8]
+            .try_into()
+            .expect("invariant: blake3 digest is 32 bytes"),
+    )
+}
+
 /// One batch cell's extracted live rows plus the parents that held them.
 struct ExtractedCellRows {
     cell: u32,
@@ -7177,6 +7222,7 @@ pub(in crate::supertable) async fn split_overflow_cell_batch(
         drained_ranges: None,
         global_vector_index: None,
         superseded_cells_additions: Some(superseded_additions),
+        split_checks_additions: None,
         graph_ref: None,
     };
     let no_removals: Vec<Arc<SuperfileEntry>> = Vec::new();
@@ -7658,6 +7704,7 @@ pub(in crate::supertable) async fn split_repack_bulk(
         drained_ranges: None,
         global_vector_index: None,
         superseded_cells_additions: Some(superseded_additions),
+        split_checks_additions: None,
         graph_ref: None,
     };
     let no_removals: Vec<Arc<SuperfileEntry>> = Vec::new();
@@ -7826,6 +7873,36 @@ pub(in crate::supertable) async fn split_overflow_cells(
     let mut splits_committed = 0usize;
     let budget_bytes = split_batch_memory_budget_bytes();
 
+    // Skip cells whose fingerprint still matches a stored verdict — their
+    // contents haven't changed since the last check. Only the modality trigger
+    // memoizes; an over-cap cell always splits. A hit is marked unsplittable so
+    // it is never extracted; a miss is re-checked and recorded after the pass.
+    let modality_d = opann::cell_split_modality_d();
+    let superseded_map = manifest.get_superseded_cells();
+    let stored_checks = manifest.get_split_checks().cloned().unwrap_or_default();
+    let mut pending_fingerprints: HashMap<u32, u64> = HashMap::new();
+    if modality_d > 0.0 {
+        for (&cell, &n) in &cell_counts {
+            if opann::split_overflow_needed(n) || !opann::split_candidate(n) {
+                continue;
+            }
+            let parents = parents_by_cell
+                .get(&cell)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let fingerprint = cell_content_fingerprint(parents, superseded_map, cell, modality_d);
+            let want = CellSplitCheck {
+                fingerprint,
+                version: CELL_SPLIT_CHECK_VERSION,
+            };
+            if stored_checks.get(&cell) == Some(&want) {
+                unsplittable.insert(cell);
+            } else {
+                pending_fingerprints.insert(cell, fingerprint);
+            }
+        }
+    }
+
     // Bulk-reshape detection: when a large fraction of the grid is
     // split-eligible (a bulk load's first optimize), take the repack path —
     // children are born in their final packed shards and the table is
@@ -7953,6 +8030,46 @@ pub(in crate::supertable) async fn split_overflow_cells(
             unsplittable = unsplittable.len(),
             "cell split pass done"
         );
+    }
+
+    // Record a verdict for each cell we checked and left whole, so the next
+    // pass can skip it. Split cells are gone; whole ones are in `unsplittable`.
+    // Nothing new to record means no commit.
+    let mut new_checks: BTreeMap<u32, CellSplitCheck> = BTreeMap::new();
+    for (cell, fingerprint) in pending_fingerprints {
+        let count = cell_counts.get(&cell).copied().unwrap_or(0);
+        if !opann::split_overflow_needed(count) && unsplittable.contains(&cell) {
+            new_checks.insert(
+                cell,
+                CellSplitCheck {
+                    fingerprint,
+                    version: CELL_SPLIT_CHECK_VERSION,
+                },
+            );
+        }
+    }
+    if let Some(storage) = inner
+        .options
+        .storage
+        .clone()
+        .filter(|_| !new_checks.is_empty())
+    {
+        let list_metadata = CommitListMetadata {
+            split_checks_additions: Some(new_checks),
+            ..CommitListMetadata::empty()
+        };
+        let committed = persist_commit_async(
+            &inner,
+            storage,
+            Vec::new(),
+            &[],
+            Vec::new(),
+            Vec::new(),
+            list_metadata,
+        )
+        .await
+        .map_err(BuildError::from)?;
+        inner.manifest.store(Arc::new(committed));
     }
     Ok(())
 }
@@ -8329,6 +8446,7 @@ pub(in crate::supertable) async fn recalibrate_probe_laws(
             drained_ranges: None,
             global_vector_index: None,
             superseded_cells_additions: None,
+            split_checks_additions: None,
             graph_ref: None,
         };
         let base = Arc::new(list_metadata.apply(&manifest));
@@ -9259,6 +9377,9 @@ pub(crate) struct CommitListMetadata {
     /// superfiles here so their now-dead blocks are excluded from reads,
     /// counts, and merges without rewriting the parents.
     pub(crate) superseded_cells_additions: Option<BTreeMap<Uuid, BTreeSet<u32>>>,
+    /// Split-check verdicts to record this commit, merged into the memo (last
+    /// writer wins per cell).
+    pub(crate) split_checks_additions: Option<BTreeMap<u32, CellSplitCheck>>,
     /// The resident `hnsw` graph ref to stamp in THIS commit (`Some(inner)`
     /// where `inner` is the built ref, or `None` if the graph declined). The
     /// graph gates query visibility, so a drain builds it against the
@@ -9280,6 +9401,7 @@ impl CommitListMetadata {
             && self.global_vector_index.is_none()
             && self.drained_ranges.is_none()
             && self.superseded_cells_additions.is_none()
+            && self.split_checks_additions.is_none()
             && self.graph_ref.is_none()
     }
 
@@ -9299,6 +9421,9 @@ impl CommitListMetadata {
         }
         if let Some(additions) = &self.superseded_cells_additions {
             out = out.with_superseded_cells_added(additions);
+        }
+        if let Some(additions) = &self.split_checks_additions {
+            out = out.with_split_checks_added(additions);
         }
         if let Some(graphs) = &self.graph_ref {
             // Stamp the graph ref so it lands atomically with membership +
@@ -10420,6 +10545,56 @@ mod tests {
                 bytes_for_cache: None,
             },
         )
+    }
+
+    fn fp_entry(id: u128) -> Arc<SuperfileEntry> {
+        Arc::new(SuperfileEntry {
+            birth_version: 0,
+            superfile_id: Uuid::from_u128(id),
+            uri: SuperfileUri(Uuid::from_u128(id)),
+            n_docs: 1,
+            id_min: 0,
+            id_max: 0,
+            scalar_stats: HashMap::new(),
+            fts_summary: HashMap::new(),
+            vector_summary: HashMap::new(),
+            partition_key: Vec::new(),
+            partition_hint: None,
+            vector_layout: VectorLayout::Ivf,
+            subsection_offsets: None,
+        })
+    }
+
+    #[test]
+    fn cell_content_fingerprint_is_order_independent_and_change_sensitive() {
+        let a = fp_entry(1);
+        let b = fp_entry(2);
+        let forward = [Arc::clone(&a), Arc::clone(&b)];
+        let reversed = [Arc::clone(&b), Arc::clone(&a)];
+        let base = cell_content_fingerprint(&forward, None, 0, 8.0);
+        // Parent order must not matter — the id list is sorted.
+        assert_eq!(base, cell_content_fingerprint(&reversed, None, 0, 8.0));
+        // A new superfile in the cell changes the fingerprint.
+        let grown = [Arc::clone(&a), Arc::clone(&b), fp_entry(3)];
+        assert_ne!(base, cell_content_fingerprint(&grown, None, 0, 8.0));
+        // A different modality threshold invalidates the verdict.
+        assert_ne!(base, cell_content_fingerprint(&forward, None, 0, 9.0));
+    }
+
+    #[test]
+    fn cell_content_fingerprint_excludes_superseded_parents() {
+        let a = fp_entry(1);
+        let b = fp_entry(2);
+        let parents = [Arc::clone(&a), Arc::clone(&b)];
+        // `b` has cell 0 superseded, so it contributes nothing: the fingerprint
+        // matches the one for `a` alone.
+        let mut superseded: BTreeMap<Uuid, BTreeSet<u32>> = BTreeMap::new();
+        superseded.insert(b.superfile_id, [0u32].into_iter().collect());
+        let only_a = [Arc::clone(&a)];
+        assert_eq!(
+            cell_content_fingerprint(&parents, Some(&superseded), 0, 8.0),
+            cell_content_fingerprint(&only_a, None, 0, 8.0),
+        );
     }
 
     /// The uploader returns shards in shard-id order no matter what order

--- a/tests/supertable/commit/pointer_atomic.rs
+++ b/tests/supertable/commit/pointer_atomic.rs
@@ -170,6 +170,7 @@ fn empty_list(manifest_id: u64, parts: Vec<ManifestPartEntry>) -> Manifest {
         global_vector_index: None,
         tombstone_seqs: Default::default(),
         superseded_cells: Default::default(),
+        split_checks: Default::default(),
         format_version: LIST_FORMAT_VERSION.into(),
         manifest_id,
         options_hash: ContentHash([0u8; 32]),


### PR DESCRIPTION
The split eligiblity right now is very simple and based on number of docs > 500k or modality set in config > 0 (min doc set to 128) this leads to a lot of superfiles being eligible for split check during optimizer. Which leads to optimizer making a lot of get_range calls on object store in every sweep even if there is no change in cells.

This Pr attempts to optimize the flow and introduce fingerprint which is basically hash of all the superfiles related to a cell, which we persist and check if there is any change during every sweep. We proceed with split check (ashman d calculation) only if hash has changed since last run.