### PR TITLE
bench: carry phrase offsets into the brute-force reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,16 @@ check:
 	# The `remote` transport is off in the shipped library, so the line above
 	# never lints it. Lint it explicitly (alongside `test-helpers`) or it rots.
 	cargo clippy --all-targets --features test-helpers,remote -- -D warnings
+	# The two lines above lint the ROOT package only: this workspace has a root
+	# package, so a bare `cargo clippy` selects it and nothing else, and
+	# `infino-bench-utils` — the other member, where every bench and the FTS
+	# quality oracle live — is never built. It went uncompiled for days after
+	# #753 gave phrases their offsets and left the oracle handing
+	# `Vec<Vec<String>>` to a `&[Phrase<String>]`; `make check` stayed green on
+	# main the whole time. Its own `--all-targets` is what catches that, and the
+	# feature is namespaced because the flag names a feature of `infino`, not of
+	# this member.
+	cargo clippy -p infino-bench-utils --all-targets --features infino/test-helpers -- -D warnings
 	# `detailed-tracing` and `metering` are off by default, so neither line
 	# above compiles the `tracing::instrument` attributes they gate. Those
 	# attributes name a function's parameters, so a signature change breaks

--- a/benches/utils/fts_quality.rs
+++ b/benches/utils/fts_quality.rs
@@ -928,7 +928,9 @@ fn recall_cell(recall: f64, gate: bool) -> Cell {
 mod tests {
     use std::sync::Mutex;
 
-    use infino::test_helpers::brute_force_bm25::BruteForceBm25;
+    use infino::{
+        superfile::fts::tokenize::Phrase, test_helpers::brute_force_bm25::BruteForceBm25,
+    };
 
     use super::*;
     use crate::corpus::for_each_generated_doc;
@@ -977,8 +979,19 @@ mod tests {
                 let owned = |v: &[Cow<'_, str>]| -> Vec<String> {
                     v.iter().map(|c| c.to_string()).collect()
                 };
-                let owned_phrases = |v: &[Vec<Cow<'_, str>>]| -> Vec<Vec<String>> {
-                    v.iter().map(|p| owned(p)).collect()
+                // The offsets come across with the terms. A phrase's spacing is
+                // what the analysis chain left behind — drop a stopword and
+                // `end of the world` is three terms at 0, 3, 4 — so rebuilding
+                // these as adjacent would have the reference verify a phrase
+                // the index never holds, and only for the queries the chain
+                // actually changes.
+                let owned_phrases = |v: &[Phrase<Cow<'_, str>>]| -> Vec<Phrase<String>> {
+                    v.iter()
+                        .map(|p| Phrase {
+                            terms: owned(&p.terms),
+                            offsets: p.offsets.clone(),
+                        })
+                        .collect()
                 };
                 let expected = reference.top_k_atoms(
                     &owned(&clauses.musts),


### PR DESCRIPTION
`infino-bench-utils` has not compiled its tests since #753 gave phrases their offsets: `BruteForceBm25::top_k_atoms` takes `&[Phrase<String>]` and the quality oracle's `owned_phrases` still handed it `Vec<Vec<String>>`. Nothing caught it because `make check` runs clippy on this package rather than the workspace, so that crate's test target is never built in CI.

The conversion carries the offsets across rather than rebuilding each phrase as adjacent. A phrase's spacing is what the analysis chain left behind — drop a stopword from `end of the world` and it is three terms at 0, 3 and 4 — so adjacent phrases would have the reference verify a phrase the index never holds, and only for the queries the chain actually changes, which is precisely what #753 added. The oracle agrees with the reference again on every battery shape and both flavours.

The import sits in the test module: the only use is there, so at the top it is an unused import on the lib target and clippy's `-D warnings` rejects it.